### PR TITLE
[PR] - Viewing, Calendar 전체적인 파일구조 및 Viewing 기본적인 코드 작성

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CheckTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CheckTodoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record CheckTodoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateMemoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateMemoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record CreateMemoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateTodoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record CreateTodoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteMemoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteMemoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record DeleteMemoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteTodoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record DeleteTodoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateMemoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateMemoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record UpdateMemoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateTodoCommand.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.command;
+
+public record UpdateTodoCommand() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/MemoService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/MemoService.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.service;
+
+public class MemoService {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/TodoService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/TodoService.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.service;
+
+public class TodoService {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CheckTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CheckTodoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface CheckTodoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateMemoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateMemoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface CreateMemoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateTodoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface CreateTodoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteMemoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteMemoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface DeleteMemoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteTodoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface DeleteTodoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/GetDailyCalendarUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/GetDailyCalendarUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface GetDailyCalendarUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateMemoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateMemoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface UpdateMemoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateTodoUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.application.usecase;
+
+public interface UpdateTodoUseCase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/model/Calendar.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/model/Calendar.java
@@ -1,0 +1,99 @@
+package com.wanted.momocity.calendar.domain.model;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  Todo 와 Memo 의 규칙 명시
+*  [calendar]
+*  - Todo / Memo 생성 규칙 정의
+*  - Todo 체크 상태 변경
+*  - Memo 날짜 유효성 규칙 정의
+*  -------------------------
+*  toggleComplete() 에서 Memo 체크 차단 -> 도메인에서 직접 규칙 수호
+*  end < start 검증 -> 도메인에서 (service 에서는 모름)
+*  isOwedBy() 권한 체크 -> 도메인에서
+* */
+
+@Getter
+public class Calendar {
+
+    private Long id;
+    private Long userId;
+    private String title;
+    private Category category;
+    private LocalDate start;
+    // nullable (Memo 전용)
+    private LocalDate end;
+    // Todo 전용
+    private boolean isCompleted;
+    // createdAt 은 JpaEntity 에서 관리
+
+    public enum Category{
+        TODO, MEMO
+    }
+
+    // Todo 신규 생성
+    public static Calendar createTodo(
+            Long userId, String title, LocalDate start
+    ) {
+        Calendar calendar = new Calendar();
+        calendar.userId = userId;
+        calendar.title = title;
+        calendar.category = Category.TODO;
+        calendar.start = start;
+        calendar.end = null;
+        calendar.isCompleted = false;
+        return calendar;
+    }
+
+    // Memo 신규 생성
+    public static Calendar createMemo(
+            Long userId, String title, LocalDate start, LocalDate end
+    ) {
+        if (end != null && end.isBefore(start)) {
+            throw new DomainRuleViolationException(
+                    "메모의 종료일은 시작일보다 이전일 수 없습니다."
+            );
+        }
+        Calendar calendar = new Calendar();
+        calendar.userId = userId;
+        calendar.title = title;
+        calendar.category = Category.MEMO;
+        calendar.start = start;
+        calendar.end = end;
+        calendar.isCompleted = false;
+        return calendar;
+    }
+
+    // Todo 체크 상태 변경 (토글)
+    public void toggleComplete() {
+        if (this.category == Category.MEMO) {
+            throw new DomainRuleViolationException(
+                    "MEMO 는 체크 상태를 변경할 수 없습니다."
+            );
+        }
+        this.isCompleted = !this.isCompleted;
+    }
+
+    // Todo / Memo 내용 수정
+    public void update(String title, LocalDate start, LocalDate end) {
+        if (end != null && end.isBefore(start)) {
+            throw new DomainRuleViolationException(
+                    "종료일은 시작일보다 이전일 수 없습니다."
+            );
+        }
+        this.title = title;
+        this.start = start;
+        this.end = end;
+    }
+
+    // 본인 소유 여부 확인
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/repository/CalendarRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/repository/CalendarRepository.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.domain.repository;
+
+public interface CalendarRepository {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaEntity.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.infrastructure.persistence;
+
+public class CalendarJpaEntity {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaRepository.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.infrastructure.persistence;
+
+public class CalendarJpaRepository {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.infrastructure.persistence;
+
+public class CalendarRepositoryAdapter {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/CalendarController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/CalendarController.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api;
+
+public class CalendarController {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/common/CalendarResponseCode.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/common/CalendarResponseCode.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.common;
+
+public class CalendarResponseCode {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CheckTodoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CheckTodoRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.request;
+
+public record CheckTodoRequest() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateMemoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateMemoRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.request;
+
+public record CreateMemoRequest() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateTodoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateTodoRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.request;
+
+public record CreateTodoRequest() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateMemoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateMemoRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.request;
+
+public record UpdateMemoRequest() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateTodoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateTodoRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.request;
+
+public record UpdateTodoRequest() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/DailyCalendarResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/DailyCalendarResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.response;
+
+public record DailyCalendarResponse() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/MemoResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/MemoResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.response;
+
+public record MemoResponse() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/TodoResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/TodoResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.calendar.presentation.api.response;
+
+public record TodoResponse() {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/command/GetStreamingUrlCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/command/GetStreamingUrlCommand.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.viewing.application.command;
+
+/*
+* comment.
+*  S3 Presigned URL 발급에 필요한 값 묶음
+*  userId(토큰) + lectureId(PathVariable) + chapterId(PathVariable)
+* */
+
+public record GetStreamingUrlCommand(
+        Long userId,
+        Long lectureId,
+        Long chapterId
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/command/SaveProgressCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/command/SaveProgressCommand.java
@@ -1,0 +1,15 @@
+package com.wanted.momocity.viewing.application.command;
+
+/*
+* comment.
+*  진척도 저장에 필요한 값 묶음
+*  usrId(토큰) + lectureId(PathVariable) + chapterId(PathVariable) + playbackSeconds(RequestBody)
+* */
+
+public record SaveProgressCommand(
+        Long userId,
+        Long lectureId,
+        Long chapterId,
+        int playbackSeconds
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/ChapterPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/ChapterPort.java
@@ -1,0 +1,24 @@
+package com.wanted.momocity.viewing.application.port;
+
+import com.wanted.momocity.viewing.domain.model.Chapter;
+
+import java.util.List;
+
+/*
+* comment.
+*  catalog 컨텍스트 소유의 Chapter 를 READ 전용으로 조회
+*  viewing 컨텍스트가 catalog 컨텍스트를 직접 참조하지 않고 해당 포트를 통해서 접근함
+*  -
+*  실제 구현체는 infrastructure.caltalog.ChapterCatalogAdater 가 담당
+* */
+
+public interface ChapterPort {
+
+    // 단건 챕터 조회
+    Chapter findById (Long chapterId);
+
+    // 강의의 전체 챕터 조회 목록
+    // totalProgress 계산 시 durationSec 합산에 사용
+    List<Chapter> findAllByLectureId (Long lectureId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/EnrollmentPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/EnrollmentPort.java
@@ -1,0 +1,32 @@
+package com.wanted.momocity.viewing.application.port;
+
+import java.util.List;
+import java.util.Optional;
+
+/*
+ * comment.
+ *  enrollment 컨텍스트 소유의 수강 정보를 READ 전용으로 조회
+ *  viewing 컨텍스트가 enrollment 를 직접 참조하지 않고 이 포트를 통해서만 접근
+ *  실제 구현체 : infrastructure.catalog.EnrollmentCatalogAdapter
+ * */
+
+public interface EnrollmentPort {
+
+    // 수강 여부 확인
+    // 수강 신청된 강의인지 체크할 때 사용
+   Optional<EnrollmentInfo> findByUserIdAndLectureId (Long userId, Long lectureId);
+
+    // 내 수강 강의 전체 목록 조회
+    // 마이페이지 수강 목록 조회할 때 사용
+   List<EnrollmentInfo> findAllByUserId (Long userId);
+
+    // EnrollmentPort 전용 응답 모델
+    // 팀원 Enrollment 도메인 모델을 직접 참조하지 않기 위해
+    // viewing 컨텍스트 전용으로 필요한 필드만 담음
+   record EnrollmentInfo(
+           Long enrollmentId,
+           Long userId,
+           Long lectureId
+   ) {}
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/LecturePort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/LecturePort.java
@@ -1,0 +1,17 @@
+package com.wanted.momocity.viewing.application.port;
+
+/*
+* comment.
+*  catalog 컨텍스트 소유의 Lecture 를 READ 전용으로 조회
+*  viewing 컨텍스트가 catalog 를 직접 참조하지 않고 해당 포트를 통해서만 접근
+* */
+
+import com.wanted.momocity.viewing.domain.model.Lecture;
+
+public interface LecturePort {
+
+    // 강의 단건 조회
+    // 강의 메타데이터, 내 수강 목록에서 사용
+    Lecture findById(Long lectureId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/S3Port.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/S3Port.java
@@ -1,0 +1,19 @@
+package com.wanted.momocity.viewing.application.port;
+
+/*
+* comment.
+*  Application 이 AWS S3 가 핗요하다고 선언하는 인터페이스
+*  실제 구현체는 infrastructure.adapter.S3PresignedUrlAdapter 가 담당
+*  -
+*  videoUrl(S3 key) 를 받아서 Presigned URL 반환
+*  -> ViewingService 가 해당 포트를 호출해서 URL 발급
+* */
+
+public interface S3Port {
+
+    // Presigned URL 발급
+    // videoUrl : chapter 테이블의 video_url (S3 key)
+    // 반환값 : 사용자가 바로 재생할 수 있는 임시 URL
+    String generatePresignedUrl (String videoUrl);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ProgressService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ProgressService.java
@@ -1,0 +1,222 @@
+package com.wanted.momocity.viewing.application.service;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.viewing.application.command.SaveProgressCommand;
+import com.wanted.momocity.viewing.application.port.ChapterPort;
+import com.wanted.momocity.viewing.application.port.EnrollmentPort;
+import com.wanted.momocity.viewing.application.port.LecturePort;
+import com.wanted.momocity.viewing.application.usecase.GetChapterProgressUseCase;
+import com.wanted.momocity.viewing.application.usecase.GetMyLectureUseCase;
+import com.wanted.momocity.viewing.application.usecase.GetTotalProgressUseCase;
+import com.wanted.momocity.viewing.application.usecase.SaveProgressUseCase;
+import com.wanted.momocity.viewing.domain.model.Chapter;
+import com.wanted.momocity.viewing.domain.model.LearningHistory;
+import com.wanted.momocity.viewing.domain.model.Lecture;
+import com.wanted.momocity.viewing.domain.repository.LearningHistoryRepository;
+import com.wanted.momocity.viewing.presentation.api.response.ChapterProgressResponse;
+import com.wanted.momocity.viewing.presentation.api.response.MyLectureResponse;
+import com.wanted.momocity.viewing.presentation.api.response.SaveProgressResponse;
+import com.wanted.momocity.viewing.presentation.api.response.TotalProgressResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/*
+* comment.
+*  진척도 관련 UseCase 구현체
+*  HTTP 모름, JPA 모름, 순수 비지니스 흐름만 담당
+*  -
+*  [담당 UseCase]
+*  - SaveProgressUseCase : 진척도 저장
+*  - GetTotalProgressUseCase : 전체 진척도 조회
+*  - GetChapterProgressUseCase : 챕터별 진척도 조회
+*  - GetMyLectureUseCase : 내 수강 강의 목록
+* */
+
+@Service
+@RequiredArgsConstructor
+public class ProgressService implements
+        SaveProgressUseCase,
+        GetTotalProgressUseCase,
+        GetChapterProgressUseCase,
+        GetMyLectureUseCase {
+
+    private final ChapterPort chapterPort;
+    private final LecturePort lecturePort;
+    private final EnrollmentPort enrollmentPort;
+    private final LearningHistoryRepository learningHistoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
+//    private final SaveProgressUseCase saveProgressUseCase;
+
+    @Override
+    @Transactional
+    // SaveProgressUseCase
+    public SaveProgressResponse saveProgress(SaveProgressCommand command) {
+
+        // 챕터 정보 조회 (durationSec 필요)
+        Chapter chapter = chapterPort.findById(command.chapterId());
+
+        // 시청 기록 조회 or 신규 생성
+        LearningHistory history = learningHistoryRepository
+                .findByUserIdAndChapterId(command.userId(), command.chapterId())
+                .orElse(LearningHistory.create(
+                        command.userId(), command.lectureId(), command.chapterId()
+                ));
+
+        // 진척도 업데이트 (도메인 메서드)
+        history.updateProgress(command.playbackSeconds(), chapter.getDurationSec());
+
+        // 쳅터 완료 처리 (도메인 메서드)
+        history.complete(command.playbackSeconds(), chapter.getDurationSec());
+
+        // 시청 기록 저장
+        LearningHistory savedHistory = learningHistoryRepository.save(history);
+
+        // 전체 진척도 계산 (learning_history 집계)
+        int totalProgress = calculateTotalProgress (command.userId(), command.lectureId());
+        int completedCount = calculateCompletedCount (command.userId(), command.lectureId());
+
+        return new SaveProgressResponse(
+                savedHistory.getChapterId(),
+                savedHistory.getWatchedSeconds(),
+                savedHistory.getProgressRate(),
+                savedHistory.isCompleted(),
+                totalProgress,
+                completedCount
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    // GetTotalProgressUseCase
+    public TotalProgressResponse getTotalProgress(Long userId, Long lectureId) {
+
+        // 수강 여부 확인
+       enrollmentPort.findByUserIdAndLectureId(userId, lectureId)
+                .orElseThrow(() -> new DomainRuleViolationException("수강 정보를 찾을 수 없습니다."));
+
+        // 전체 챕터 수 조회
+        List<Chapter> chapters = chapterPort.findAllByLectureId(lectureId);
+
+        // 진척도 계산 (learning_history 집계)
+        int totalProgress = calculateTotalProgress(userId, lectureId);
+        int completedCount = calculateCompletedCount(userId, lectureId);
+
+        return new TotalProgressResponse(
+                lectureId,
+                totalProgress,
+                completedCount,
+                chapters.size()
+        );
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    // GetChapterProgressUseCase
+    public ChapterProgressResponse getChapterProgress(Long userId, Long lectureId) {
+
+        // 전체 챕터 목록 조회
+        List<Chapter> chapters = chapterPort.findAllByLectureId(lectureId);
+
+        // 시청 기록 전체 조회
+        List<LearningHistory> histories = learningHistoryRepository
+                .findByUserIdAndLectureId(userId, lectureId);
+
+        // 챕터별 전체 진척도 매핑
+        List<ChapterProgressResponse.ChapterProgressItem> items = chapters.stream()
+                .map(chapter -> {
+                    // 해당 챕터 시청 기록 찾기 (없으면 0 으로 처리)
+                    LearningHistory history = histories.stream()
+                            .filter(h -> h.getChapterId().equals(chapter.getId()))
+                            .findFirst()
+                            .orElse(LearningHistory.create(userId, lectureId, chapter.getId()));
+
+                    return new ChapterProgressResponse.ChapterProgressItem(
+                            chapter.getId(),
+                            chapter.getTitle(),
+                            chapter.getOrderNo(),
+                            history.getWatchedSeconds(),
+                            chapter.getDurationSec(),
+                            history.getProgressRate(),
+                            history.isCompleted()
+                    );
+                })
+                .toList();
+
+        return new ChapterProgressResponse(lectureId, items);
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    // GetMyLectureUseCase
+    public List<MyLectureResponse> getMyLectures(Long userId) {
+
+        // 수강 목록 전체 조회
+        return enrollmentPort.findAllByUserId(userId)
+                .stream()
+                .map(enrollment -> {
+                    Lecture lecture = lecturePort.findById(enrollment.lectureId());
+                    int totalProgress = calculateTotalProgress(userId, enrollment.lectureId());
+                    return new MyLectureResponse(
+                            lecture.getId(),
+                            lecture.getTitle(),
+                            lecture.getThumbnailUrl(),
+                            lecture.getCategory(),
+                            totalProgress
+                    );
+                })
+                .toList();
+
+    }
+
+    // private 메서드 (내부 로직)
+    // enrollment 진척도 재계산 및 저장
+    private int calculateTotalProgress(Long userId, Long lectureId) {
+
+        List<Chapter> chapters = chapterPort.findAllByLectureId(lectureId);
+        List<LearningHistory> histories = learningHistoryRepository
+                .findByUserIdAndLectureId(userId, lectureId);
+
+        // 완료 챕터 durationSec 합산
+        int completedDurationSum = chapters.stream()
+                .filter(chapter -> histories.stream()
+                        .anyMatch(h -> h.getChapterId().equals(chapter.getId())
+                        && h.isCompleted()))
+                .mapToInt(Chapter::getDurationSec)
+                .sum();
+
+        // 미완료 챕터 watchedSeconds 합산
+        int inProgressWatchedSum = histories.stream()
+                .filter(h -> !h.isCompleted())
+                .mapToInt(LearningHistory::getWatchedSeconds)
+                .sum();
+
+        // 전체 durationSec 합산
+        int totalDurationSum =chapters.stream()
+                .mapToInt(Chapter::getDurationSec)
+                .sum();
+
+        if (totalDurationSum == 0) return 0;
+        return (int) Math.round(
+                (double)(completedDurationSum + inProgressWatchedSum)
+                / totalDurationSum * 100
+        );
+
+    }
+
+    // 완료 된 챕터 수 계산 (learning_history 집계)
+    private int calculateCompletedCount (Long userId, Long lectureId) {
+        return (int) learningHistoryRepository
+                .findByUserIdAndLectureId(userId, lectureId)
+                .stream()
+                .filter(LearningHistory::isCompleted)
+                .count();
+    }
+
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingService.java
@@ -1,0 +1,136 @@
+package com.wanted.momocity.viewing.application.service;
+
+/*
+* comment.
+*  영상 재생 관련 UseCase 구현체
+*  Domain 객체들을 불러서 비지니스 호출 조율
+*  HTTP 모름, JPA 모름, 순수 비지니스 흐름만 담당
+*  -
+*  [담당 UseCase]
+*  - GetStreamingUrlUseCase : S3 Presigned URL 발급
+*  - GetLectureMetaUseCase : 플레이어 UI 상단 정보
+*  - GetChapterResumeUseCase : 챕터 이어보기 지점 조회
+* */
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.viewing.application.port.ChapterPort;
+import com.wanted.momocity.viewing.application.port.LecturePort;
+import com.wanted.momocity.viewing.application.port.S3Port;
+import com.wanted.momocity.viewing.application.usecase.GetChapterResumeUseCase;
+import com.wanted.momocity.viewing.application.usecase.GetLectureMetaUseCase;
+import com.wanted.momocity.viewing.application.usecase.GetStreamingUrlUseCase;
+import com.wanted.momocity.viewing.domain.model.Chapter;
+import com.wanted.momocity.viewing.domain.model.LearningHistory;
+import com.wanted.momocity.viewing.domain.model.Lecture;
+import com.wanted.momocity.viewing.domain.repository.LearningHistoryRepository;
+import com.wanted.momocity.viewing.presentation.api.response.ChapterResumeResponse;
+import com.wanted.momocity.viewing.presentation.api.response.LectureMetaResponse;
+import com.wanted.momocity.viewing.presentation.api.response.StreamingUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ViewingService implements
+        GetStreamingUrlUseCase,
+        GetLectureMetaUseCase,
+        GetChapterResumeUseCase {
+
+    private final S3Port s3Port;
+    private final ChapterPort chapterPort;
+    private final LecturePort lecturePort;
+    private final LearningHistoryRepository learningHistoryRepository;
+
+    // GetStreamingUrlUseCase
+    @Override
+    public StreamingUrlResponse getStreamingUrl (Long userId, Long lectureId, Long chapterId) {
+
+        // 챕터 정보 조회
+        Chapter chapter = chapterPort.findById(chapterId);
+
+        // 재생 가능 여부 확인 (도메인 메서드)
+        if(!chapter.isPlayable()) {
+            throw new DomainRuleViolationException("현재 재생할 수 없는 영상입니다.");
+        }
+
+        // S3 Presigned URL 발급
+        String presignedUrl = s3Port.generatePresignedUrl(
+                chapter.getVideoUrl()
+        );
+
+        return new StreamingUrlResponse(
+                chapter.getId(),
+                presignedUrl,
+                3600,
+                chapter.getTitle(),
+                chapter.getDurationSec()
+        );
+
+    }
+
+    // GetLectureMeteUseCase
+    @Override
+    public LectureMetaResponse getLectureMeta (Long userId, Long lectureId) {
+        // 강의 정보 조회
+        Lecture lecture = lecturePort.findById(lectureId);
+
+        // 전체 챕터 수 조회
+        List<Chapter> chapters = chapterPort.findAllByLectureId(lectureId);
+
+        // 현재 챕터 조회
+        LearningHistory currentHistory = learningHistoryRepository
+                .findLatestByUserIdAndLectureId(userId, lectureId)
+                .orElse(null);
+
+        // 현재 챕터 정보 (시청 기록 없으면 첫 번째 챕터)
+        Chapter currentChapter = currentHistory != null
+                ? chapterPort.findById(currentHistory.getChapterId())
+                : chapters.get(0);
+
+        return new LectureMetaResponse(
+                lecture.getId(),
+                lecture.getTitle(),
+                lecture.getInstructorName(),
+                chapters.size(),
+                currentChapter.getOrderNo(),
+                currentChapter.getId(),
+                currentChapter.getTitle()
+        );
+    }
+
+    // GetChapterResumeUseCase
+    @Override
+    public ChapterResumeResponse getChapterResume (
+            Long userId, Long lectureId, Long chapterId
+    ) {
+        // 챕터 정보 조회
+        Chapter chapter = chapterPort.findById(chapterId);
+
+        // 시청 기록 조회
+        LearningHistory history = learningHistoryRepository
+                .findByUserIdAndChapterId(userId, chapterId)
+                .orElse(LearningHistory.create(userId, lectureId, chapterId));
+
+        // 전체 진척도 조회
+        int totalProgress = learningHistoryRepository
+                .findByUserIdAndLectureId(userId, lectureId)
+                .stream()
+                .mapToInt(LearningHistory::getProgressRate)
+                .sum();
+
+
+        return new ChapterResumeResponse(
+                lectureId,
+                chapter.getId(),
+                chapter.getTitle(),
+                history.getLastPositionSec(),
+                chapter.getDurationSec(),
+                totalProgress
+        );
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetChapterProgressUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetChapterProgressUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.presentation.api.response.ChapterProgressResponse;
+
+/*
+* comment.
+*  챕터별 진척도 조회
+* */
+
+public interface GetChapterProgressUseCase {
+
+    ChapterProgressResponse getChapterProgress (Long userId, Long lectureId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetChapterResumeUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetChapterResumeUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.presentation.api.response.ChapterResumeResponse;
+
+/*
+* comment.
+*  챕터 이어보기 시작 지점 조회
+* */
+
+public interface GetChapterResumeUseCase {
+
+    ChapterResumeResponse getChapterResume (Long userId, Long lectureId, Long chapterId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetLectureMetaUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetLectureMetaUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.presentation.api.response.LectureMetaResponse;
+
+/*
+* comment.
+*  강의 메타데이터 조회 (플레이어 UI 상단용)
+* */
+
+public interface GetLectureMetaUseCase {
+
+    LectureMetaResponse getLectureMeta (Long userId, Long lectureId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetMyLectureUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetMyLectureUseCase.java
@@ -1,0 +1,15 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.presentation.api.response.MyLectureResponse;
+
+import java.util.List;
+
+/*
+* comment.
+*  내 수강 강의 전체 목록 조회
+* */
+public interface GetMyLectureUseCase {
+
+    List<MyLectureResponse> getMyLectures (Long userId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetStreamingUrlUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetStreamingUrlUseCase.java
@@ -1,0 +1,15 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.presentation.api.response.StreamingUrlResponse;
+
+/*
+* comment.
+*  Controller 는 해당 인터페이스만 알고, 실제 구현체인 ViewingService 를 모름
+*  -> 테스트 시 Mock 으로 교체 가능
+* */
+
+public interface GetStreamingUrlUseCase {
+
+    StreamingUrlResponse getStreamingUrl (Long userId, Long lectureId, Long chapterId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetTotalProgressUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/GetTotalProgressUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.presentation.api.response.TotalProgressResponse;
+
+/*
+* comment.
+*  강의 전체 진척도 조회
+* */
+
+public interface GetTotalProgressUseCase {
+
+    TotalProgressResponse getTotalProgress (Long userId, Long lectureId);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/SaveProgressUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/usecase/SaveProgressUseCase.java
@@ -1,0 +1,16 @@
+package com.wanted.momocity.viewing.application.usecase;
+
+import com.wanted.momocity.viewing.application.command.SaveProgressCommand;
+import com.wanted.momocity.viewing.presentation.api.response.SaveProgressResponse;
+
+/*
+* comment.
+*  시청 중 진척도 저장(5-10초 주기 호출)
+* */
+
+public interface SaveProgressUseCase {
+
+    // 파라미터가 3개 이상, 묶어서 전달
+    SaveProgressResponse saveProgress (SaveProgressCommand command);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/event/ChapterCompletedEvent.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/event/ChapterCompletedEvent.java
@@ -1,0 +1,18 @@
+package com.wanted.momocity.viewing.domain.event;
+
+import com.wanted.momocity.global.domain.common.event.DomainEvent;
+
+import java.time.Instant;
+
+/*
+* comment.
+*  챕터 시청이 완료되었을 때 발행 -> ProgressService 가 받아서 completedCount, totalProgress 업데이트
+* */
+
+public record ChapterCompletedEvent (
+        Long userId,
+        Long lectureId,
+        Long chapterId,
+        Instant occurredAt
+) implements DomainEvent {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/event/CourseCompletedEvent.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/event/CourseCompletedEvent.java
@@ -1,0 +1,17 @@
+package com.wanted.momocity.viewing.domain.event;
+
+import com.wanted.momocity.global.domain.common.event.DomainEvent;
+
+import java.time.Instant;
+
+/*
+* comment.
+*  totalProgress = 100 도달 시 발행 -> 수강 상태 변경, 강좌 수료 처리
+* */
+
+public record CourseCompletedEvent (
+        Long userId,
+        Long lectureId,
+        Instant occurredAt
+) implements DomainEvent {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Chapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Chapter.java
@@ -1,0 +1,33 @@
+package com.wanted.momocity.viewing.domain.model;
+
+import lombok.Getter;
+
+/*
+* comment.
+*  Chapter 은 catalog 컨텍스트 소유 -> READ 전용
+*  생성 / 수정 없이 조회만 하기 때문에 create() 는 생성하지 않음
+*  isPlayable() : S3 URL 발급 전에 반드시 체크해야 하는 비지니스 규칙
+* */
+
+@Getter
+public class Chapter {
+
+    private Long id;
+    private Long lectureId;
+    private String title;
+    private int orderNo;
+    private String videoUrl;
+    private int durationSec;
+    private VideoStatus videoStatus;
+    // createdAt, updateAt 은 JpaEntity 에서 관리
+
+    public enum VideoStatus{
+        UPLOADING, ENCODING, READY, FAILED
+    }
+
+    // 재생 가능 여부 확인
+    public boolean isPlayable() {
+        return this.videoStatus == VideoStatus.READY;
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
@@ -1,0 +1,80 @@
+package com.wanted.momocity.viewing.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public class LearningHistory {
+
+    private Long id;
+    private Long userId;
+    private Long lectureId;
+    private Long chapterId;
+    private int watchedSeconds;
+    private boolean isCompleted;
+    private int lastPositionSec;
+    private int progressRate;
+    // createdAt, updateAt 은 JPA 에서 관리
+
+    // 신규 생성용
+    public static LearningHistory create(
+            Long userId, Long lectureId, Long chapterId
+    ) {
+        LearningHistory history = new LearningHistory();
+        history.userId = userId;
+        history.lectureId = lectureId;
+        history.chapterId = chapterId;
+        history.watchedSeconds = 0;
+        history.isCompleted = false;
+        history.lastPositionSec = 0;
+        history.progressRate = 0;
+        return history;
+    }
+
+    // 진척도 업데이트
+    public void updateProgress (
+            int playbackSeconds, int durationSec
+    ) {
+        if (playbackSeconds > this.watchedSeconds) {
+            this.watchedSeconds = playbackSeconds;
+            this.progressRate = (int) Math.round(
+                    (double) this.watchedSeconds / durationSec * 100
+            );
+            if (this.progressRate >= 100) {
+                this.progressRate = 100;
+            }
+        }
+    }
+
+    // 챕터 완료처리
+    public void complete (int playbackSeconds, int durationSec) {
+        if(!this.isCompleted && playbackSeconds >= durationSec * 0.9) {
+            this.isCompleted = true;
+            this.progressRate = 100;
+            this.watchedSeconds = durationSec;
+        }
+    }
+
+    // 나가기 버튼 클릭 시 이어보기 지점 저장
+    public void saveLastPosition(int lastPositionSec) {
+        this.lastPositionSec = lastPositionSec;
+    }
+
+    // DB 에서 조회한 데이터로 도메인 객체 복원용
+    // create() 는 신규 생성, reconstitute() 는 DB 복원
+    public static LearningHistory reconstitute(
+            Long id, Long userId, Long lectureId, Long chapterId, int watchedSeconds, boolean isCompleted,
+            int lastPositionSec, int progressRate
+    ) {
+        LearningHistory history = new LearningHistory();
+        history.id = id;
+        history.userId = userId;
+        history.lectureId = lectureId;
+        history.chapterId = chapterId;
+        history.watchedSeconds = watchedSeconds;
+        history.isCompleted = isCompleted;
+        history.lastPositionSec = lastPositionSec;
+        history.progressRate = progressRate;
+        return history;
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Lecture.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Lecture.java
@@ -1,0 +1,30 @@
+package com.wanted.momocity.viewing.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public class Lecture {
+
+    private Long id;
+    private Long teacherId;
+    private String title;
+    private String thumbnailUrl;
+    private String category;
+    private String instructorName;
+
+
+    public static Lecture reconstitute(
+            Long id, Long teacherId, String title,
+            String thumbnailUrl, String category, String instructorName
+    ) {
+        Lecture lecture = new Lecture();
+        lecture.id = id;
+        lecture.teacherId = teacherId;
+        lecture.title = title;
+        lecture.thumbnailUrl = thumbnailUrl;
+        lecture.category = category;
+        lecture.instructorName = instructorName;
+        return lecture;
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/repository/LearningHistoryRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/repository/LearningHistoryRepository.java
@@ -1,0 +1,28 @@
+package com.wanted.momocity.viewing.domain.repository;
+
+import com.wanted.momocity.viewing.domain.model.LearningHistory;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LearningHistoryRepository {
+
+    // 저장 (신규 생성 + 수정)
+    LearningHistory save (LearningHistory learningHistory);
+
+    // 특정 챕터의 시청 기록 조회
+    Optional<LearningHistory> findByUserIdAndChapterId(
+            Long userId, Long chapterId
+    );
+
+    // 특정 강의의 전체 챕터 시청 기록 조회
+    List<LearningHistory> findByUserIdAndLectureId (
+            Long userId, Long lectureId
+    );
+
+    // 가장 최근 시청 기록 조회 (현재 챕터 파악용)
+    Optional<LearningHistory> findLatestByUserIdAndLectureId (
+            Long userId, Long lectureId
+    );
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/adapter/LearningHistoryRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/adapter/LearningHistoryRepositoryAdapter.java
@@ -1,0 +1,61 @@
+package com.wanted.momocity.viewing.infrastructure.adapter;
+
+import com.wanted.momocity.viewing.domain.model.LearningHistory;
+import com.wanted.momocity.viewing.domain.repository.LearningHistoryRepository;
+import com.wanted.momocity.viewing.infrastructure.persistence.LearningHistoryJpaEntity;
+import com.wanted.momocity.viewing.infrastructure.persistence.LearningHistoryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/*
+* comment.
+*  domain.repository 인터페이스 <- 구현 -> JpaRepository 연결
+*  Domain 은 이 클래스를 모르고, LearningHistoryRepository 인터페이스만 앎
+*  -
+*  저장 : Domain -> JpaEntity (from()) -> DB 저장
+*  조회 : DB 조회 -> JpaEntity -> Domain (toDomain())
+* */
+
+@Component
+@RequiredArgsConstructor
+// implements : domain.repository 인터페이스 구현
+public class LearningHistoryRepositoryAdapter implements LearningHistoryRepository {
+
+    private final LearningHistoryJpaRepository jpaRepository;
+
+    @Override
+    public LearningHistory save(LearningHistory learningHistory) {
+        // from() : 저장 전 Domain -> JpaEntity 변환
+        LearningHistoryJpaEntity entity = LearningHistoryJpaEntity.from(learningHistory);
+        // toDomain() : 조회 후 JpaEntity -> Domain 변환
+        return jpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public Optional<LearningHistory> findByUserIdAndChapterId(Long userId, Long chapterId) {
+        return jpaRepository
+                .findByUserIdAndChapterId(userId,chapterId)
+                // .map() : Optional/stream 안에서 변환할 때 사용
+                // :: : 메서드 참조 (람다 축약형)
+                .map(LearningHistoryJpaEntity::toDomain);
+    }
+
+    @Override
+    public List<LearningHistory> findByUserIdAndLectureId(Long userId, Long lectureId) {
+        return jpaRepository
+                .findByUserIdAndLectureId(userId, lectureId)
+                .stream()
+                .map(LearningHistoryJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<LearningHistory> findLatestByUserIdAndLectureId(Long userId, Long lectureId) {
+        return jpaRepository
+                .findTopByUserIdAndLectureIdOrderByUpdatedAtDesc(userId, lectureId)
+                .map(LearningHistoryJpaEntity::toDomain);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/adapter/S3PresignedUrlAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/adapter/S3PresignedUrlAdapter.java
@@ -1,0 +1,48 @@
+package com.wanted.momocity.viewing.infrastructure.adapter;
+
+import com.wanted.momocity.viewing.application.port.S3Port;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.time.Duration;
+
+/*
+* comment.
+*  S3PresignedUrlAdapter
+*  - S3Port 인터페이스 구현체
+*  - AWS S3 SDK 를 직접 다루는 유일한 클래스
+*  - Application 은 S3Port 인터페이스만 알고 이 클래스를 직접 모름
+ * */
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignedUrlAdapter implements S3Port {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public String generatePresignedUrl(String videoUrl) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(videoUrl)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                // S3 에 저장된 비공개 영상을 인증 없이 일정 시간만 접근 가능한 임시 URL 로 발급
+                // 유효시간 1시간 (3600초)
+                .signatureDuration(Duration.ofHours(1))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest)
+                .url()
+                .toString();
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/ChapterCatalogAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/ChapterCatalogAdapter.java
@@ -1,0 +1,34 @@
+package com.wanted.momocity.viewing.infrastructure.catalog;
+
+import com.wanted.momocity.viewing.application.port.ChapterPort;
+import com.wanted.momocity.viewing.domain.model.Chapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/*
+* comment.
+*  catalog 컨텍스트 소유의 Chapter 를 READ 전용으로 조회
+*  ChapterPort 인터페이스 구현체
+*  -
+*  현재 : ChapterJpaRepository, ChapterJpaEntity 완성 후 주입 예정
+* */
+
+@Component
+@RequiredArgsConstructor
+public class ChapterCatalogAdapter implements ChapterPort {
+
+    // ChapterJpaRepository 완성 후 주입 예정
+    // private final ChapterJpaRepository chapterJpaRepository;
+
+    @Override
+    public Chapter findById(Long chapterId) {
+       throw new UnsupportedOperationException("구현 예정");
+    }
+
+    @Override
+    public List<Chapter> findAllByLectureId(Long lectureId) {
+        throw new UnsupportedOperationException("구현 예정");
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/EnrollmentCatalogAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/EnrollmentCatalogAdapter.java
@@ -1,0 +1,32 @@
+package com.wanted.momocity.viewing.infrastructure.catalog;
+
+import com.wanted.momocity.viewing.application.port.EnrollmentPort;
+import com.wanted.momocity.viewing.application.port.EnrollmentPort.EnrollmentInfo;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/*
+* comment.
+*  Enrollment 인터페이스 구현체
+*  enrollment 컨텍스트 소유의 수강 정보를 READ 전용으로 조회
+* */
+
+@Component
+public class EnrollmentCatalogAdapter implements EnrollmentPort{
+
+    @Override
+    public Optional<EnrollmentInfo> findByUserIdAndLectureId(
+            Long userId, Long lectureId
+    ) {
+        throw new UnsupportedOperationException("구현 예정");
+    }
+
+    @Override
+    public List<EnrollmentInfo> findAllByUserId(Long userId) {
+        throw new UnsupportedOperationException("구현 예정");
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/LectureCatalogAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/LectureCatalogAdapter.java
@@ -1,0 +1,44 @@
+package com.wanted.momocity.viewing.infrastructure.catalog;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.viewing.application.port.LecturePort;
+import com.wanted.momocity.viewing.domain.model.Lecture;
+import org.springframework.stereotype.Component;
+
+/*
+* comment.
+*  LecturePort 인터페이스 구현체
+*  catalog 컨텍스트 소유의 Lecture 를 READ 전용으로 조회
+* */
+
+@Component
+public class LectureCatalogAdapter implements LecturePort {
+
+    // LectureJpaRepository 완성 후 주입
+    // private final LectureJpaRepository lectureJpaRepository;
+
+    @Override
+    public Lecture findById(Long lectureId) {
+
+//        LectureJpaEntity lectureJpaEntity =
+//                lectureJpaRepository.findById(lectureId)
+//                .orElseThrow(() ->
+//                        new DomainRuleViolationException("강의를 찾을 수 없습니다."));
+//
+//        String instructorName =
+//                userJpaRepository.findById(lectureEntity.getTeacherId())
+//                        .map(UserJpaEntity::getName)
+//                        .orElseThrow(() -> new DomainRuleViolationException("강사를 찾을 수 없습니다."));
+//
+//        return Lecture.reconstitute(
+//                lectureEntity.getId(),
+//                lectureEntity.getTeacherId(),
+//                lectureEntity.getTitle(),
+//                lectureEntity.getThumbnailUrl(),
+//                lectureEntity.getCategory(),
+//                instructorName
+//        );
+
+        throw new UnsupportedOperationException("구현 예정");
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/persistence/LearningHistoryJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/persistence/LearningHistoryJpaEntity.java
@@ -1,0 +1,73 @@
+package com.wanted.momocity.viewing.infrastructure.persistence;
+
+import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
+import com.wanted.momocity.viewing.domain.model.LearningHistory;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+* comment.
+*  infrastructure.persistence
+*  - DB 테이블과 1:1 매핑되는 JPA 클래스
+*  - Domain Model (LearningHistory) 을 모르고, DB 컬럼 구조만 표현함
+*  -
+*  Domain Model 과 JpaEntity 를 분리하는 이유
+*  - Domain Model -> 순수 비지니스 규칙 (JPA 모름)
+*  - JpaEntity -> DB 매핑 전용 (비지니스 규칙 없음)
+*  - 둘 사이 변환은 RepositoryAdapter 가 담당
+* */
+
+@Getter
+@Entity
+@Table(name = "learning_history")
+@NoArgsConstructor
+public class LearningHistoryJpaEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name ="user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "lecture_id", nullable = false)
+    private Long lectureId;
+
+    @Column(name = "chapter_id", nullable = false)
+    private Long chapterId;
+
+    @Column(name = "watched_seconds", nullable = false)
+    private int watchedSeconds;
+
+    @Column(name = "is_completed", nullable = false)
+    private boolean isCompleted;
+
+    @Column(name = "last_position_sec", nullable = false)
+    private int lastPositionSec;
+
+    @Column(name = "progress_rate", nullable = false)
+    private int progressRate;
+
+    // Domain Model -> JpaEntity 변환 (저장용)
+    public static LearningHistoryJpaEntity from(LearningHistory domain) {
+        LearningHistoryJpaEntity entity = new LearningHistoryJpaEntity();
+        entity.id = domain.getId();
+        entity.userId = domain.getUserId();
+        entity.lectureId = domain.getLectureId();
+        entity.chapterId = domain.getChapterId();
+        entity.watchedSeconds = domain.getWatchedSeconds();
+        entity.isCompleted = domain.isCompleted();
+        entity.lastPositionSec = domain.getLastPositionSec();
+        entity.progressRate = domain.getProgressRate();
+        return entity;
+    }
+
+    // JpaEntity -> Domain Model 변환 (조회용)
+    public LearningHistory toDomain() {
+        return LearningHistory.reconstitute(
+                id, userId,lectureId, chapterId, watchedSeconds, isCompleted, lastPositionSec, progressRate
+        );
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/persistence/LearningHistoryJpaRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/persistence/LearningHistoryJpaRepository.java
@@ -1,0 +1,33 @@
+package com.wanted.momocity.viewing.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/*
+* comment.
+*  Spring Data JPA 가 구현체를 자동으로 생성해주는 JPA 전용 인터페이스
+*  Domain 을 모르고 JpaEntity 만 다룸
+*  실제 DB 쿼리는 여기서 실행됨
+* */
+
+public interface LearningHistoryJpaRepository extends JpaRepository<LearningHistoryJpaEntity, Long> {
+
+    // 특정 챕터 시청 기록 조회
+    // 단건 조회는 결과가 없을 수 있어 Optional 사용
+    Optional<LearningHistoryJpaEntity> findByUserIdAndChapterId (
+            Long userId, Long chapterId
+    );
+
+    // 특정 강의 전체 챕터 시청 기록 조회
+    List<LearningHistoryJpaEntity> findByUserIdAndLectureId(
+            Long userId, Long lectureId
+    );
+
+    // updated_at 기준 최신 1개
+    Optional<LearningHistoryJpaEntity> findTopByUserIdAndLectureIdOrderByUpdatedAtDesc (
+            Long userId, Long lectureId
+    );
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/ViewingController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/ViewingController.java
@@ -1,0 +1,198 @@
+package com.wanted.momocity.viewing.presentation.api;
+
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.viewing.application.command.SaveProgressCommand;
+import com.wanted.momocity.viewing.application.usecase.*;
+import com.wanted.momocity.viewing.presentation.api.common.ViewingResponseCode;
+import com.wanted.momocity.viewing.presentation.api.request.SaveProgressRequest;
+import com.wanted.momocity.viewing.presentation.api.response.*;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/*
+* comment.
+*  HTTP 요청을 받아서 UseCase 에 전달하고 응답 반환
+*  비지니스 로직 없음, HTTP 반환만 담당
+* */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ViewingController {
+
+    private final GetStreamingUrlUseCase getStreamingUrlUseCase;
+    private final GetLectureMetaUseCase getLectureMetaUseCase;
+    private final SaveProgressUseCase saveProgressUseCase;
+    private final GetChapterResumeUseCase getChapterResumeUseCase;
+    private final GetTotalProgressUseCase getTotalProgressUseCase;
+    private final GetChapterProgressUseCase getChapterProgressUseCase;
+    private final GetMyLectureUseCase getMyLectureUseCase;
+
+    // S3 Presigned URL 발급
+    // GET /api/v1/lectures/{lectureId}/chapters/{chapterId}/stream
+    @GetMapping("/lectures/{lectureId}/chapters/{chapterId}/stream")
+    public ResponseEntity<ApiResponse<StreamingUrlResponse>> getStreamingUrl (
+            @PathVariable Long lectureId,
+            @PathVariable Long chapterId
+    ) {
+
+        // JWT 완성 후 @AuthenticationPrincipal 교체 예정
+        Long userId = 1L;
+
+        StreamingUrlResponse response = getStreamingUrlUseCase
+                .getStreamingUrl(userId, lectureId, chapterId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.STREAMING_URL_ISSUED,
+                        "영상 스트리밍 URL 이 발급되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // 강의 메타데이터 조회
+    // GET /api/v1/lectures/{lectureId}
+    @GetMapping("/lectures/{lectureId}")
+    public ResponseEntity<ApiResponse<LectureMetaResponse>> getLectureMeta(
+            @PathVariable Long lectureId
+    ) {
+
+        Long userId = 1L;
+
+        LectureMetaResponse response = getLectureMetaUseCase
+                .getLectureMeta(userId, lectureId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.LECTURE_META_FOUND,
+                        "강의 메타데이터 조회에 성공했습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // 강의 영상 재생 진척도 저장
+    // PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}/progress
+    @PatchMapping("/lectures/{lectureId}/chapters/{chapterId}/progress")
+    public ResponseEntity<ApiResponse<SaveProgressResponse>> saveProgress(
+            @PathVariable Long lectureId,
+            @PathVariable Long chapterId,
+            @RequestBody @Valid SaveProgressRequest request
+            ) {
+
+        Long userId = 1L;
+
+        SaveProgressCommand command = new SaveProgressCommand(
+                userId,
+                lectureId,
+                chapterId,
+                request.playbackSeconds()
+        );
+
+        SaveProgressResponse response = saveProgressUseCase
+                .saveProgress(command);
+
+        return  ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.PROGRESS_SAVED,
+                        "진척도가 업데이트되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // 챕터 이어보기
+    // GET /api/v1/lectures/{lectureId}/chapters/{chapterId}/resume
+    @GetMapping("/lectures/{lectureId}/chapters/{chapterId}/resume")
+    public ResponseEntity<ApiResponse<ChapterResumeResponse>> getChapterResume(
+            @PathVariable Long lectureId,
+            @PathVariable Long chapterId
+    ) {
+
+        Long userId = 1L;
+
+        ChapterResumeResponse response = getChapterResumeUseCase
+                .getChapterResume(userId, lectureId, chapterId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.CHAPTER_RESUME_FOUND,
+                        "챕터 이어보기 정보를 조회했습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // 전체 진척도 조회
+    // GET /api/v1/lectures/{lectureId}/progress
+    @GetMapping("/lectures/{lectureId}/progress")
+    public ResponseEntity<ApiResponse<TotalProgressResponse>> getTotalProgress(
+            @PathVariable Long lectureId
+    ) {
+
+        Long userId = 1L;
+
+        TotalProgressResponse response = getTotalProgressUseCase
+                .getTotalProgress(userId, lectureId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.TOTAL_PROGRESS_FOUND,
+                        "전체 진척도를 조회했습니다.",
+                        response
+                )
+        );
+    }
+
+    // 챕터별 진척도 조회
+    // GET /api/v1/lectures/{lectureId}/chapters/progress
+    @GetMapping("/lectures/{lectureId}/chapters/progress")
+    public ResponseEntity<ApiResponse<ChapterProgressResponse>> getChapterProgress(
+            @PathVariable Long lectureId
+    ) {
+
+        Long userId = 1L;
+
+        ChapterProgressResponse response = getChapterProgressUseCase
+                .getChapterProgress(userId, lectureId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.CHAPTER_PROGRESS_FOUND,
+                        "챕터별 진척도를 조회했습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // 내 수강 강의 목록 조회
+    // GET /api/v1/users/me/lectures
+    @GetMapping("/users/me/lectures")
+    public ResponseEntity<ApiResponse<List<MyLectureResponse>>> getMyLectures () {
+
+        Long userId = 1L;
+
+        List<MyLectureResponse> responses = getMyLectureUseCase
+                .getMyLectures(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ViewingResponseCode.MY_LECTURES_FOUND,
+                        "수강 강의 목록을 조회했습니다.",
+                        responses
+                )
+        );
+
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/common/ViewingResponseCode.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/common/ViewingResponseCode.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.viewing.presentation.api.common;
+
+/*
+* comment.
+*  viewing 컨텍스트 전용 API 응답 코드 상수 모음
+*  클라이언트가 업무 시나리오 기준으로 응답 해석 가능
+*  VIEWING-*
+* */
+
+public class ViewingResponseCode {
+
+    private ViewingResponseCode() {}
+
+    // 강의 시청
+    public static final String STREAMING_URL_ISSUED = "VIEWING-STREAMING-URL-ISSUED";
+    public static final String LECTURE_META_FOUND    = "VIEWING-LECTURE-META-FOUND";
+    public static final String CHAPTER_RESUME_FOUND  = "VIEWING-CHAPTER-RESUME-FOUND";
+
+    // 진척도
+    public static final String PROGRESS_SAVED        = "VIEWING-PROGRESS-SAVED";
+    public static final String TOTAL_PROGRESS_FOUND  = "VIEWING-TOTAL-PROGRESS-FOUND";
+    public static final String CHAPTER_PROGRESS_FOUND = "VIEWING-CHAPTER-PROGRESS-FOUND";
+
+    // 내 강의
+    public static final String MY_LECTURES_FOUND     = "VIEWING-MY-LECTURES-FOUND";
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/request/SaveProgressRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/request/SaveProgressRequest.java
@@ -1,0 +1,20 @@
+package com.wanted.momocity.viewing.presentation.api.request;
+
+/*
+* comment.
+*  진척도 저장 API 의 RequestBody
+*  프론트가 5-10 초 주기로 현재 재생 위치를 전송
+*  record 라서 불변객체
+*  -
+*  playbackSeconds : 0 이상 필수값
+* */
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record SaveProgressRequest(
+        @NotNull(message = "재생 시간 값은 필수 항목입니다.")
+        @Min(value = 0, message = "재생 시간은 0 이상이어야 합니다.")
+        Integer playbackSeconds
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterProgressResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterProgressResponse.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+import java.util.List;
+
+/*
+* comment.
+*  ChapterProgressResponse.ChapterProgressItem 으로 접근
+*  -> ChapterProgressResponse 에서만 쓰는 아이템 모델이라 안에 묶음
+*  -
+*  챕터별 진척도 목록 반환
+* */
+
+public record ChapterProgressResponse(
+        Long lectureId,
+        List<ChapterProgressItem> chapters
+) {
+    public record ChapterProgressItem(
+            Long chapterId,
+            String title,
+            int orderNo,
+            int watchedSeconds,
+            int durationSec,
+            int progressRate,
+            boolean isCompleted
+    ) {}
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterResumeResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterResumeResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+/*
+* comment.
+*  이어보기 시작 지점 반환
+*  프론트가 lastPositionSec 받아서 영상 시작 시점 세팅
+* */
+
+public record ChapterResumeResponse(
+        Long lectureId,
+        Long chapterId,
+        String chapterTitle,
+        int lastPositionSec,
+        int durationSec,
+        int totalProgress
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/LectureMetaResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/LectureMetaResponse.java
@@ -1,0 +1,18 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+/*
+* comment.
+*  강의 메타데이터 (플레이어 UI 상단용)
+*  learning_history 에서 현재 챕터 조회 후 반환
+* */
+
+public record LectureMetaResponse(
+        Long lectureId,
+        String lectureTitle,
+        String instructorName,
+        int totalChapterCount,
+        int currentChapterNo,
+        Long currentChapterId,
+        String currentChapterTitle
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/MyLectureResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/MyLectureResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+/*
+* comment.
+*  내 수강 강의 목록 단건 반환
+* */
+
+public record MyLectureResponse(
+        Long lectureId,
+        String lectureTitle,
+        String thumbnailUrl,
+        String category,
+        int totalProgress
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/SaveProgressResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/SaveProgressResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+/*
+* comment.
+*  진척도 저장 후 업데이트 된 상태 반환
+*  프론트가 이 값으로 UI 진척도 바 업데이트
+* */
+
+public record SaveProgressResponse(
+        Long chapterId,
+        int watchedSeconds,
+        int progressRate,
+        boolean isCompleted,
+        int totalProgress,
+        int completedCount
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/StreamingUrlResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/StreamingUrlResponse.java
@@ -1,0 +1,18 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+/*
+* comment.
+*  Service 처리 결과를 Controller 가 클라이언트에 돌려줄 형태로 포장, record 라서 불변 객체
+*  -
+*  S3 Presigned URL + 챕터 기본 정보를 프론트에 전달
+* */
+
+public record StreamingUrlResponse(
+        Long chapterId,
+        String presignedUrl,
+        // URL 유효 시간 (초)
+        int expiresIn,
+        String videoTitle,
+        int durationSec
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/TotalProgressResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/TotalProgressResponse.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.viewing.presentation.api.response;
+
+/*
+* comment.
+*  강의 전체 진척도 반환
+* */
+
+public record TotalProgressResponse(
+        Long lectureId,
+        int totalProgress,
+        int completedCount,
+        int totalChapterCount
+) {
+}


### PR DESCRIPTION
## 📌 작업 내용
Viewing, Calendar 전체 파일구조 및 Viewing 기본 코드 작성

## ✅ 구현 사항
#24

### Viewing 도메인
- Domain Model: LearningHistory, Chapter, Lecture
- Domain Event: ChapterCompletedEvent, CourseCompletedEvent
- Domain Repository: LearningHistoryRepository
- Application Port: ChapterPort, LecturePort, EnrollmentPort, S3Port
- Application UseCase: 7개 UseCase 인터페이스 정의
- Application Service: ViewingService, ProgressService
- Infrastructure: LearningHistoryJpaEntity, LearningHistoryRepositoryAdapter, S3PresignedUrlAdapter
- Infrastructure Catalog: ChapterCatalogAdapter, LectureCatalogAdapter, EnrollmentCatalogAdapter (껍데기 - 팀원 머지 후 구현 예정)
- Presentation: ViewingController, SaveProgressRequest, Response 7개

### Calendar 도메인
- 전체 파일구조 생성

## 🔧 TODO (추후 작업)
- [ ] JWT 인증 완성 후 `userId = 1L` → `@AuthenticationPrincipal` 교체
- [ ] 팀원 ChapterJpaRepository 머지 후 ChapterCatalogAdapter 구현
- [ ] 팀원 LectureJpaRepository 머지 후 LectureCatalogAdapter 구현
- [ ] 팀원 EnrollmentJpaRepository 머지 후 EnrollmentCatalogAdapter 구현
- [ ] Calendar 도메인 구현

## 📝 참고 사항
- enrollment 테이블 소유권: 팀원 담당
- 진척도 계산: enrollment 캐싱 없이 learning_history 집계로 계산
- Adapter 껍데기는 UnsupportedOperationException 반환