### PR TITLE
[PR] 수강 내역 기반 강의 목록 조회 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/adapter/LectureEnrollmentQueryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/adapter/LectureEnrollmentQueryAdapter.java
@@ -1,0 +1,58 @@
+package com.wanted.momocity.enrollment.infrastructure.adapter;
+
+import com.wanted.momocity.enrollment.infrastructure.persistence.EnrollmentJpaEntity;
+import com.wanted.momocity.enrollment.infrastructure.persistence.EnrollmentJpaRepository;
+import com.wanted.momocity.lecture.application.port.LectureEnrollmentQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * LectureEnrollmentQueryAdapter는 lecture 목록 조회에서 필요한
+ * enrollment 정보를 제공하는 Adapter
+ * lecture 패키지는 enrollment 테이블을 직접 알지 않고,
+ * LectureEnrollmentQueryPort를 통해 필요한 정보만 요청
+ */
+@Component
+@RequiredArgsConstructor
+public class LectureEnrollmentQueryAdapter implements LectureEnrollmentQueryPort {
+
+    // enrollment 테이블 조회를 담당하는 JPA Repository
+    private final EnrollmentJpaRepository enrollmentJpaRepository;
+
+    /**
+     * 사용자가 수강 신청한 강의 ID 목록을 조회
+     */
+    @Override
+    public List<Long> findLectureIdsByUserId(Long userId) {
+        return enrollmentJpaRepository.findAllByUserId(userId)
+                .stream()
+                .map(EnrollmentJpaEntity::getLectureId)
+                .toList();
+    }
+
+    /*
+     * 특정 사용자의 특정 강의 수강 신청 정보를 조회
+     * 강의 목록 응답에서 totalProgress, completedCount를 채울 때 사용
+     */
+    @Override
+    public Optional<EnrollmentProgress> findByUserIdAndLectureId(
+            Long userId,
+            Long lectureId
+    ) {
+        return enrollmentJpaRepository.findByUserIdAndLectureId(userId, lectureId)
+                .map(this::toProgress);
+    }
+
+    // EnrollmentJpaEntity를 lecture 쪽에서 필요한 진행 정보로 변환
+    private EnrollmentProgress toProgress(EnrollmentJpaEntity entity) {
+        return new EnrollmentProgress(
+                entity.getId(),
+                entity.getLectureId(),
+                entity.getTotalProgress(),
+                entity.getCompletedCount()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/LectureEnrollmentQueryPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/LectureEnrollmentQueryPort.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.lecture.application.port;
+
+import java.util.List;
+import java.util.Optional;
+
+/*
+ * LectureEnrollmentQueryPort는 lecture 조회에서 필요한 enrollment 정보를 가져오기 위한 포트
+ * lecture 패키지가 enrollment 구현체를 직접 알지 않도록
+ * 인터페이스로 분리합니다.
+ */
+public interface LectureEnrollmentQueryPort {
+
+    // 사용자가 수강 신청한 강의 ID 목록을 조회\
+    List<Long> findLectureIdsByUserId(Long userId);
+
+    // 특정 사용자의 특정 강의 수강 신청 정보를 조회
+    Optional<EnrollmentProgress> findByUserIdAndLectureId(Long userId, Long lectureId);
+
+    // 강의 목록 응답에 필요한 수강 진행 정보
+    record EnrollmentProgress(
+            Long enrollmentId,
+            Long lectureId,
+            int totalProgress,
+            int completedCount
+    ) {
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetLecturesQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetLecturesQuery.java
@@ -1,0 +1,46 @@
+package com.wanted.momocity.lecture.application.query;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.domain.model.LectureCategory;
+
+// GetLecturesQuery는 강의 목록 조회 조건을 담는 객체
+// Controller가 받은 조회 조건을 Service로 넘기는 상자
+public record GetLecturesQuery(
+
+        // Authorization 토큰에서 꺼낸 로그인 사용자 email
+        String userEmail,
+
+        // 강의 카테고리 필터
+        // 값이 없으면 전체 카테고리를 조회
+        LectureCategory category,
+
+        // 수강 신청 여부 필터
+        // true면 내가 신청한 강의만,
+        // false면 내가 신청하지 않은 강의만,
+        // null이면 수강 신청 여부와 상관없이 조회
+        Boolean enrolled,
+
+        // 조회할 페이지 번호
+        // page는 1부터 시작
+        int page,
+
+        // 한 페이지에 조회할 강의 개수
+        int size
+
+) {
+
+    /**
+     * compact constructor -> 생성자를 풀지 않음 즉, 필드를 다시 적지 않고 짧게 쓸 수 있음
+     *
+     * record가 생성될 때 page, size 값이 정상인지 검사합니다.
+     */
+    public GetLecturesQuery {
+        if (page < 1) {
+            throw new DomainRuleViolationException("페이지 번호는 0 이상이어야 합니다.");
+        }
+
+        if (size < 1) {
+            throw new DomainRuleViolationException("페이지 크기는 1 이상이어야 합니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -1,0 +1,115 @@
+package com.wanted.momocity.lecture.application.service;
+
+import com.wanted.momocity.enrollment.application.port.StudentAccountPort;
+import com.wanted.momocity.lecture.application.port.LectureEnrollmentQueryPort;
+import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
+import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import com.wanted.momocity.lecture.presentation.api.response.LectureListItemResponse;
+import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/*
+ * LectureQueryService는 강의 목록 조회 로직을 처리하는 서비스
+ * enrolled=true / false 조건에 따라
+ * 로그인 사용자의 수강 신청 여부를 기준으로 강의를 필터링함.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LectureQueryService implements LectureQueryUseCase {
+
+    // 강의 데이터를 조회하는 저장소
+    private final LectureRepository lectureRepository;
+
+    // 로그인 사용자 email로 userId를 찾기 위한 포트
+    private final StudentAccountPort studentAccountPort;
+
+    // 사용자의 수강 신청 정보를 조회하기 위한 포트
+    private final LectureEnrollmentQueryPort lectureEnrollmentQueryPort;
+
+    // 강의 목록을 조회
+    @Override
+    public LecturePageResponse getLectures(GetLecturesQuery query) {
+
+        // Authorization 토큰에서 꺼낸 email로 userId를 조회
+        Long userId = studentAccountPort.getStudentId(query.userEmail());
+
+        // userId 기준으로 수강 신청한 강의 ID 목록을 조회
+        List<Long> enrolledLectureIds = lectureEnrollmentQueryPort.findLectureIdsByUserId(userId);
+
+        // 강의 목록을 조회
+        // category와 enrolled 조건은 repository에서 처리함.
+        var lecturePage = lectureRepository.findLectures(
+                query.category(),
+                query.enrolled(),
+                enrolledLectureIds,
+                query.page(),
+                query.size()
+        );
+
+        // 조회된 강의들을 응답 DTO로 변환합니다.
+        List<LectureListItemResponse> content = lecturePage.content().stream()
+                .map(lecture -> toResponse(
+                        lecture,
+                        enrolledLectureIds.contains(lecture.getId()),
+                        userId
+                ))
+                .toList();
+
+        return new LecturePageResponse(
+                content,
+                query.page(),
+                query.size(),
+                lecturePage.totalElements(),
+                lecturePage.totalPages()
+        );
+    }
+
+    /**
+     * Lecture 도메인 객체를 목록 응답 DTO로 변환
+     */
+    private LectureListItemResponse toResponse(
+            Lecture lecture,
+            boolean enrolled,
+            Long userId
+    ) {
+        // 수강 신청 ID
+        Long enrollmentId = null;
+
+        // 기본값은 0
+        int totalProgress = 0;
+        int completedCount = 0;
+
+        // 수강 신청한 강의라면 enrollment에서 진도 정보를 조회
+        if (enrolled) {
+            var enrollmentInfo = lectureEnrollmentQueryPort.findByUserIdAndLectureId(
+                    userId,
+                    lecture.getId()
+            );
+
+            if (enrollmentInfo.isPresent()) {
+                enrollmentId = enrollmentInfo.get().enrollmentId();
+                totalProgress = enrollmentInfo.get().totalProgress();
+                completedCount = enrollmentInfo.get().completedCount();
+            }
+        }
+
+        return new LectureListItemResponse(
+                enrollmentId,
+                lecture.getId(),
+                lecture.getTitle(),
+                lecture.getThumbnailUrl(),
+                lecture.getCategory().name(),
+                lecture.getStatus().name(),
+                enrolled,
+                totalProgress,
+                completedCount
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
@@ -1,0 +1,20 @@
+package com.wanted.momocity.lecture.application.usecase;
+
+import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+
+/**
+ * LectureQueryUseCase는 강의 조회 기능
+ *
+ * Controller는 이 인터페이스를 통해
+ * 강의 조회 기능을 호출
+ */
+public interface LectureQueryUseCase {
+
+    /*
+     * 강의 목록을 조회
+     * GetLecturesQuery 안에는
+     * category, enrolled, page, size 같은 조회 조건이 들어 있음
+     */
+    LecturePageResponse getLectures(GetLecturesQuery query);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LecturePage.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LecturePage.java
@@ -1,0 +1,21 @@
+package com.wanted.momocity.lecture.domain.model;
+
+import java.util.List;
+
+/*
+ * LecturePage는 강의 목록 조회 결과와 페이징 정보를 담는 도메인
+ * Spring Data의 Page를 application 계층 밖으로 직접 노출하지 않기 위해 사용
+ */
+public record LecturePage(
+
+        // 현재 페이지의 강의 목록
+        List<Lecture> content,
+
+        // 전체 강의 개수
+        long totalElements,
+
+        // 전체 페이지 수
+        int totalPages
+
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
@@ -1,6 +1,8 @@
 package com.wanted.momocity.lecture.domain.repository;
 
 import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureCategory;
+import com.wanted.momocity.lecture.domain.model.LecturePage;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,9 +16,24 @@ import java.util.Optional;
  */
 public interface LectureRepository {
 
-    /*
-     * 강의를 저장
-     * 신규 강의 생성, 강의 수정, 강의 삭제 상태 반영 모두 save를 통해 처리
-     */
+    // 강의를 저장
     Lecture save(Lecture lecture);
+
+    // 강의 ID로 강의를 조회
+    Optional<Lecture> findById(Long lectureId);
+
+    /*
+     * 강의 목록을 조회
+     * category가 있으면 해당 카테고리만 조회
+     * enrolled가 true이면 enrolledLectureIds에 포함된 강의만 조회
+     * enrolled가 false이면 enrolledLectureIds에 포함되지 않은 강의만 조회
+     * enrolled가 null이면 수강 여부와 상관없이 조회
+     */
+    LecturePage findLectures(
+            LectureCategory category,
+            Boolean enrolled,
+            List<Long> enrolledLectureIds,
+            int page,
+            int size
+    );
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -1,10 +1,17 @@
 package com.wanted.momocity.lecture.infrastructure.persistence;
 
 import com.wanted.momocity.lecture.domain.model.Lecture;
-
+import com.wanted.momocity.lecture.domain.model.LectureCategory;
+import com.wanted.momocity.lecture.domain.model.LecturePage;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @Transactional
@@ -32,11 +39,96 @@ public class LectureRepositoryAdapter implements LectureRepository {
         return toDomain(saved);
     }
 
-    /*
-     * JPA Entity를 순수 도메인 모델로 변환한다.
-     *
-     * Controller나 Application 계층으로 JPA Entity를 직접 넘기지 않기 위해 사용한다.
-     */
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Lecture> findById(Long lectureId) {
+        return repository.findById(lectureId)
+                .map(this::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LecturePage findLectures(
+            LectureCategory category,
+            Boolean enrolled,
+            List<Long> enrolledLectureIds,
+            int page,
+            int size
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<LectureJpaEntity> lecturePage = findLecturePage(
+                category,
+                enrolled,
+                enrolledLectureIds,
+                pageable
+        );
+
+        List<Lecture> content = lecturePage.getContent().stream()
+                .map(this::toDomain)
+                .toList();
+
+        return new LecturePage(
+                content,
+                lecturePage.getTotalElements(),
+                lecturePage.getTotalPages()
+        );
+    }
+
+    private Page<LectureJpaEntity> findLecturePage(
+            LectureCategory category,
+            Boolean enrolled,
+            List<Long> enrolledLectureIds,
+            Pageable pageable
+    ) {
+        // enrolled 조건이 없으면 category 조건만 적용합니다.
+        if (enrolled == null) {
+            if (category == null) {
+                return repository.findAll(pageable);
+            }
+
+            return repository.findAllByCategory(category, pageable);
+        }
+
+        // enrolled=true인데 신청한 강의가 없다면 결과는 빈 페이지
+        if (Boolean.TRUE.equals(enrolled) && enrolledLectureIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // enrolled=true이면 신청한 강의만 조회
+        if (Boolean.TRUE.equals(enrolled)) {
+            if (category == null) {
+                return repository.findAllByIdIn(enrolledLectureIds, pageable);
+            }
+
+            return repository.findAllByCategoryAndIdIn(
+                    category,
+                    enrolledLectureIds,
+                    pageable
+            );
+        }
+
+        // enrolled=false인데 신청한 강의가 없다면 전체 강의를 조회
+        if (enrolledLectureIds.isEmpty()) {
+            if (category == null) {
+                return repository.findAll(pageable);
+            }
+
+            return repository.findAllByCategory(category, pageable);
+        }
+
+        // enrolled=false이면 신청하지 않은 강의만 조회
+        if (category == null) {
+            return repository.findAllByIdNotIn(enrolledLectureIds, pageable);
+        }
+
+        return repository.findAllByCategoryAndIdNotIn(
+                category,
+                enrolledLectureIds,
+                pageable
+        );
+    }
+
     private Lecture toDomain(LectureJpaEntity entity) {
         return Lecture.restore(
                 entity.getId(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -1,11 +1,48 @@
 package com.wanted.momocity.lecture.infrastructure.persistence;
 
+import com.wanted.momocity.lecture.domain.model.LectureCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-/*
- * JPA 전용 Repository다.
- * application/domain 계층에서는 직접 사용하지 않고,
- * LectureRepositoryAdapter 내부에서만 사용한다.
+import java.util.Collection;
+
+/**
+ * SpringDataLectureRepository는 실제 lecture 테이블 조회를 담당하는 JPA Repository
  */
 public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEntity, Long> {
+
+    // 카테고리 조건 없이 전체 강의를 조회
+    Page<LectureJpaEntity> findAll(Pageable pageable);
+
+    // 특정 카테고리 강의만 조회
+    Page<LectureJpaEntity> findAllByCategory(LectureCategory category, Pageable pageable);
+
+    /*
+     * 특정 ID 목록에 포함된 강의만 조회
+     * enrolled=true 조건에서 사용
+     */
+    Page<LectureJpaEntity> findAllByIdIn(Collection<Long> lectureIds, Pageable pageable);
+
+    // 특정 카테고리이면서, ID 목록에 포함된 강의만 조회
+    Page<LectureJpaEntity> findAllByCategoryAndIdIn(
+            LectureCategory category,
+            Collection<Long> lectureIds,
+            Pageable pageable
+    );
+
+    /*
+     * 특정 ID 목록에 포함되지 않은 강의만 조회
+     * enrolled=false 조건에서 사용
+     */
+    Page<LectureJpaEntity> findAllByIdNotIn(Collection<Long> lectureIds, Pageable pageable);
+
+    /*
+     * 특정 카테고리이면서, ID 목록에 포함되지 않은 강의만 조회
+     */
+    Page<LectureJpaEntity> findAllByCategoryAndIdNotIn(
+            LectureCategory category,
+            Collection<Long> lectureIds,
+            Pageable pageable
+    );
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -1,0 +1,90 @@
+package com.wanted.momocity.lecture.presentation.api;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
+import com.wanted.momocity.lecture.domain.model.LectureCategory;
+import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * LectureController는 일반 사용자가 보는 강의 조회 API를 담당합니다.
+ *
+ * 강사용 강의 관리는 TeacherLectureController에서 처리하고,
+ * 여기서는 메인/마이페이지 강의 목록 조회를 처리합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lectures")
+public class LectureController {
+
+    // 강의 조회 UseCase입니다.
+    private final LectureQueryUseCase lectureQueryUseCase;
+
+    /**
+     * 강의 목록 조회 API
+     *
+     * 예:
+     * GET /api/v1/lectures?enrolled=true
+     * GET /api/v1/lectures?category=STUDY&enrolled=false&page=0&size=10
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<LecturePageResponse>> getLectures(
+            Authentication authentication,
+
+            // 강의 카테고리 필터
+            // 없으면 전체 카테고리 조회
+            @RequestParam(required = false) String category,
+
+            // 수강 신청 여부 필터
+            // true: 신청한 강의만
+            // false: 신청하지 않은 강의만
+            // null: 수강 여부 상관없이 전체 조회
+            @RequestParam(required = false) Boolean enrolled,
+
+            // 페이지 번호입니다. 기본값은 0
+            @RequestParam(defaultValue = "1") int page,
+
+            // 페이지 크기입니다. 기본값은 10
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        String userEmail = authentication.getName();
+
+        GetLecturesQuery query = new GetLecturesQuery(
+                userEmail,
+                parseCategory(category),
+                enrolled,
+                page,
+                size
+        );
+
+        LecturePageResponse response = lectureQueryUseCase.getLectures(query);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "강의 목록 조회에 성공했습니다.",
+                response
+        ));
+    }
+
+    /*
+     * 문자열 category를 LectureCategory enum으로 변환
+     * category가 없으면 null을 반환해서 전체 카테고리를 조회
+     */
+    private LectureCategory parseCategory(String category) {
+        if (category == null || category.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LectureCategory.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new DomainRuleViolationException("허용되지 않는 강의 카테고리입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/CreateLectureResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/CreateLectureResponse.java
@@ -5,9 +5,8 @@ import com.wanted.momocity.lecture.domain.model.Lecture;
 import java.time.LocalDateTime;
 
 /*
- * CreateLectureResponse는 강의 등록 성공 시 프론트에 내려주는 응답 DTO다.
- *
- * API 명세의 data 필드 구조에 맞춰 생성된 강의의 기본 정보를 포함한다.
+ * CreateLectureResponse는 강의 등록 성공 시 프론트에 내려주는 응답 DTO
+ * API 명세의 data 필드 구조에 맞춰 생성된 강의의 기본 정보를 포함
  */
 public record CreateLectureResponse(
         Long lectureId,
@@ -23,8 +22,7 @@ public record CreateLectureResponse(
 ) {
 
     /*
-     * 도메인 모델 Lecture를 응답 DTO로 변환한다.
-     *
+     * 도메인 모델 Lecture를 응답 DTO로 변환
      * Controller에서 응답 객체를 직접 조립하지 않도록 변환 책임을 이곳에 둔다.
      */
     public static CreateLectureResponse from(Lecture lecture) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/LectureListItemResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/LectureListItemResponse.java
@@ -1,0 +1,36 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+/**
+ * LectureListItemResponse는 강의 목록의 강의 1개를 표현하는 응답 DTO
+ */
+public record LectureListItemResponse(
+
+        // 수강신청 ID
+        Long enrollmentId,
+
+        // 강의 ID
+        Long lectureId,
+
+        // 강의 제목입
+        String title,
+
+        // 강의 썸네일 이미지 URL
+        String thumbnailUrl,
+
+        // 강의 카테고리
+        String category,
+
+        // 강의 상태
+        String lectureStatus,
+
+        // 로그인 사용자가 이 강의를 수강 신청했는지 여부
+        boolean enrolled,
+
+        // 전체 진도율
+        int totalProgress,
+
+        // 완료한 챕터 수
+        int completedCount
+
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/LecturePageResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/LecturePageResponse.java
@@ -1,0 +1,29 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import java.util.List;
+
+/**
+ * LecturePageResponse는 강의 목록 페이지 응답 DTO
+ *
+ * content에는 강의 목록이 들어가고,
+ * page, size, totalElements, totalPages는 페이징 정보를 나타냄
+ */
+public record LecturePageResponse(
+
+        // 현재 페이지의 강의 목록
+        List<LectureListItemResponse> content,
+
+        // 현재 페이지 번호
+        int page,
+
+        // 한 페이지 크기
+        int size,
+
+        // 전체 강의 개수
+        long totalElements,
+
+        // 전체 페이지 수입니다.
+        int totalPages
+
+) {
+}


### PR DESCRIPTION
## 작업 내용

- 로그인한 사용자의 수강 여부를 기준으로 강의 목록을 조회할 수 있도록 구현했습니다.
- `GET /api/v1/lectures` API에 `category`, `enrolled`, `page`, `size` 조회 조건을 추가했습니다.
- `enrolled=true`인 경우 사용자가 수강신청한 강의만 조회합니다.
- `enrolled=false`인 경우 사용자가 아직 수강신청하지 않은 강의만 조회합니다.
- `enrolled` 값이 없는 경우 수강 여부와 관계없이 강의 목록을 조회합니다.
- 응답에 `enrollmentId`, `enrolled`, `totalProgress`, `completedCount` 정보를 포함했습니다.
- 프론트 기준에 맞춰 페이지 번호는 1부터 시작하도록 처리했습니다.

## API

### 강의 목록 조회

```http
GET /api/v1/lectures



## Query Parameter로 진행
###예시
GET /api/v1/lectures?category=STUDY
GET /api/v1/lectures?category=STUDY&enrolled=true
GET /api/v1/lectures?category=STUDY&enrolled=false
GET /api/v1/lectures?enrolled=true


close #97 

