### PR TITLE
[PR] AsyncConfig 외부 설정화 및 AsyncConfigurer 적용

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/AsyncConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/AsyncConfig.java
@@ -1,11 +1,17 @@
 package com.wanted.momocity.global.infrastructure.config;
 
 import com.wanted.momocity.global.infrastructure.aop.MdcTaskDecorator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.concurrent.Executor;
 
 /*
@@ -26,17 +32,44 @@ import java.util.concurrent.Executor;
  */
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+@EnableConfigurationProperties(AsyncProperties.class)
+public class AsyncConfig implements AsyncConfigurer {
+
+    private final AsyncProperties asyncProperties;
+
+    public AsyncConfig(AsyncProperties asyncProperties) {
+        this.asyncProperties = asyncProperties;
+    }
 
     @Bean(name = "domainEventExecutor")
     public Executor domainEventExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setThreadNamePrefix("domain-event-");
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(4);
-        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix(asyncProperties.threadNamePrefix());
+        executor.setCorePoolSize(asyncProperties.corePoolSize());
+        executor.setMaxPoolSize(asyncProperties.maxPoolSize());
+        executor.setQueueCapacity(asyncProperties.queueCapacity());
         executor.setTaskDecorator(new MdcTaskDecorator());
         executor.initialize();
         return executor;
+    }
+
+    // 비동기 예외를 핸들링 할 수 있는 메서드
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new LoggingAsyncExceptionHandler();
+    }
+
+    // 비동기 관련 예외처리를 커스텀하는 내부 클래스
+    /*comment
+     *  void 형태의 비동기 메서드의 예외는 호출자에게 작접 전달할 방법이 없다
+     *  고로,AsyncUncaughtExceptionHandler 에서 별도로 로깅 / 알림 처리 / 예외 처리를 해야한다  */
+    @Slf4j
+    private static class LoggingAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+        @Override
+        public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+            log.error("[비동기 전용 예외 처리기] method = {}, params = {}, message = {}",
+                    method.getName(), Arrays.toString(params), ex.getMessage());
+        }
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/AsyncProperties.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/AsyncProperties.java
@@ -1,0 +1,21 @@
+package com.wanted.momocity.global.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/*
+ * AsyncConfig 에서 사용하는 ThreadPool 설정값을 외부화한다.
+ * application.yaml 에 async.* 로 오버라이드할 수 있다.
+ * 미설정 시 아래 기본값이 적용된다.
+ */
+
+@ConfigurationProperties(prefix = "app.async")
+public record AsyncProperties(
+
+         int corePoolSize,
+         int maxPoolSize,
+         int queueCapacity,
+         String threadNamePrefix
+
+) {
+
+}

--- a/legend-momo-city/src/main/resources/application-dev.yaml
+++ b/legend-momo-city/src/main/resources/application-dev.yaml
@@ -84,3 +84,13 @@ logging:
     root: INFO
     com.wanted.momocity: DEBUG
     org.hibernate.SQL: DEBUG
+
+# ===== Async =====
+app:
+  async:
+    core-pool-size: 4
+    max-pool-size: 8
+    queue-capacity: 100
+    thread-name-prefix: async-class-
+  retry:
+    fixed-delay-ms: 5000


### PR DESCRIPTION
## 📝 요약

`AsyncConfig`의 ThreadPool 설정값을 외부 설정으로 분리하고, 비동기 예외 핸들러를 추가하여 silent 예외 누락을 방지한다.

Closes #(이슈번호)

---

## 🛠 변경 사항

### 1. `AsyncProperties.java` (신규)
- `@ConfigurationProperties(prefix = "app.async")` + `record` 형태
- 필드: `corePoolSize`, `maxPoolSize`, `queueCapacity`, `threadNamePrefix`
- yaml-first 정책 — 디폴트값은 yaml 에 위치

### 2. `AsyncConfig.java` (수정)
- `implements AsyncConfigurer` 추가 → `@Override` 정상 동작
- `@EnableConfigurationProperties(AsyncProperties.class)` 적용
- ThreadPool 파라미터 하드코딩 → `AsyncProperties` 에서 주입
- `LoggingAsyncExceptionHandler` 내부 `static class` 추가 — `AsyncUncaughtExceptionHandler` 구현
- 생성자 주입 방식으로 `AsyncProperties` 의존성 명시

### 3. `application-dev.yaml` (수정)
- `app.async.*` 섹션 추가
  - `core-pool-size: 4`
  - `max-pool-size: 8`
  - `queue-capacity: 100`
  - `thread-name-prefix: async-class-`

---

## 🤔 왜 이렇게?

| 항목 | 선택 | 이유 |
|---|---|---|
| prefix | `app.async` | 기존 yaml 의 `app.*` 네임스페이스 컨벤션 준수, Spring 예약 키 충돌 회피 |
| Properties 타입 | `record` | 불변 보장, 보일러플레이트 제거 (Lombok 불필요) |
| 디폴트값 위치 | yaml-only | 모든 설정값을 yaml 한 곳에서 파악 가능 (운영 친화) |
| `LoggingAsyncExceptionHandler` | 내부 `static class` | `AsyncConfig` 전용이므로 외부 노출 불필요 |

---

## ✅ 검증

- [x] `./gradlew compileJava` 통과
- [x] `AsyncProperties` ↔ `application-dev.yaml` 키 매칭 직접 대조 일치
- [x] `AsyncConfigurer` 부모 인터페이스 시그니처 매칭 정합성 확인
- [x] `AsyncProperties` 클래스 주석 갱신 (prefix 변경 반영)

---

## 🔜 추후 검증 항목

> 외부 의존성(MySQL / Redis / SMTP / S3) 필요로 인해 로컬 환경 부팅 검증은 별도 단계에서 진행한다.

- [ ] 애플리케이션 부팅 시 `domainEventExecutor` Bean 정상 등록 확인
- [ ] `@Async("domainEventExecutor")` 호출 시 워커 스레드 이름이 `async-class-N` 형태인지 확인
- [ ] `@Async` void 메서드에서 의도적 예외 발생 → 로그에 `[비동기 전용 예외 처리기]` 메시지 출력 확인
- [ ] 비동기 작업 로그에 `momoTraceId` MDC 값이 워커 스레드로 정상 전파되는지 확인 (`MdcTaskDecorator` 검증)

---

## 📡 영향 범위

| 구분 | 영향 여부 | 비고 |
|---|---|---|
| **API 스펙** | 없음 | 외부 노출 엔드포인트 무변동 |
| **클라이언트** | 없음 | 호출자 입장에서 동작 변화 없음 |
| **DB 스키마** | 없음 | 스키마 / 마이그레이션 무관 |
| **운영** | 있음 (긍정) | 환경별 ThreadPool 튜닝이 yaml 만으로 가능 |
| **로그 포맷** | 있음 (긍정) | 비동기 예외 발생 시 `[비동기 전용 예외 처리기]` prefix 로그 신규 생성 |
| **MDC 추적** | 변화 없음 | 기존 `MdcTaskDecorator` 적용 유지 |

---

## ⚠️ 후속 작업

- `app.retry.fixed-delay-ms` 는 본 PR 범위 밖. 소비처 없음 → 별도 이슈에서 처리 예정
- 다른 프로파일 yaml (`application-staging.yaml`, `application-prod.yaml` 등) 에도 `app.async.*` 키 동기화 필요

---

## 📌 변경된 파일

```
modified:   legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/AsyncConfig.java
new file:   legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/AsyncProperties.java
modified:   legend-momo-city/src/main/resources/application-dev.yaml
```