### PR TITLE
[PR] 오늘 작업 일괄 - AOP 개선 / member 충돌 해결 / MS-6 / admin 대시보드 / Swagger

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/package-info.java
@@ -1,2 +1,0 @@
-/** 관리자 페이지 - 응용 계층 (대시보드/로그 조회 유스케이스). */
-package com.wanted.momocity.admin.application;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/AdminDashboardQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/AdminDashboardQueryService.java
@@ -1,0 +1,43 @@
+package com.wanted.momocity.admin.application.service;
+
+import com.wanted.momocity.admin.application.usecase.AdminDashboardQueryUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/* comment.
+    AdminDashboardQueryService 정리
+    1. 이 클래스의 역할 : AdminDashboardQueryUseCase 의 구현체 / 다른 영역 통계를 모은다.
+    2. 위치 : admin/application/service (응용 계층 - 구현)
+    3. 왜 @Transactional 에 readOnly = true 인가 (MS-6 와 다른 부분!) : Query 라서 조회만 하게 진행함
+    4. 왜 의존성 필드가 아직 비어있는가 : 다른 영역의 공개 서비스 단계라 주입 보류
+    5. MS-6 의 MemberCommandService 와 핵심 차이 : MemberCommandService 는 자기 영역 데이터만 변경
+ */
+@Service
+@Transactional(readOnly = true)
+public class AdminDashboardQueryService implements AdminDashboardQueryUseCase {
+
+    /* comment.
+        m03 우선순위에서 추가될 의존성 :
+        - private final MemberQueryService memberQueryService;     (회원 영역 공개 서비스)
+        - private final ReportQueryService reportQueryService;     (신고 영역 공개 서비스 - 미구현)
+        - private final LectureQueryService lectureQueryService;   (강의 영역 공개 서비스 - 미구현)
+
+        현재는 다른 영역의 공개 서비스가 아직 stub 단계라 주입 보류.
+        모든 영역이 준비되면 생성자 주입으로 추가.
+     */
+    public AdminDashboardQueryService() {
+        // m03 우선순위 - 위 3개 서비스 생성자 주입 예정
+    }
+
+    /* comment.
+        실제 구현 시 흐름 (m03 우선순위) :
+        1. long memberCount = memberQueryService.countAll()
+        2. long reportCount = reportQueryService.countAll()
+        3. long lectureCount = lectureQueryService.countAll()
+        4. return new DashboardSummary(memberCount, reportCount, lectureCount)
+     */
+    @Override
+    public DashboardSummary getDashboardSummary() {
+        throw new UnsupportedOperationException("TODO: m03 우선순위 - admin 대시보드 요약 통계 구현");
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/usecase/AdminDashboardQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/usecase/AdminDashboardQueryUseCase.java
@@ -1,0 +1,26 @@
+package com.wanted.momocity.admin.application.usecase;
+
+/* comment.
+    AdminDashboardQueryUseCase 정리
+    1. 이 인터페이스의 역할 : 관리자 대시보드 요약 통계 조회 응용 계층 계약
+    2. 위치 : admin/application/usecase (응용 계층 - 계약)
+    3. 왜 Query 전용인가 (Command 없음) : 조회 전용 - 데이터 변경 없음. CQRS 의 Q 측
+    4. 왜 admin 영역에 두는가 (cross-cutting) : 여러 영역의 통계를 모음 = 한 영역에 속하지 않음.
+    5. 왜 Result 를 중첩 record 로 두는가 : 출력 계약도 같은 위치
+ */
+public interface AdminDashboardQueryUseCase {
+
+    DashboardSummary getDashboardSummary();
+
+    /* comment.
+        DashboardSummary 정리
+        1. 이 record 의 역할 : 대시보드 요약 데이터 묶음 (회원/신고/강의 총 개수)
+        2. 필드 3개 의미 : memberCount(회원 총 수), reportCount(신고 총 수), lectureCount(강의 총 수)
+        3. 왜 long 타입인가 : 카운트는 음수가 될 수 없기 때문에 수십억 가능성 대비 int 대신 long
+     */
+    record DashboardSummary(
+            long memberCount,
+            long reportCount,
+            long lectureCount
+    ) { }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/AdminDashboardController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/AdminDashboardController.java
@@ -1,0 +1,55 @@
+package com.wanted.momocity.admin.presentation.api;
+
+import com.wanted.momocity.admin.application.usecase.AdminDashboardQueryUseCase;
+import com.wanted.momocity.admin.presentation.api.response.DashboardSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/* comment.
+    AdminDashboardController 정리
+    1. 이 클래스의 역할 : 관리자 대시보드 통계 HTTP API 진입점. FE 대시보드 페이지 열 때 호출
+    2. 다루는 API :
+        - GET /api/v1/admin/dashboard/summary
+    3. 클래스 레벨 어노테이션 :
+        - @RestController              : REST API 컨트롤러, 반환값 자동 JSON 변환
+        - @RequestMapping("/api/v1/admin") : 클래스 안 모든 핸들러 URL 앞에 공통 prefix
+        - @PreAuthorize("hasRole('ADMIN')") : 모든 핸들러 호출 전 권한 검사. ADMIN 아니면 403
+        - @Tag                         : Swagger UI 에서 "Admin - 대시보드" 그룹으로 표시
+    4. 의존성 :
+        - AdminDashboardQueryUseCase : UseCase 인터페이스 의존
+    5. MS-6 컨트롤러와 핵심 차이 :
+        - HTTP 메서드 : GET 방식과 PATCH 방식
+ */
+@RestController
+@RequestMapping("/api/v1/admin")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin - 대시보드", description = "관리자 대시보드 통계 (회원/신고/강의 수)")
+public class AdminDashboardController {
+
+    private final AdminDashboardQueryUseCase dashboardQueryUseCase;
+
+    public AdminDashboardController(AdminDashboardQueryUseCase dashboardQueryUseCase) {
+        this.dashboardQueryUseCase = dashboardQueryUseCase;
+    }
+
+    /* comment.
+        실제 구현 시 흐름 (m03 우선순위) :
+        1. DashboardSummary summary = dashboardQueryUseCase.getDashboardSummary()
+        2. DashboardSummaryResponse response = new DashboardSummaryResponse(
+               summary.memberCount(), summary.reportCount(), summary.lectureCount())
+        3. return ResponseEntity.ok(response)
+     */
+    @GetMapping("/dashboard/summary")
+    @Operation(
+            summary = "관리자 대시보드 요약 통계",
+            description = "회원 / 신고 / 강의 총 개수를 한 번에 조회한다. FE 대시보드 페이지 진입 시 호출."
+    )
+    public ResponseEntity<DashboardSummaryResponse> getDashboardSummary() {
+        throw new UnsupportedOperationException("TODO: m03 우선순위 - admin 대시보드 요약 통계 컨트롤러 구현");
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/response/DashboardSummaryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/response/DashboardSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.momocity.admin.presentation.api.response;
+
+/* comment.
+    DashboardSummaryResponse 정리
+    1. 이 record 의 역할 : 대시보드 통계 결과를 클라이언트에 돌려주는 HTTP 응답 바디
+    2. 위치 : admin/presentation/api/response (표현 계층 - 출력 DTO)
+    3. 왜 응용 Result(DashboardSummary) 와 분리하는가 : 응용 출력과 HTTP 응답 격리
+    4. 왜 필드가 응용 Result 와 동일한가 : 응용 출력 그대로 클라이언트에 전달
+    5. 왜 import 가 하나도 없는가 : long 은 자바 기본형. 외부 클래스 의존성 0
+ */
+public record DashboardSummaryResponse(
+        long memberCount,
+        long reportCount,
+        long lectureCount
+) { }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/package-info.java
@@ -1,2 +1,0 @@
-/** 관리자 페이지 - 표현 계층 (HTTP 컨트롤러, 요청/응답 DTO). */
-package com.wanted.momocity.admin.presentation;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/aop/GlobalFlowLoggingAspect.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/aop/GlobalFlowLoggingAspect.java
@@ -56,17 +56,19 @@ public class GlobalFlowLoggingAspect {
         String traceId = MDC.get(TRACE_ID_KEY);
         long startedAt = System.currentTimeMillis();
 
-        log.info("[momocity-흐름][{}] 진입 | 컨텍스트={} | 계층={} | 메서드={}",
+        // 팀원과 협의 완료 (log.info -> log.debug)
+        log.debug("[momocity-흐름][{}] 진입 | 컨텍스트={} | 계층={} | 메서드={}",
                 traceId, context, layer, method);
 
         try {
             Object result = joinPoint.proceed();
             long elapsedMs = System.currentTimeMillis() - startedAt;
-            log.info("[momocity-흐름][{}] 종료 | 컨텍스트={} | 계층={} | 메서드={} | 소요시간={}ms",
+            log.debug("[momocity-흐름][{}] 종료 | 컨텍스트={} | 계층={} | 메서드={} | 소요시간={}ms",
                     traceId, context, layer, method, elapsedMs);
             return result;
         } catch (Throwable throwable) {
             long elapsedMs = System.currentTimeMillis() - startedAt;
+            // 예외는 항상 있어야하기 때문에 유지
             log.warn(
                     "[momocity-흐름][{}] 예외 발생 | 컨텍스트={} | 계층={} | 메서드={} | 소요시간={}ms | 예외메시지={}",
                     traceId, context, layer, method, elapsedMs,
@@ -78,6 +80,43 @@ public class GlobalFlowLoggingAspect {
                 MDC.remove(TRACE_ID_KEY);
             }
         }
+    }
+
+        /* comment.
+            서비스 계층의 입출력 추적 어드바이스
+            그룹화 및 TRACE_ID_KEY 상수를 공유하기 때문에 동일한 클래스에서 진행 / 추후 어드바이스가 늘어난다면 분리 예정
+            흐름 추적 어드바이스는 DEBUG 로 강등되었기 때문에 발표할 때는 주석 또는 나오지 않게 처리
+         */
+
+    @Around("execution(* com.wanted.momocity..application.service..*(..))")
+    public Object logServiceIo(ProceedingJoinPoint joinPoint) throws Throwable {
+        String traceId = MDC.get(TRACE_ID_KEY);
+        String method = joinPoint.getSignature().toShortString();
+        Object[] args = joinPoint.getArgs();
+
+        log.info("[momocity-서비스][{}] 입력 | 메서드={} | 인자={}",
+                traceId, method, formatArgs(args));
+
+        Object result = joinPoint.proceed();
+
+        log.info("[momocity-서비스][{}] 출력 | 메서드={} | 반환={}",
+                traceId, method, formatResult(result));
+
+        return result;
+    }
+
+    private String formatArgs(Object[] args) {
+        if (args == null || args.length == 0) {
+            return "(없음)";
+        }
+        return java.util.Arrays.toString(args);
+    }
+
+    private String formatResult(Object result) {
+        if (result == null) {
+            return "(반환값 없음)";
+        }
+        return result.toString();
     }
 
     private boolean ensureTraceId() {
@@ -143,4 +182,5 @@ public class GlobalFlowLoggingAspect {
         }
         return message;
     }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/application/command/ChangeMemberStatusCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/application/command/ChangeMemberStatusCommand.java
@@ -1,0 +1,25 @@
+package com.wanted.momocity.member.application.command;
+
+import com.wanted.momocity.member.domain.model.MemberStatus;
+
+/* comment.
+    ChangeMemberStatusCommand 정리
+    1. 이 record 의 역할 : 관리자가 회원 상태 변경 요청 시 응용 계층에 전달되는 입력
+    2. 위치 : member/application/command (응용 계층 - 입력)
+    3. 왜 record 인가 : 불변성을 유지하기 때문에 record 사용
+    4. 왜 Request DTO 와 분리하는가 : HTTP 관심사와 비즈니스 입력 분리해 계층을 분리하기 위함
+    5. 검증의 의미 : 잘못된 입력이 useCase 진입 못하게 1차적으로 방어한다.
+ */
+public record ChangeMemberStatusCommand(
+        Long userId,
+        MemberStatus newStatus
+) {
+    public ChangeMemberStatusCommand {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("userId 는 1 이상이어야 합니다.");
+        }
+        if (newStatus == null) {
+            throw new IllegalArgumentException("newStatus 는 필수입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/application/service/MemberCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/application/service/MemberCommandService.java
@@ -1,0 +1,40 @@
+package com.wanted.momocity.member.application.service;
+
+import com.wanted.momocity.member.application.command.ChangeMemberStatusCommand;
+import com.wanted.momocity.member.application.usecase.MemberCommandUseCase;
+import com.wanted.momocity.member.domain.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/* comment.
+    MemberCommandService 정리
+    1. 이 클래스의 역할 : MemberCommandUseCase 인터페이스의 실제 구현체. 회원 상태 변경 비즈니스 흐름 조정
+    2. 위치 : member/application/service (응용 계층 - 구현)
+    3. 왜 MemberQueryService 와 분리하는가 (CQRS) : 조회와 변경 책임 분리 목적
+    4. 왜 @Transactional 에 readOnly = true 안 붙이나 : command 라 쓰는 작업이다. 따라서 readOnly X
+    5. 왜 implements MemberCommandUseCase 인가 : 컨트롤러가 구현체 대신 인터페이스에 의존하게 된다.
+    6. 왜 생성자 주입인가 (필드 주입 아님) : final 가능하며, 테스트 mock을 사용할 수 있기 때문이다.
+ */
+@Service
+@Transactional
+public class MemberCommandService implements MemberCommandUseCase {
+
+    private final MemberRepository memberRepository;
+
+    public MemberCommandService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    /* comment.
+        구현은 m03 우선순위 3 에서 채울 예정. 현재는 시그니처만 잡아둠.
+        실제 흐름 (구현 시) :
+        1. memberRepository.findById(command.userId()) 로 회원 조회
+        2. member.changeStatusByAdmin(command.newStatus()) 로 도메인 행위 호출
+        3. memberRepository.save(member) 로 저장
+        4. MemberStatusChangeResult 만들어 반환
+     */
+    @Override
+    public MemberStatusChangeResult changeStatus(ChangeMemberStatusCommand command) {
+        throw new UnsupportedOperationException("TODO: m03 우선순위 3 - 회원 상태 변경 구현");
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/application/service/MemberQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/application/service/MemberQueryService.java
@@ -18,7 +18,7 @@ import java.util.Optional;
         → MemberQueryService          ← *이 클래스*
         → MemberRepository (도메인 인터페이스)
         → MemberRepositoryAdapter (실제 구현)
-        → SpringDataUserRepository
+        → SpringDataMemberRepository
         → 데이터베이스
     4. 왜 공개 서비스가 필요할까?
         - 강사 영역이 MemberRepository 를 직접 호출하면, 회원 영역의 세부 약속까지 전부 알게 된다.

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/application/usecase/MemberCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/application/usecase/MemberCommandUseCase.java
@@ -1,0 +1,32 @@
+package com.wanted.momocity.member.application.usecase;
+
+import com.wanted.momocity.member.application.command.ChangeMemberStatusCommand;
+
+import java.time.LocalDateTime;
+
+/* comment.
+    MemberCommandUseCase 정리
+    1. 이 인터페이스의 역할 : 회원 상태 변경의 응용 계층 계약 정의
+    2. 위치 : member/application/usecase (응용 계층 - 계약)
+    3. 왜 interface 인가 : 구현 교체 또는 테스트를 진행할 때 mock 을 사용하기 위함
+    4. 왜 Result 를 인터페이스 안에 중첩 record 로 두는가 : 응집도를 위해
+ */
+public interface MemberCommandUseCase {
+
+    MemberStatusChangeResult changeStatus(ChangeMemberStatusCommand command);
+
+    /* comment.
+        MemberStatusChangeResult 정리
+        1. 이 record 의 역할 : 상태 변경 작업 결과 데이터에 묶는 용도
+        2. 왜 use case 와 같은 파일에 두는가 : useCase 출력 계약도 useCase 인터페이스 안에 있다. 응집도를 위해서
+        3. 어떤 필드가 들어가는가 :
+            - userId : 변경된 회원 Id
+            - status : 변경 후 상태
+            - changedAt : 변경 시각
+     */
+    record MemberStatusChangeResult(
+            Long userId,
+            String status,
+            LocalDateTime changedAt
+    ) { }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/domain/model/MemberCategory.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/domain/model/MemberCategory.java
@@ -8,7 +8,7 @@ package com.wanted.momocity.member.domain.model;
     HEALTH(헬스/운동) / STUDY(공부/자기개발) / COOK(요리)
     BEAUTY(뷰티) / ART(예술/창작)
     4. 강제성 : 회원의 관심사 분류이기 때문에 NULL 허용 가능 ( ERD 기준 - nullable ).MemberRole/MemberStatus 처럼 필수 X
-    5. 사용 위치 : Member.category, UserJpaEntity.category 변환, 강사 신청자 목록/상세 응답 category 필드
+    5. 사용 위치 : Member.category, MemberJpaEntity.category 변환, 강사 신청자 목록/상세 응답 category 필드
     6. 영역 경계 처리 : 강사 영역의 TeacherApplication 은 이 ENUM 을 직접 챙기지 않고 STRING 타입으로 받는다.
  */
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/domain/model/MemberRole.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/domain/model/MemberRole.java
@@ -17,7 +17,7 @@ package com.wanted.momocity.member.domain.model;
     2. 왜 ENUM 을 사용했는가? : 문자열 대신 타입 안정성을 위해서
     3. 데이터베이스의 어떤 컬럼과 맵핑되는가? : user.role
     4. 3개 값의 의미 : student(학생)/teacher(강사)/admin(관리자)
-    5. 사용 위치 : Member.role, UserJpaEntity.role 변환, 강사 영역의 MemberUserAdapter 에서 필터링
+    5. 사용 위치 : Member.role, MemberJpaEntity.role 변환, 강사 영역의 MemberUserAdapter 에서 필터링
  */
 
 public enum MemberRole {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/domain/model/MemberStatus.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/domain/model/MemberStatus.java
@@ -18,7 +18,7 @@ package com.wanted.momocity.member.domain.model;
      6. module03 미구현 항목 : BANNED/BLACK 값은 enum 에 있지만 자동 정지 로직은 module04 에서
      진행 예정. ERD 에 suspended_until, violation_count 같은 컬럼 존재 X
      module03 에서는 해당 enum 자리만 보존예정
-     7. 사용 위치 : Member.status, UserJpaEntity.status 변환, 강사 영역의 신청자 필터
+     7. 사용 위치 : Member.status, MemberJpaEntity.status 변환, 강사 영역의 신청자 필터
      status='PENDING' 회원 상태 변경 API
  */
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/infrastructure/persistence/MemberJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/infrastructure/persistence/MemberJpaEntity.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /* comment.
-    UserJpaEntity 정리
+    MemberJpaEntity 정리
     1. 해당 클래스의 역할 : user 테이블과 1:1 매핑되는 JPA 저장 모델
     2. 회원 영역이 단독적으로 소유 : 강사/신고/관리자영역은 이 클래스에 직접적으로 매핑 절대 금지!!
     3. Member 도메인 모델과의 관계
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 
 @Entity // JPA 가 이 클래스를 영속성 객체로 인식하게 함
 @Table(name = "user") // " " 테이블과 매핑 명시
-public class UserJpaEntity extends BaseTimeEntity {
+public class MemberJpaEntity extends BaseTimeEntity {
 
     // ENUM 매핑이 String 인 이유 : role/status/category 가 도메인에서 ENUM 인데 여기서는
     // STRING -> Adapter 가 enum.name() <-> String  변환
@@ -78,7 +78,7 @@ public class UserJpaEntity extends BaseTimeEntity {
     @Column(name = "is_tempPWD")
     private Boolean isTempPWD;
 
-    protected UserJpaEntity() {
+    protected MemberJpaEntity() {
     }
 
     // JPA 저장 모델 메소드 (도메인 행위 아님). 도메인 검증은 Member.approveAsTeacher() 등이 담당.

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/infrastructure/persistence/MemberRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/infrastructure/persistence/MemberRepositoryAdapter.java
@@ -23,11 +23,11 @@ import java.util.Optional;
     1. 해당 클래스가 하는 역할 : 도메인 MemberRepository 인터페이스를 JPA 로 구현하는 어댑터이다.
     2. 위치 : member/infrastructure/persistence (인프라 계층)
     3. 핵심 책임 :
-        - 도메인 Member 모델과 JPA UserJpaEntity 간 변환한다.
-        - SpringDataUserRepository 의 실제 DB 호출을 감싸서 도메인이 안 보이게 격리한다.
+        - 도메인 Member 모델과 JPA MemberJpaEntity 간 변환한다.
+        - SpringDataMemberRepository 의 실제 DB 호출을 감싸서 도메인이 안 보이게 격리한다.
     5. 의존 방향 (클린 아키텍처의 정점) :
         - implements MemberRepository (도메인 인터페이스) ← 인프라가 도메인 약속을 *지킴*
-        - SpringDataUserRepository 주입 (인프라 → 인프라) ← 같은 계층 호출
+        - SpringDataMemberRepository 주입 (인프라 → 인프라) ← 같은 계층 호출
         - Member 사용 (인프라 → 도메인) ← 인프라는 도메인을 알아도 OK
         - 도메인은 *이 클래스의 존재를 모름* (인터페이스만 봄)
  */
@@ -41,9 +41,9 @@ public class MemberRepositoryAdapter implements MemberRepository {
 
     // final : 한 번 주입되면 불변한 상태로 의존성 주입
     // autowired 필드 주입 -> 생성자가 없어도 되지만, final을 사용할 수 없음. 테스트가 어려움.
-    private final SpringDataUserRepository repository;
+    private final SpringDataMemberRepository repository;
 
-    public MemberRepositoryAdapter(SpringDataUserRepository repository) {
+    public MemberRepositoryAdapter(SpringDataMemberRepository repository) {
         this.repository = repository;
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/infrastructure/persistence/SpringDataMemberRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/infrastructure/persistence/SpringDataMemberRepository.java
@@ -5,24 +5,24 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /* comment.
-    SpringDataUserRepository 정리
+    SpringDataMemberRepository 정리
     1. Spring Data JPA 가 런타임에 자동으로 구현 클래스를 만들어주는 저장소 인터페이스
     2. 위치 : member/infrastructure/persistence (인프라 계층)
     3. 누가 호출하는가? : MemberRepositoryAdapter 가 주입받아서 호출한다. (하지만 직접 외부 노출하지 않는다)
     4. 핵심 기능 : 메소드 이름만 규칙대로 적으면 Spring Data 가 SQL 을 자동 생성
     5. 도메인 MemberRepository 와의 차이점
         - MemberRepository : 우리 비즈니스 약속, 도메인 모델 Member 를 다룸
-        - SpringDataUserRepository : Spring 기술 인터페이스, JPA Entity UserJpaEntity 를 다룸
+        - SpringDataMemberRepository : Spring 기술 인터페이스, JPA Entity MemberJpaEntity 를 다룸
         - 둘을 잇는 다리가 위에서 말한 MemberRepositoryAdapter 이다.
  */
 
 // import 가 Spring 인 이유 : 이 파일은 인프라 계층인데, Spring 의존 OK이다. 도메인 계층의 MemberRepository 와 다른 작업을 한다.
-public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, Long> {
+public interface SpringDataMemberRepository extends JpaRepository<MemberJpaEntity, Long> {
 
-    // Member 가 아닌 UserJpaEntity 를 반환하는 이유
+    // Member 가 아닌 MemberJpaEntity 를 반환하는 이유
     // 이 인터페이스는 인프라 계층이기 때문에 도메인 모델을 모른다.
-    // Adapter 가 받아서 UserJpaEntity -> Member 변환하는 책임을 가지고있다.
-    Page<UserJpaEntity> findByRoleAndStatusAndDeletedAtIsNull(String role, String status, Pageable pageable);
+    // Adapter 가 받아서 MemberJpaEntity -> Member 변환하는 책임을 가지고있다.
+    Page<MemberJpaEntity> findByRoleAndStatusAndDeletedAtIsNull(String role, String status, Pageable pageable);
 
     long countByRoleAndStatusAndDeletedAtIsNull(String role, String status);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/MemberAdminController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/MemberAdminController.java
@@ -1,0 +1,75 @@
+package com.wanted.momocity.member.presentation.api;
+
+import com.wanted.momocity.member.application.usecase.MemberCommandUseCase;
+import com.wanted.momocity.member.presentation.api.request.ChangeMemberStatusRequest;
+import com.wanted.momocity.member.presentation.api.response.ChangeMemberStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/* comment.
+    MemberAdminController 정리
+    1. 이 클래스의 역할 : 관리자 영역의 회원 상태 변경 HTTP API 진입점
+    2. 다루는 API :
+        - PATCH /api/v1/admin/users/{userId}/status
+    3. 클래스 레벨 어노테이션 :
+        - @RestController : 클래스가 REST API 컨트롤러임을 표시
+        - @RequestMapping("/api/v1/admin") : 클래스 안 모든 핸들러 URL 앞에
+        - @PreAuthorize("hasRole('ADMIN')") : 모든 핸들러 호출 전 권한 검사
+        - @Tag : Swagger UI 에서 Member - 회원 상태 관리로 표시
+    4. 의존성 :
+        - MemberCommandUseCase : UseCase 인터페이스 의존
+        - 왜 구현체(Service) 가 아니라 인터페이스 의존? : 구현체 교체 가능하게 하기 위해서
+    5. Controller 의 책임 5단계 :
+        a) HTTP 요청 받기
+        b) Request DTO -> Command 변환
+        c) UseCase 호출
+        d) Result -> Response 변환
+        e) ResponseEntity 로 응답 반환
+    6. Controller 가 *하지 않는 일* :
+        - 비즈니스 로직 (UseCase/Service)
+        - DB 직접 접근 (Repository/Adapter)
+        - 도메인 검증 (Member 도메인 모델)
+ */
+@RestController
+@RequestMapping("/api/v1/admin")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Member - 회원 상태 관리", description = "관리자가 회원 상태 변경 (MS-6)")
+public class MemberAdminController {
+
+    private final MemberCommandUseCase memberCommandUseCase;
+
+    public MemberAdminController(MemberCommandUseCase memberCommandUseCase) {
+        this.memberCommandUseCase = memberCommandUseCase;
+    }
+
+    /* comment.
+        실제 구현 시 흐름 (m03 우선순위 3) :
+        1. MemberStatus newStatus = MemberStatus.valueOf(request.status())   // String -> enum
+        2. ChangeMemberStatusCommand command = new ChangeMemberStatusCommand(userId, newStatus)
+        3. MemberStatusChangeResult result = memberCommandUseCase.changeStatus(command)
+        4. ChangeMemberStatusResponse response = new ChangeMemberStatusResponse(
+               result.userId(), result.status(), result.changedAt())
+        5. return ResponseEntity.ok(response)
+     */
+    @PatchMapping("/users/{userId}/status")
+    @Operation(
+            summary = "회원 상태 변경 (MS-6)",
+            description = "관리자가 회원 상태를 ACTIVE / BANNED / BLACK / DELETED 등으로 변경한다."
+    )
+    public ResponseEntity<ChangeMemberStatusResponse> changeStatus(
+            @Parameter(description = "회원 user PK", example = "7")
+            @PathVariable Long userId,
+            @Valid @RequestBody ChangeMemberStatusRequest request
+    ) {
+        throw new UnsupportedOperationException("TODO: m03 우선순위 3 - MS-6 회원 상태 변경 컨트롤러 구현");
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/MemberAdminController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/MemberAdminController.java
@@ -6,6 +6,8 @@ import com.wanted.momocity.member.presentation.api.response.ChangeMemberStatusRe
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 
 /* comment.
     MemberAdminController 정리
@@ -65,6 +68,13 @@ public class MemberAdminController {
             summary = "회원 상태 변경 (MS-6)",
             description = "관리자가 회원 상태를 ACTIVE / BANNED / BLACK / DELETED 등으로 변경한다."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 상태 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 status 값 또는 userId 형식 오류 (validation 실패)"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 또는 만료"),
+            @ApiResponse(responseCode = "403", description = "ADMIN 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원")
+    })
     public ResponseEntity<ChangeMemberStatusResponse> changeStatus(
             @Parameter(description = "회원 user PK", example = "7")
             @PathVariable Long userId,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/request/ChangeMemberStatusRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/request/ChangeMemberStatusRequest.java
@@ -1,0 +1,22 @@
+package com.wanted.momocity.member.presentation.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+/* comment.
+    ChangeMemberStatusRequest 정리
+    1. 이 record 의 역할 : HTTP PATCH 요청 body 를 받는 입력 DTO.JSON -> 자바 객체 변환한다.
+    2. 위치 : member/presentation/api/request (표현 계층 - 입력 DTO)
+    3. 왜 Command 와 분리하는가 : HTTP 관심사와 비즈니스 관심사 격리해서 계층 책임을 분리한다.
+    4. 왜 String 으로 받고 MemberStatus enum 으로 직접 안 받는가 : 검증 후 안전하게 enum 변환, 잘못된 값이 컨틀롤러 진입 차단.
+    5. 왜 검증 어노테이션을 여기서 거는가 (@NotBlank, @Pattern) : @Valid 와 함께 작동. 1차 방어선 역할을 한다.
+ */
+public record ChangeMemberStatusRequest(
+
+        @NotBlank(message = "status 는 필수입니다.")
+        @Pattern(
+                regexp = "ACTIVE|PENDING|REJECTED|BANNED|BLACK|DELETED",
+                message = "status 는 ACTIVE / PENDING / REJECTED / BANNED / BLACK / DELETED 중 하나여야 합니다."
+        )
+        String status
+) { }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/response/ChangeMemberStatusResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/api/response/ChangeMemberStatusResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.momocity.member.presentation.api.response;
+
+import java.time.LocalDateTime;
+
+/* comment.
+    ChangeMemberStatusResponse 정리
+    1. 이 record 의 역할 : 상태 변경 결과를 클라이언트로 돌려주는 HTTP 응답 body
+    2. 위치 : member/presentation/api/response (표현 계층 - 출력 DTO)
+    3. 왜 Result(MemberStatusChangeResult) 와 분리하는가 : 응용 Result와 HTTP Response 격리 목적
+    4. 왜 필드가 응용 Result 와 동일한가 : 응용 출력을 그대로 클라이언트에 전달해준다.
+    5. Swagger 어노테이션(@Schema) 이 지금 왜 없는가 : 현재는 골격만 진행
+ */
+public record ChangeMemberStatusResponse(
+        Long userId,
+        String status,
+        LocalDateTime changedAt
+) { }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/member/presentation/package-info.java
@@ -1,2 +1,0 @@
-/** 회원 - 표현 계층 (HTTP 컨트롤러, 요청/응답 DTO). */
-package com.wanted.momocity.member.presentation;


### PR DESCRIPTION
## 관련 이슈


오늘 오전부터 진행된 5개 작업을 한 번에 PR. 메인 항목은 **이슈 해결(auth↔member 충돌)** 이고, 나머지는 같은 브랜치에서 작업된 부가 항목.

---

## 🔴 메인 — 1. auth ↔ member 중복 클래스 리네임 (이슈 해결, `67461fb`)

`BeanDefinitionOverrideException` + `DuplicateMappingException` 로 앱 부팅 자체가 막혀있던 상태 해결.

### 리네임 (git mv 로 깃 히스토리 보존)
| Before | After |
|---|---|
| `member.SpringDataUserRepository` | `SpringDataMemberRepository` |
| `member.UserJpaEntity` | `MemberJpaEntity` |

### 참조 업데이트 (member 영역 내부)
`MemberRepositoryAdapter`, `SpringDataMemberRepository`, `MemberRole`, `MemberStatus`, `MemberCategory`, `MemberQueryService`

### 미변경
- auth 영역의 동일 이름 클래스는 손대지 않음 (의미 자연스러움 + 다른 팀 영역)

---

## 🟡 부가 — 2. AOP 로그 개선 (`67461fb` 에 동봉)

`GlobalFlowLoggingAspect.java` 손봄:

- 전 계층 진입/종료 로그를 **`log.info` → `log.debug`** 로 강등 (운영 환경 로그 폭발 방지)
- 서비스 계층 입출력 추적 어드바이스 **신규 추가** → `log.info` 로 비즈니스 흐름 명시
- 결과: dev 환경에선 디테일까지 / 운영 환경에선 서비스 입출력만 (`application-dev.yaml` 의 `logging.level.com.wanted.momocity: DEBUG` 로 분리)

---

## 🟢 부가 — 3. 회원 영역 MS-6 컨트롤러 풀세트 (`fa42eb2`)

회원 상태 변경 API 신규 추가 — `PATCH /api/v1/admin/users/{userId}/status`

### 신규 파일 6개 (4계층 stub)
| 계층 | 파일 |
|---|---|
| 응용 - 입력 | `ChangeMemberStatusCommand` |
| 응용 - 계약 | `MemberCommandUseCase` + 중첩 `MemberStatusChangeResult` |
| 응용 - 구현 | `MemberCommandService` |
| 표현 - 입력 | `ChangeMemberStatusRequest` (`@Valid` 검증 포함) |
| 표현 - 출력 | `ChangeMemberStatusResponse` |
| 표현 - 진입 | `MemberAdminController` |

실제 비즈니스 로직은 `UnsupportedOperationException("TODO: m03 우선순위 3")` 마커로 시그니처만 잡아둠. 어제 강사 영역 MS-3/4/5 패턴과 100% 일관.

---

## 🟢 부가 — 4. admin 대시보드 요약 API (`28d228b`)

FE 가 이미 UI 보유. 백엔드 API 골격 신규 추가 — `GET /api/v1/admin/dashboard/summary`

### 신규 파일 4개
| 파일 | 역할 |
|---|---|
| `AdminDashboardQueryUseCase` + 중첩 `DashboardSummary` | 응용 계약 |
| `AdminDashboardQueryService` | 구현 stub |
| `DashboardSummaryResponse` | 출력 DTO |
| `AdminDashboardController` | 진입점 |

응답: `{ memberCount, reportCount, lectureCount }` — FE 가 받자마자 표시 가능.

특징: **cross-cutting** 영역 (member/report/lecture 모두 호출 예정), **Query 전용** (Command 없음), `@Transactional(readOnly = true)`

---

## 🟢 부가 — 5. Swagger 문서화 시작

`MemberAdminController.changeStatus` 에 `@ApiResponse` 5개 추가 (200/400/401/403/404). 향후 다른 컨트롤러 + DTO `@Schema` 까지 확장 예정.

---

## 영향 범위

- ✅ **DB 영향 없음** — `@Table(name = "user")` 매핑 그대로
- ✅ **API 스펙 변경 없음** — 내부 리네임 + 신규 stub API
- ✅ **외부 영역 영향 없음** — `member.SpringDataUserRepository`, `member.UserJpaEntity` 를 외부에서 import 하는 코드 사전 검색 0건
- ✅ **auth 영역 미수정** — 다른 팀 코드 보존
- ⚠️ **신규 API 2개 추가** — `/api/v1/admin/users/{userId}/status`, `/api/v1/admin/dashboard/summary` (둘 다 ADMIN 권한)

## 검증

- [x] `./gradlew compileJava` 통과
- [x] `./gradlew bootRun` 으로 `BeanDefinitionOverrideException`, `DuplicateMappingException` 해소 확인 (DB 연결 단계까지 도달)
- [x] AOP DEBUG 로그가 dev 환경에서 정상 적용되는지 확인

## Test Plan

- [ ] CI 컴파일 통과 확인
- [ ] dev 환경에서 앱 정상 부팅 확인
- [ ] Swagger UI `/swagger-ui.html` 에서 신규 API 노출 확인
- [ ] member / admin API 라우팅 smoke test