### PR TITLE
[PR] 강의 목록 조회 시 Active 상태 강의만 조회 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
@@ -23,8 +23,9 @@ public interface LectureRepository {
     Optional<Lecture> findById(Long lectureId);
 
     /*
-     * 강의 목록을 조회
-     * category가 있으면 해당 카테고리만 조회
+     * 학생용 강의 목록을 조회
+     * 이 조회는 기본적으로 ACTIVE 상태의 강의만 대상으로 한다.
+     * category가 있으면 해당 카테고리의 강의만 조회
      * enrolled가 true이면 enrolledLectureIds에 포함된 강의만 조회
      * enrolled가 false이면 enrolledLectureIds에 포함되지 않은 강의만 조회
      * enrolled가 null이면 수강 여부와 상관없이 조회

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.wanted.momocity.lecture.infrastructure.persistence;
 import com.wanted.momocity.lecture.domain.model.Lecture;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LecturePage;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,6 +24,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
         this.repository = repository;
     }
 
+    // 강의를 저장합니다.
     @Override
     public Lecture save(Lecture lecture) {
         LectureJpaEntity entity = new LectureJpaEntity(
@@ -39,6 +41,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
         return toDomain(saved);
     }
 
+    // 강의 ID로 강의를 조회합니다.
     @Override
     @Transactional(readOnly = true)
     public Optional<Lecture> findById(Long lectureId) {
@@ -46,6 +49,8 @@ public class LectureRepositoryAdapter implements LectureRepository {
                 .map(this::toDomain);
     }
 
+    // 학생용 강의 목록을 조회합니다.
+    // 학생용 목록은 기본적으로 ACTIVE 상태의 강의만 내려줍니다.
     @Override
     @Transactional(readOnly = true)
     public LecturePage findLectures(
@@ -55,6 +60,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
             int page,
             int size
     ) {
+        // 프론트는 page를 1부터 보내고, Spring Data JPA는 page를 0부터 시작합니다.
         Pageable pageable = PageRequest.of(page - 1, size);
 
         Page<LectureJpaEntity> lecturePage = findLecturePage(
@@ -75,60 +81,83 @@ public class LectureRepositoryAdapter implements LectureRepository {
         );
     }
 
+    // category, enrolled 조건에 맞춰 ACTIVE 강의만 조회합니다.
     private Page<LectureJpaEntity> findLecturePage(
             LectureCategory category,
             Boolean enrolled,
             List<Long> enrolledLectureIds,
             Pageable pageable
     ) {
-        // enrolled 조건이 없으면 category 조건만 적용합니다.
+        // 학생용 강의 목록은 항상 ACTIVE 강의만 조회합니다.
+        LectureStatus status = LectureStatus.ACTIVE;
+
+        // enrolled 조건이 없으면 수강 여부와 상관없이 ACTIVE 강의를 조회합니다.
         if (enrolled == null) {
             if (category == null) {
-                return repository.findAll(pageable);
+                return repository.findAllByStatus(status, pageable);
             }
 
-            return repository.findAllByCategory(category, pageable);
+            return repository.findAllByCategoryAndStatus(
+                    category,
+                    status,
+                    pageable
+            );
         }
 
-        // enrolled=true인데 신청한 강의가 없다면 결과는 빈 페이지
+        // enrolled=true인데 신청한 강의가 없다면 결과는 빈 페이지입니다.
         if (Boolean.TRUE.equals(enrolled) && enrolledLectureIds.isEmpty()) {
             return Page.empty(pageable);
         }
 
-        // enrolled=true이면 신청한 강의만 조회
+        // enrolled=true이면 신청한 ACTIVE 강의만 조회합니다.
         if (Boolean.TRUE.equals(enrolled)) {
             if (category == null) {
-                return repository.findAllByIdIn(enrolledLectureIds, pageable);
+                return repository.findAllByStatusAndIdIn(
+                        status,
+                        enrolledLectureIds,
+                        pageable
+                );
             }
 
-            return repository.findAllByCategoryAndIdIn(
+            return repository.findAllByCategoryAndStatusAndIdIn(
                     category,
+                    status,
                     enrolledLectureIds,
                     pageable
             );
         }
 
-        // enrolled=false인데 신청한 강의가 없다면 전체 강의를 조회
+        // enrolled=false인데 신청한 강의가 없다면 신청 제외할 강의가 없으므로 ACTIVE 강의 전체를 조회합니다.
         if (enrolledLectureIds.isEmpty()) {
             if (category == null) {
-                return repository.findAll(pageable);
+                return repository.findAllByStatus(status, pageable);
             }
 
-            return repository.findAllByCategory(category, pageable);
+            return repository.findAllByCategoryAndStatus(
+                    category,
+                    status,
+                    pageable
+            );
         }
 
-        // enrolled=false이면 신청하지 않은 강의만 조회
+        // enrolled=false이면 신청하지 않은 ACTIVE 강의만 조회합니다.
         if (category == null) {
-            return repository.findAllByIdNotIn(enrolledLectureIds, pageable);
+            return repository.findAllByStatusAndIdNotIn(
+                    status,
+                    enrolledLectureIds,
+                    pageable
+            );
         }
 
-        return repository.findAllByCategoryAndIdNotIn(
+        return repository.findAllByCategoryAndStatusAndIdNotIn(
                 category,
+                status,
                 enrolledLectureIds,
                 pageable
         );
     }
 
+    // JPA Entity를 도메인 모델로 변환합니다.
     private Lecture toDomain(LectureJpaEntity entity) {
         return Lecture.restore(
                 entity.getId(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -1,6 +1,7 @@
 package com.wanted.momocity.lecture.infrastructure.persistence;
 
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,36 +13,47 @@ import java.util.Collection;
  */
 public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEntity, Long> {
 
-    // 카테고리 조건 없이 전체 강의를 조회
-    Page<LectureJpaEntity> findAll(Pageable pageable);
+    // 강의 상태 조건으로 강의 목록을 조회합니다.
+    Page<LectureJpaEntity> findAllByStatus(
+            LectureStatus status,
+            Pageable pageable
+    );
 
-    // 특정 카테고리 강의만 조회
-    Page<LectureJpaEntity> findAllByCategory(LectureCategory category, Pageable pageable);
-
-    /*
-     * 특정 ID 목록에 포함된 강의만 조회
-     * enrolled=true 조건에서 사용
-     */
-    Page<LectureJpaEntity> findAllByIdIn(Collection<Long> lectureIds, Pageable pageable);
-
-    // 특정 카테고리이면서, ID 목록에 포함된 강의만 조회
-    Page<LectureJpaEntity> findAllByCategoryAndIdIn(
+    // 카테고리와 강의 상태 조건으로 강의 목록을 조회합니다.
+    Page<LectureJpaEntity> findAllByCategoryAndStatus(
             LectureCategory category,
+            LectureStatus status,
+            Pageable pageable
+    );
+
+    // 특정 ID 목록에 포함되고, 특정 상태인 강의만 조회합니다.
+// enrolled=true 조건에서 사용합니다.
+    Page<LectureJpaEntity> findAllByStatusAndIdIn(
+            LectureStatus status,
             Collection<Long> lectureIds,
             Pageable pageable
     );
 
-    /*
-     * 특정 ID 목록에 포함되지 않은 강의만 조회
-     * enrolled=false 조건에서 사용
-     */
-    Page<LectureJpaEntity> findAllByIdNotIn(Collection<Long> lectureIds, Pageable pageable);
-
-    /*
-     * 특정 카테고리이면서, ID 목록에 포함되지 않은 강의만 조회
-     */
-    Page<LectureJpaEntity> findAllByCategoryAndIdNotIn(
+    // 카테고리 조건까지 함께 적용해서, 특정 ID 목록에 포함된 강의만 조회합니다.
+    Page<LectureJpaEntity> findAllByCategoryAndStatusAndIdIn(
             LectureCategory category,
+            LectureStatus status,
+            Collection<Long> lectureIds,
+            Pageable pageable
+    );
+
+    // 특정 ID 목록에 포함되지 않고, 특정 상태인 강의만 조회합니다.
+// enrolled=false 조건에서 사용합니다.
+    Page<LectureJpaEntity> findAllByStatusAndIdNotIn(
+            LectureStatus status,
+            Collection<Long> lectureIds,
+            Pageable pageable
+    );
+
+    // 카테고리 조건까지 함께 적용해서, 특정 ID 목록에 포함되지 않은 강의만 조회합니다.
+    Page<LectureJpaEntity> findAllByCategoryAndStatusAndIdNotIn(
+            LectureCategory category,
+            LectureStatus status,
             Collection<Long> lectureIds,
             Pageable pageable
     );


### PR DESCRIPTION
## 추가 작업 내용

- 학생용 강의 목록 조회 시 `ACTIVE` 상태의 강의만 조회되도록 기본 필터를 적용했습니다.
- `GET /api/v1/lectures`는 프론트에서 `status` 값을 전달하지 않아도 내부적으로 `LectureStatus.ACTIVE` 기준으로 조회합니다.
- `category`, `enrolled=true`, `enrolled=false` 조건과 함께 사용해도 항상 `ACTIVE` 강의만 응답되도록 처리했습니다.

## 반영된 조회 기준

```http
 예시
- ACTIVE 강의 전체 조회
GET /api/v1/lectures?category=STUDY

- ACTIVE + STUDY + 내가 수강신청한 강의 조회
GET /api/v1/lectures?category=STUDY&enrolled=false

close #107 