### PR TITLE
Calendar 도메인 코드 작성

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/legend-momo-city" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CheckTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CheckTodoCommand.java
@@ -1,4 +1,13 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record CheckTodoCommand() {
+/*
+* comment
+*  userId(토큰) + calendarId(PathVariable) + isCompleted(RequestBody)
+* */
+
+public record CheckTodoCommand(
+        Long userId,
+        Long calendarId,
+        boolean isCompleted
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateMemoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateMemoCommand.java
@@ -1,4 +1,17 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record CreateMemoCommand() {
+/*
+* comment.
+*  userId(토큰) + title, start, end(RequestBody)
+*  end = nullable
+* */
+
+import java.time.LocalDate;
+
+public record CreateMemoCommand(
+        Long userId,
+        String title,
+        LocalDate start,
+        LocalDate end
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/CreateTodoCommand.java
@@ -1,4 +1,15 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record CreateTodoCommand() {
+/*
+* comment.
+*  userId(토큰) + title(RequestBody) + start(RequestBody)
+* */
+
+import java.time.LocalDate;
+
+public record CreateTodoCommand(
+        Long userId,
+        String title,
+        LocalDate start
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteMemoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteMemoCommand.java
@@ -1,4 +1,12 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record DeleteMemoCommand() {
+/*
+* comment.
+*  userId(토큰) + calendarId(PathVariable)
+* */
+
+public record DeleteMemoCommand(
+        Long userId,
+        Long calendarId
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/DeleteTodoCommand.java
@@ -1,4 +1,12 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record DeleteTodoCommand() {
+/*
+* comment.
+*  userId(토큰) + calendarId(PathVariable)
+* */
+
+public record DeleteTodoCommand(
+        Long userId,
+        Long calendarId
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateMemoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateMemoCommand.java
@@ -1,4 +1,17 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record UpdateMemoCommand() {
+/*
+* comment.
+*  userId(토큰) + calendarId(PathVariable) + title, start, end(RequestBody)
+* */
+
+import java.time.LocalDate;
+
+public record UpdateMemoCommand(
+        Long userId,
+        Long calendarId,
+        String title,
+        LocalDate start,
+        LocalDate end
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateTodoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/command/UpdateTodoCommand.java
@@ -1,4 +1,16 @@
 package com.wanted.momocity.calendar.application.command;
 
-public record UpdateTodoCommand() {
+/*
+* comment.
+*  userId(토큰) + calendarId(PathVariable) + Title, start(RequestBody)
+* */
+
+import java.time.LocalDate;
+
+public record UpdateTodoCommand(
+        Long userId,
+        Long calendarId,
+        String title,
+        LocalDate start
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/MemoService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/MemoService.java
@@ -1,4 +1,119 @@
 package com.wanted.momocity.calendar.application.service;
 
-public class MemoService {
+import com.wanted.momocity.calendar.application.command.CreateMemoCommand;
+import com.wanted.momocity.calendar.application.command.DeleteMemoCommand;
+import com.wanted.momocity.calendar.application.command.UpdateMemoCommand;
+import com.wanted.momocity.calendar.application.usecase.CreateMemoUseCase;
+import com.wanted.momocity.calendar.application.usecase.DeleteMemoUseCase;
+import com.wanted.momocity.calendar.application.usecase.UpdateMemoUseCase;
+import com.wanted.momocity.calendar.domain.model.Calendar;
+import com.wanted.momocity.calendar.domain.repository.CalendarRepository;
+import com.wanted.momocity.calendar.presentation.api.response.MemoResponse;
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+* comment.
+*  Memo 관련 UseCase 구현체
+*  Http 모름, JPA 모름, 순수 비지니스 흐름만 담당
+*  -
+*  [담당 UseCase]
+*  - CreateMemoUseCase : Memo 등록
+*  - UpdateMemoUseCase : Memo 수정
+*  - DeleteMemoUseCase : Memo 삭제
+* */
+
+@Service
+@RequiredArgsConstructor
+public class MemoService implements
+        CreateMemoUseCase,
+        UpdateMemoUseCase,
+        DeleteMemoUseCase {
+
+    private final CalendarRepository calendarRepository;
+
+    @Override
+    @Transactional
+    // CreateMemoUseCase
+    public MemoResponse createMemo(CreateMemoCommand command) {
+
+        // 도메인 메서드로 Memo 생성
+        // end < start 검증은 도메인에서 처리
+        Calendar calendar = Calendar.createMemo(
+                command.userId(),
+                command.title(),
+                command.start(),
+                command.end()
+        );
+
+        // 저장
+        Calendar saved = calendarRepository.save(calendar);
+
+        return new MemoResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getCategory(),
+                saved.getStart(),
+                saved.getEnd()
+        );
+    }
+
+    @Override
+    @Transactional
+    // UpdateMemoUseCase
+    public MemoResponse updateMemo(UpdateMemoCommand command) {
+
+        // 조회
+        Calendar calendar = calendarRepository.findById(command.calendarId())
+                .orElseThrow(() -> new DomainRuleViolationException(
+                        "메모를 찾을 수 없습니다."
+                ));
+
+        // 본인 고유 여부 확인 (도메인 메서드)
+        if (!calendar.isOwnedBy(command.userId())) {
+            throw new DomainRuleViolationException(
+                    "본인의 메모만 수정할 수 있습니다."
+            );
+        }
+
+        // 수정 (도메인 메서드)
+        calendar.update(command.title(), command.start(), command.end());
+
+        // 저장
+        Calendar saved = calendarRepository.save(calendar);
+
+        return new MemoResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getCategory(),
+                saved.getStart(),
+                saved.getEnd()
+        );
+
+    }
+
+    @Override
+    @Transactional
+    // DeleteMemoUseCase
+    public void deleteMemo(DeleteMemoCommand command) {
+
+        // 조회
+        Calendar calendar = calendarRepository.findById(command.calendarId())
+                .orElseThrow(() -> new DomainRuleViolationException(
+                        "메모를 찾을 수 없습니다."
+                ));
+
+        // 본인 소유 여부 확인 (도메인 메서드)
+        if (!calendar.isOwnedBy(command.userId())) {
+            throw new DomainRuleViolationException(
+                    "본인의 메모만 삭제할 수 있습니다."
+            );
+        }
+
+        // 삭제
+        calendarRepository.delete(command.calendarId());
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/TodoService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/service/TodoService.java
@@ -1,4 +1,158 @@
 package com.wanted.momocity.calendar.application.service;
 
-public class TodoService {
+import com.wanted.momocity.calendar.application.command.CheckTodoCommand;
+import com.wanted.momocity.calendar.application.command.CreateTodoCommand;
+import com.wanted.momocity.calendar.application.command.DeleteTodoCommand;
+import com.wanted.momocity.calendar.application.command.UpdateTodoCommand;
+import com.wanted.momocity.calendar.application.usecase.CheckTodoUseCase;
+import com.wanted.momocity.calendar.application.usecase.CreateTodoUseCase;
+import com.wanted.momocity.calendar.application.usecase.DeleteTodoUseCase;
+import com.wanted.momocity.calendar.application.usecase.UpdateTodoUseCase;
+import com.wanted.momocity.calendar.domain.model.Calendar;
+import com.wanted.momocity.calendar.domain.repository.CalendarRepository;
+import com.wanted.momocity.calendar.presentation.api.response.TodoResponse;
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+* comment.
+*  Todo 관련 UseCase 구현체
+*  HTTP 모름, JPA 모름, 순수 비지니스 흐름만 담당
+*  -
+*  [담당 UseCase]
+*  - CreateTodoUseCase : Todo 등록
+*  - UpdateTodoUseCase : Todo 수정
+*  - DeleteTodoUseCase : Todo 삭제
+*  - CheckTodoUseCase : Todo 체크 상태 변경
+* */
+
+@Service
+@RequiredArgsConstructor
+public class TodoService implements
+        CreateTodoUseCase,
+        UpdateTodoUseCase,
+        DeleteTodoUseCase,
+        CheckTodoUseCase {
+
+    private final CalendarRepository calendarRepository;
+
+    @Override
+    @Transactional
+    // CreateTodoUseCase
+    public TodoResponse createTodo(CreateTodoCommand command) {
+
+        // 도메인 메서드로 Todo 생성
+        Calendar calendar = Calendar.createTodo(
+                command.userId(),
+                command.title(),
+                command.start()
+        );
+
+        // 저장
+        Calendar saved = calendarRepository.save(calendar);
+
+        return new TodoResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getCategory(),
+                saved.getStart(),
+                saved.isCompleted()
+        );
+
+    }
+
+    @Override
+    @Transactional
+    // UpdateTodoUseCase
+    public TodoResponse updateTodo(UpdateTodoCommand command) {
+
+        // 조회
+        Calendar calendar = calendarRepository.findById(command.calendarId())
+                .orElseThrow(() -> new DomainRuleViolationException(
+                        "Todo 를 찾을 수 없습니다."
+                ));
+
+        // 본인 소유 여부 확인 (도메인 메서드)
+        if (!calendar.isOwnedBy(command.userId())) {
+            throw new DomainRuleViolationException(
+                    "본인의 Todo 만 수정할 수 있습니다."
+            );
+        }
+
+        // 수정 (도메인 메서드)
+        calendar.update(command.title(), command.start(), null);
+
+        // 저장
+        Calendar saved = calendarRepository.save(calendar);
+
+        return new TodoResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getCategory(),
+                saved.getStart(),
+                saved.isCompleted()
+        );
+
+    }
+
+    @Override
+    @Transactional
+    // DeleteTodoUseCase
+    public void deleteTodo(DeleteTodoCommand command) {
+
+        // 조회
+        Calendar calendar = calendarRepository.findById(command.calendarId())
+                .orElseThrow(() -> new DomainRuleViolationException(
+                        "Todo 를 찾을 수 없습니다."
+                ));
+
+        // 본인 소유 여부 확인 (도메인 메서드)
+        if (!calendar.isOwnedBy(command.userId())) {
+            throw new DomainRuleViolationException(
+                    "본인의 Todo 만 삭제할 수 있습니다."
+            );
+        }
+
+        // 삭제
+        calendarRepository.delete(command.calendarId());
+
+    }
+
+    @Override
+    @Transactional
+    // CheckTodoUseCase
+    public TodoResponse checkTodo(CheckTodoCommand command) {
+
+        // 조회
+        Calendar calendar = calendarRepository.findById(command.calendarId())
+                .orElseThrow(() -> new DomainRuleViolationException(
+                        "Todo 를 찾을 수 없습니다."
+                ));
+
+        // 본인 소유 여부 확인 (도메인 메서드)
+        if (!calendar.isOwnedBy(command.userId())) {
+            throw new DomainRuleViolationException(
+                    "본인의 Todo 만 변경할 수 있습니다."
+            );
+        }
+
+        // 체크 상태 변경 (도메인 메서드)
+        // Momo 호출 시 도메인에서 예외 발생
+        calendar.toggleComplete();
+
+        // 저장
+        Calendar saved = calendarRepository.save(calendar);
+
+        return new TodoResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getCategory(),
+                saved.getStart(),
+                saved.isCompleted()
+        );
+
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CheckTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CheckTodoUseCase.java
@@ -1,4 +1,15 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.CheckTodoCommand;
+import com.wanted.momocity.calendar.presentation.api.response.TodoResponse;
+
+/*
+ * comment.
+ *  Todo 체크 상태 변경
+ * */
+
 public interface CheckTodoUseCase {
+
+    TodoResponse checkTodo(CheckTodoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateMemoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateMemoUseCase.java
@@ -1,4 +1,15 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.CreateMemoCommand;
+import com.wanted.momocity.calendar.presentation.api.response.MemoResponse;
+
+/*
+* comment.
+*  Memo 등록
+* */
+
 public interface CreateMemoUseCase {
+
+    MemoResponse createMemo(CreateMemoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/CreateTodoUseCase.java
@@ -1,4 +1,15 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.CreateTodoCommand;
+import com.wanted.momocity.calendar.presentation.api.response.TodoResponse;
+
+/*
+ * comment.
+ *  Todo 등록
+ * */
+
 public interface CreateTodoUseCase {
+
+    TodoResponse createTodo(CreateTodoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteMemoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteMemoUseCase.java
@@ -1,4 +1,14 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.DeleteMemoCommand;
+
+/*
+* comment.
+*  Memo 삭제
+* */
+
 public interface DeleteMemoUseCase {
+
+    void deleteMemo(DeleteMemoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/DeleteTodoUseCase.java
@@ -1,4 +1,14 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.DeleteTodoCommand;
+
+/*
+ * comment.
+ *  Todo 삭제
+ * */
+
 public interface DeleteTodoUseCase {
+
+    void deleteTodo(DeleteTodoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/GetDailyCalendarUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/GetDailyCalendarUseCase.java
@@ -1,4 +1,16 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+/*
+* comment.
+*  날짜별 캘린더 조회 (Todo  + Memo)
+* */
+
+import com.wanted.momocity.calendar.presentation.api.response.DailyCalendarResponse;
+
+import java.time.LocalDate;
+
 public interface GetDailyCalendarUseCase {
+
+    DailyCalendarResponse getDailyCalendar(Long userId, LocalDate date);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateMemoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateMemoUseCase.java
@@ -1,4 +1,15 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.UpdateMemoCommand;
+import com.wanted.momocity.calendar.presentation.api.response.MemoResponse;
+
+/*
+* comment.
+*  Memo 수정
+* */
+
 public interface UpdateMemoUseCase {
+
+    MemoResponse updateMemo(UpdateMemoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateTodoUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/usecase/UpdateTodoUseCase.java
@@ -1,4 +1,15 @@
 package com.wanted.momocity.calendar.application.usecase;
 
+import com.wanted.momocity.calendar.application.command.UpdateTodoCommand;
+import com.wanted.momocity.calendar.presentation.api.response.TodoResponse;
+
+/*
+ * comment.
+ *  Todo 수정
+ * */
+
 public interface UpdateTodoUseCase {
+
+    TodoResponse updateTodo(UpdateTodoCommand command);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/model/Calendar.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/model/Calendar.java
@@ -96,4 +96,21 @@ public class Calendar {
         return this.userId.equals(userId);
     }
 
+    // DB 에서 조회한 데이터로 도메인 객체 복원용
+    // create() 는 신규생성, reconstitute() 는 DB 복원
+    public static Calendar reconstitute(
+            Long id, Long userId, String title, Category category,
+            LocalDate start, LocalDate end, boolean isCompleted
+    ) {
+        Calendar calendar = new Calendar();
+        calendar.id = id;
+        calendar.userId = userId;
+        calendar.title = title;
+        calendar.category = category;
+        calendar.start = start;
+        calendar.end = end;
+        calendar.isCompleted = isCompleted;
+        return calendar;
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/repository/CalendarRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/domain/repository/CalendarRepository.java
@@ -1,4 +1,31 @@
 package com.wanted.momocity.calendar.domain.repository;
 
+import com.wanted.momocity.calendar.domain.model.Calendar;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/*
+* comment.
+*  domain 이 저장소가 필요하다고 선언하는 인터페이스
+*  JPA 모름
+*  실제 구현체는 infrastructure.persistence.CalendarRepositoryAdapter 가 담당
+* */
+
 public interface CalendarRepository {
+
+    // 저장 (신규 생성 + 성장)
+    Calendar save (Calendar calendar);
+
+    // 단건 조회
+    Optional<Calendar> findById(Long id);
+
+    // 날짜별 조회 (Todo + Memo)
+    // start <= date AND (end >= date OR end is NULL)
+    List<Calendar> findByUserIdAndDate (Long userId, LocalDate date);
+
+    // 삭제
+    void delete(Long id);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaEntity.java
@@ -1,4 +1,69 @@
 package com.wanted.momocity.calendar.infrastructure.persistence;
 
+import com.wanted.momocity.calendar.domain.model.Calendar;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  calendar 테이블과 1:1 매핑되는 JPA 전용 클래스
+*  Domain Model(Calendar) 을 모르고 DB 컬럼 구조만 표현
+*  도메인 <-> JpaEntity 변환은 CalendarRepositoryAdapter 가 담당
+* */
+
+@Getter
+@Entity
+@Table(name = "calendar")
+@NoArgsConstructor
 public class CalendarJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Calendar.Category category;
+
+    @Column(name = "start", nullable = false)
+    private LocalDate start;
+
+    // nullable (Memo 전용)
+    @Column(name = "end")
+    private LocalDate end;
+
+    // Todo 전용, 기본값 false
+    @Column(name = "is_completed", nullable = false)
+    private boolean isCompleted;
+
+    // Domain → JpaEntity 변환 (저장용)
+    public static CalendarJpaEntity from(Calendar domain) {
+        CalendarJpaEntity entity = new CalendarJpaEntity();
+        entity.id = domain.getId();
+        entity.userId = domain.getUserId();
+        entity.title = domain.getTitle();
+        entity.category = domain.getCategory();
+        entity.start = domain.getStart();
+        entity.end = domain.getEnd();
+        entity.isCompleted = domain.isCompleted();
+        return entity;
+    }
+
+    // JpaEntity → Domain 변환 (조회용)
+    public Calendar toDomain() {
+        return Calendar.reconstitute(
+                id, userId, title, category,
+                start, end, isCompleted
+        );
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarJpaRepository.java
@@ -1,4 +1,38 @@
 package com.wanted.momocity.calendar.infrastructure.persistence;
 
-public class CalendarJpaRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/*
+* comment.
+*  Spring Data JPA 가 구현체 자동 생성
+*  Domain 모름, JpaEntity 만 다룸
+*  실제 DB 쿼리는 해당 클래스에서 실행
+* */
+
+public interface CalendarJpaRepository extends JpaRepository<CalendarJpaEntity, Long> {
+
+    // 날짜별 조회
+    // Todo / Memo 날짜 필터링 조건이 달라서 네이밍 규칙으로 표현 불가
+    // Todo : start = date
+    // Memo : start <= date AND (end >= date OR end IS NULL)
+    @Query("""
+            SELECT c FROM CalendarJpaEntity c
+            WHERE c.userId = :userId
+            AND (
+                (c.category = 'TODO' AND c.start = :date)
+                OR
+                (c.category = 'MEMO' AND c.start <= :date
+                AND (c.end >= :date OR c.end IS NULL))
+            )
+            """)
+    List<CalendarJpaEntity> findByUserIdAndDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
@@ -1,4 +1,49 @@
 package com.wanted.momocity.calendar.infrastructure.persistence;
 
-public class CalendarRepositoryAdapter {
+import com.wanted.momocity.calendar.domain.model.Calendar;
+import com.wanted.momocity.calendar.domain.repository.CalendarRepository;
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarRepositoryAdapter implements CalendarRepository {
+
+    private final CalendarJpaRepository jpaRepository;
+
+    @Override
+    public Calendar save(Calendar calendar) {
+        CalendarJpaEntity entity = CalendarJpaEntity.from(calendar);
+        return jpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public Optional<Calendar> findById(Long id) {
+        return jpaRepository.findById(id)
+                .map(CalendarJpaEntity::toDomain);
+    }
+
+    @Override
+    public List<Calendar> findByUserIdAndDate(Long userId, LocalDate date) {
+        return jpaRepository.findByUserIdAndDate(userId, date)
+                .stream()
+                .map(CalendarJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void delete(Long id) {
+        if (!jpaRepository.existsById(id)) {
+            throw new DomainRuleViolationException(
+                    "삭제할 항목을 찾을 수 없습니다."
+            );
+        }
+        jpaRepository.deleteById(id);
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/CalendarController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/CalendarController.java
@@ -1,4 +1,243 @@
 package com.wanted.momocity.calendar.presentation.api;
 
+import com.wanted.momocity.calendar.application.command.*;
+import com.wanted.momocity.calendar.application.usecase.*;
+import com.wanted.momocity.calendar.presentation.api.common.CalendarResponseCode;
+import com.wanted.momocity.calendar.presentation.api.request.*;
+import com.wanted.momocity.calendar.presentation.api.response.DailyCalendarResponse;
+import com.wanted.momocity.calendar.presentation.api.response.MemoResponse;
+import com.wanted.momocity.calendar.presentation.api.response.TodoResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  HTTP 요청을 받아서 UseCase 에 전달하고 응답 반환
+*  비지니스 로직 없음, HTTP 반환만 담당
+* */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/calendar")
 public class CalendarController {
+
+    private final GetDailyCalendarUseCase getDailyCalendarUseCase;
+    private final CreateTodoUseCase createTodoUseCase;
+    private final UpdateTodoUseCase updateTodoUseCase;
+    private final DeleteTodoUseCase deleteTodoUseCase;
+    private final CheckTodoUseCase checkTodoUseCase;
+    private final CreateMemoUseCase createMemoUseCase;
+    private final UpdateMemoUseCase updateMemoUseCase;
+    private final DeleteMemoUseCase deleteMemoUseCase;
+
+    // 날짜별 캘린더 조회
+    // GET /api/v1/calendar/daily?date=2026-05-26
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponse<DailyCalendarResponse>> getDailyCalendar (
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate date
+            ) {
+
+        Long userId = 1L;
+
+        DailyCalendarResponse response = getDailyCalendarUseCase
+                .getDailyCalendar(userId, date);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        CalendarResponseCode.DAILY_CALENDAR_FOUND,
+                        "날짜별 캘린더 데이터를 조회했습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // Todo 등록
+    // POST /api/v1/calendar/todo
+    @PostMapping("/todo")
+    public ResponseEntity<ApiResponse<TodoResponse>> createTodo(
+            @RequestParam @Valid CreateTodoRequest request
+    ) {
+
+        Long userId = 1L;
+
+        CreateTodoCommand command = new CreateTodoCommand(
+                userId,
+                request.title(),
+                request.start()
+        );
+
+        TodoResponse response = createTodoUseCase.createTodo(command);
+
+        return ResponseEntity.status(201).body(
+                ApiResponse.created(
+                        CalendarResponseCode.TODO_CREATED,
+                        "Todo 가 등록되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // Todo 수정
+    // PATCH /api/v1/calendar/todo/{calendarId}
+    @PatchMapping("/todo/{calendarId}")
+    public ResponseEntity<ApiResponse<TodoResponse>> updateTodo(
+            @PathVariable Long calendarId,
+            @RequestBody @Valid UpdateTodoRequest request
+            ) {
+
+        Long userId = 1L;
+
+        UpdateTodoCommand command = new UpdateTodoCommand(
+                userId,
+                calendarId,
+                request.title(),
+                request.start()
+        );
+
+        TodoResponse response = updateTodoUseCase.updateTodo(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        CalendarResponseCode.TODO_UPDATED,
+                        "Todo 가 수정되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // Todo 삭제
+    // DELETE /api/v1/calendar/todo/{calendarId}
+    @DeleteMapping("/todo/{calendarId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTodo(
+            @PathVariable Long calendarId
+    ) {
+        Long userId = 1L;
+
+        DeleteTodoCommand command = new DeleteTodoCommand(userId, calendarId);
+        deleteTodoUseCase.deleteTodo(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        CalendarResponseCode.TODO_DELETED,
+                        "Todo 가 삭제되었습니다."
+                )
+        );
+    }
+
+    // Todo 체크 상태 변경
+    // PATCH /api/v1/calendar/todo/{calendarId}/check
+    @PatchMapping("/todo/{calendarId}/check")
+    public ResponseEntity<ApiResponse<TodoResponse>> checkTodo(
+            @PathVariable Long calendarId,
+            @RequestBody @Valid CheckTodoRequest request
+            ) {
+
+        Long userId = 1L;
+
+        CheckTodoCommand command = new CheckTodoCommand(
+                userId,
+                calendarId,
+                request.isCompleted()
+        );
+
+        TodoResponse response = checkTodoUseCase.checkTodo(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        CalendarResponseCode.TODO_CHECKED,
+                        "Todo 체크 상태가 변경되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // Memo 등록
+    // POST /api/v1/calendar/memo
+    @PostMapping("/memo")
+    public ResponseEntity<ApiResponse<MemoResponse>> createMemo(
+            @RequestBody @Valid CreateMemoRequest request
+            ) {
+
+        Long userId = 1L;
+
+        CreateMemoCommand command = new CreateMemoCommand(
+                userId,
+                request.title(),
+                request.start(),
+                request.end()
+        );
+
+        MemoResponse response = createMemoUseCase.createMemo(command);
+
+        return ResponseEntity.status(201).body(
+                ApiResponse.created(
+                        CalendarResponseCode.MEMO_CREATED,
+                        "메모가 등록되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // Memo 수정
+    // PATCH /api/v1/calendar/memo/{calendarId}
+    @PatchMapping("/memo/{calendarId}")
+    public ResponseEntity<ApiResponse<MemoResponse>> updateMemo(
+            @PathVariable Long calendarId,
+            @RequestBody @Valid UpdateMemoRequest request
+            ) {
+
+        Long userId = 1L;
+
+        UpdateMemoCommand command = new UpdateMemoCommand(
+                userId,
+                calendarId,
+                request.title(),
+                request.start(),
+                request.end()
+        );
+
+        MemoResponse response = updateMemoUseCase.updateMemo(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        CalendarResponseCode.MEMO_UPDATED,
+                        "메모가 수정되었습니다.",
+                        response
+                )
+        );
+
+    }
+
+    // Memo 삭제
+    // DELETE /api/v1/calendar/memo/{calendarId}
+    @DeleteMapping("/memo/{calendarId}")
+    public ResponseEntity<ApiResponse<Void>> deleteMemo(
+            @PathVariable Long calendarId
+    ) {
+
+        Long userId = 1L;
+
+        DeleteMemoCommand command = new DeleteMemoCommand(userId, calendarId);
+        deleteMemoUseCase.deleteMemo(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        CalendarResponseCode.MEMO_DELETED,
+                        "메모가 삭제되었습니다."
+                )
+        );
+
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/common/CalendarResponseCode.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/common/CalendarResponseCode.java
@@ -1,4 +1,26 @@
 package com.wanted.momocity.calendar.presentation.api.common;
 
+/*
+* comment.
+*  calendar 컨텍스트 전용 API 응답 코드 상수 모음
+*  CALENDAR-*
+* */
+
 public class CalendarResponseCode {
+
+    private CalendarResponseCode() {}
+
+    // 캘린더 조회
+    public static final String DAILY_CALENDAR_FOUND  = "CALENDAR-DAILY-FOUND";
+
+    // Todo
+    public static final String TODO_CREATED          = "CALENDAR-TODO-CREATED";
+    public static final String TODO_UPDATED          = "CALENDAR-TODO-UPDATED";
+    public static final String TODO_DELETED          = "CALENDAR-TODO-DELETED";
+    public static final String TODO_CHECKED          = "CALENDAR-TODO-CHECKED";
+
+    // Memo
+    public static final String MEMO_CREATED          = "CALENDAR-MEMO-CREATED";
+    public static final String MEMO_UPDATED          = "CALENDAR-MEMO-UPDATED";
+    public static final String MEMO_DELETED          = "CALENDAR-MEMO-DELETED";
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CheckTodoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CheckTodoRequest.java
@@ -1,4 +1,17 @@
 package com.wanted.momocity.calendar.presentation.api.request;
 
-public record CheckTodoRequest() {
+import jakarta.validation.constraints.NotNull;
+
+/*
+* comment,
+*  isCompleted 필수값
+*  true -> 완료, false -> 미완료 (토글방식)
+* */
+
+public record CheckTodoRequest(
+
+        @NotNull(message =  "체크 상태 값은 필수 항목입니다.")
+        boolean isCompleted
+
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateMemoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateMemoRequest.java
@@ -1,4 +1,25 @@
 package com.wanted.momocity.calendar.presentation.api.request;
 
-public record CreateMemoRequest() {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  title, start 필수값
+*  end nullable (없으면 start 하루만 표시)
+* */
+
+public record CreateMemoRequest(
+
+        @NotBlank(message = "제목은 필수 항목입니다.")
+        String title,
+
+        @NotNull(message = "시작 날짜는 필수 항목입니다")
+        LocalDate start,
+
+        LocalDate end // nullable
+
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateTodoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/CreateTodoRequest.java
@@ -1,4 +1,22 @@
 package com.wanted.momocity.calendar.presentation.api.request;
 
-public record CreateTodoRequest() {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  title, start 팔수값
+* */
+
+public record CreateTodoRequest(
+
+        @NotBlank(message = "제목은 필수 항목입니다.")
+        String title,
+
+        @NotNull(message = "날짜는 필수 항목입니다.")
+        LocalDate start
+
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateMemoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateMemoRequest.java
@@ -1,4 +1,19 @@
 package com.wanted.momocity.calendar.presentation.api.request;
 
-public record UpdateMemoRequest() {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record UpdateMemoRequest(
+
+        @NotBlank(message = "수정할 제목은 필수 항목입니다.")
+        String title,
+
+        @NotNull(message = "시작 날짜는 필수 항목입니다.")
+        LocalDate start,
+
+        LocalDate end // nullable
+
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateTodoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/request/UpdateTodoRequest.java
@@ -1,4 +1,22 @@
 package com.wanted.momocity.calendar.presentation.api.request;
 
-public record UpdateTodoRequest() {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  title, start 필수값
+* */
+
+public record UpdateTodoRequest(
+
+        @NotBlank(message = "수정할 제목은 필수 항목입니다.")
+        String title,
+
+        @NotNull(message = "날짜는 필수 항목입니다.")
+        LocalDate start
+
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/DailyCalendarResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/DailyCalendarResponse.java
@@ -1,4 +1,18 @@
 package com.wanted.momocity.calendar.presentation.api.response;
 
-public record DailyCalendarResponse() {
+import java.time.LocalDate;
+import java.util.List;
+
+/*
+* comment.
+*  날짜별 캘린더 조회 반환
+*  todos : 해당 날짜 Todo 목록
+*  memos : 해당 날짜 Memo 목록
+* */
+
+public record DailyCalendarResponse(
+        LocalDate date,
+        List<TodoResponse> todos,
+        List<MemoResponse> memos
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/MemoResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/MemoResponse.java
@@ -1,4 +1,21 @@
 package com.wanted.momocity.calendar.presentation.api.response;
 
-public record MemoResponse() {
+import com.wanted.momocity.calendar.domain.model.Calendar;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  Memo 단건 반환
+*  category 는 항상 MEMO
+*  end 는 nullable
+* */
+
+public record MemoResponse(
+        Long calendarId,
+        String title,
+        Calendar.Category category,
+        LocalDate start,
+        LocalDate end
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/TodoResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/response/TodoResponse.java
@@ -1,4 +1,20 @@
 package com.wanted.momocity.calendar.presentation.api.response;
 
-public record TodoResponse() {
+import com.wanted.momocity.calendar.domain.model.Calendar;
+
+import java.time.LocalDate;
+
+/*
+* comment.
+*  Todo 단건 반환
+*  category 는 항상 TODO
+* */
+
+public record TodoResponse(
+        Long calendarId,
+        String title,
+        Calendar.Category category,
+        LocalDate start,
+        boolean isCompleted
+) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/persistence/BaseTimeEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/persistence/BaseTimeEntity.java
@@ -16,11 +16,11 @@ import java.time.LocalDateTime;
  *
  * 클린 아키텍처 위치:
  * - 도메인 모델은 JPA를 모른다.
- * - 각 컨텍스트의 infrastructure/persistence 패키지에 있는 XxxJpaEntity가 이 클래스를 상속한다.
+ * - 각 컨텍스트의 infrastructure/persistence 패키지에 있는 XxxJpaEntity 가 이 클래스를 상속한다.
  * - 도메인 ↔ JpaEntity 변환은 RepositoryAdapter가 담당한다.
  *
  * deleted_at(soft delete) 컬럼이 필요한 엔티티는
- * 별도 BaseSoftDeleteEntity를 정의하거나 각 JpaEntity에서 직접 박는다.
+ * 별도 BaseSoftDeleteEntity를 정의하거나 각 JpaEntity 에서 직접 박는다.
  *
  * 동작 조건:
  * - 메인 애플리케이션 또는 Config 클래스에 @EnableJpaAuditing 이 적용되어 있어야 한다.

--- a/legend-momo-city/src/main/resources/application-dev.yaml
+++ b/legend-momo-city/src/main/resources/application-dev.yaml
@@ -59,7 +59,8 @@ cloud:
   aws:
     s3:
       bucket: ${AWS_S3_BUCKET:momocity-bucket} # 설정 해주셔야합니다
-      region: ${AWS_S3_REGION:ap-northeast-2} # 설정 해주셔야합니다
+    region:
+      static: ${AWS_S3_REGION:ap-northeast-2} # 설정 해주셔야합니다
     credentials:
       access-key: ${AWS_ACCESS_KEY:} # 설정 해주셔야합니다
       secret-key: ${AWS_SECRET_KEY:} # 설정 해주셔야합니다
@@ -84,13 +85,3 @@ logging:
     root: INFO
     com.wanted.momocity: DEBUG
     org.hibernate.SQL: DEBUG
-
-# ===== Async =====
-app:
-  async:
-    core-pool-size: 4
-    max-pool-size: 8
-    queue-capacity: 100
-    thread-name-prefix: async-class-
-  retry:
-    fixed-delay-ms: 5000

--- a/legend-momo-city/src/main/resources/application.yaml
+++ b/legend-momo-city/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
-spring:
+ spring:
   application:
     name: legend-momo-city
 
-  # 환경변수 SPRING_PROFILES_ACTIVE 미지정 시 dev 프로파일로 부트
+    # 환경변수 SPRING_PROFILES_ACTIVE 미지정 시 dev 프로파일로 부트
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}


### PR DESCRIPTION
📌 작업 내용
Viewing, Calendar 전체 파일구조 및 Viewing/Calendar 기본 코드 작성

✅ 구현 사항

[#41](https://github.com/MoMoFighters/BACK-Fighters/issues/24)

Viewing 도메인
* Domain Model: LearningHistory, Chapter, Lecture
* Domain Event: ChapterCompletedEvent, CourseCompletedEvent
* Domain Repository: LearningHistoryRepository
* Application Port: ChapterPort, LecturePort, EnrollmentPort, S3Port
* Application UseCase: 7개 UseCase 인터페이스 정의
* Application Service: ViewingService, ProgressService
* Infrastructure: LearningHistoryJpaEntity, LearningHistoryRepositoryAdapter, S3PresignedUrlAdapter
* Infrastructure Catalog: ChapterCatalogAdapter, LectureCatalogAdapter, EnrollmentCatalogAdapter (껍데기 - 팀원 머지 후 구현 예정)
* Presentation: ViewingController, SaveProgressRequest, Response 7개

Calendar 도메인
* Domain Model: Calendar (Todo/Memo 비즈니스 규칙)
* Domain Repository: CalendarRepository
* Application Command: 7개
* Application UseCase: 8개
* Infrastructure: CalendarJpaEntity, CalendarJpaRepository, CalendarRepositoryAdapter
* Application Service: TodoService, MemoService, GetDailyCalendarService
* Presentation: CalendarController, Request 5개, Response 3개, CalendarResponseCode

🔧 TODO (추후 작업)
* JWT 인증 완성 후 `userId = 1L` → `@AuthenticationPrincipal` 교체
* 팀원 ChapterJpaRepository 머지 후 ChapterCatalogAdapter 구현
* 팀원 LectureJpaRepository 머지 후 LectureCatalogAdapter 구현
* 팀원 EnrollmentJpaRepository 머지 후 EnrollmentCatalogAdapter 구현

📝 참고 사항
* enrollment 테이블 소유권: 팀원 담당
* 진척도 계산: enrollment 캐싱 없이 learning_history 집계로 계산
* Adapter 껍데기는 UnsupportedOperationException 반환
* Todo/Memo 같은 calendar 테이블, category ENUM 으로 구분
* Todo 만 체크 상태 변경 가능, Memo 체크 시 도메인 예외 발생