### PR TITLE
[PR] Swagger 문서화 및 LectureAggregate 모델명 변경(모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/EnrollmentController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/EnrollmentController.java
@@ -6,6 +6,8 @@ import com.wanted.momocity.enrollment.domain.model.Enrollment;
 import com.wanted.momocity.enrollment.presentation.api.response.CreateEnrollmentResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,12 +17,18 @@ import org.springframework.web.bind.annotation.*;
 // EnrollmentController는 수강신청 API 요청을 받는 컨트롤러
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Enrollment", description = "수강신청 API")
 public class EnrollmentController {
 
     // 수강신청 생성 UseCase
     // 실제 비즈니스 로직은 EnrollmentCommandService가 처리
     private final EnrollmentCommandUseCase enrollmentCommandUseCase;
 
+
+    @Operation(
+            summary = "수강신청",
+            description = "로그인한 학생이 특정 강의를 수강신청합니다."
+    )
     // 수강신청 API
     @PostMapping("/api/v1/lectures/{lectureId}/enrollments")
     public ResponseEntity<ApiResponse<CreateEnrollmentResponse>> createEnrollment(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
@@ -3,7 +3,7 @@ package com.wanted.momocity.lecture.application.service;
 import com.wanted.momocity.lecture.application.command.CreateLectureCommand;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,14 +27,14 @@ public class LectureCommandService implements LectureCommandUseCase {
     }
 
     @Override
-    public Lecture createLecture(CreateLectureCommand command) {
+    public LectureAggregate createLecture(CreateLectureCommand command) {
         /*
          * Authorization 토큰에서 얻은 email로 강사 id를 조회한다.
          */
         Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
 
         // command.thumbnailUrl()은 S3 업로드 후 생성된 이미지 URL이다.
-        Lecture lecture = Lecture.create(
+        LectureAggregate lecture = LectureAggregate.create(
                 teacherId,
                 command.title(),
                 command.description(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -4,7 +4,7 @@ import com.wanted.momocity.enrollment.application.port.StudentAccountPort;
 import com.wanted.momocity.lecture.application.port.LectureEnrollmentQueryPort;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
 import com.wanted.momocity.lecture.presentation.api.response.LectureListItemResponse;
 import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
@@ -75,7 +75,7 @@ public class LectureQueryService implements LectureQueryUseCase {
      * Lecture 도메인 객체를 목록 응답 DTO로 변환
      */
     private LectureListItemResponse toResponse(
-            Lecture lecture,
+            LectureAggregate lecture,
             boolean enrolled,
             Long userId
     ) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureCommandUseCase.java
@@ -1,7 +1,7 @@
 package com.wanted.momocity.lecture.application.usecase;
 
 import com.wanted.momocity.lecture.application.command.CreateLectureCommand;
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 
 /*
  * LectureCommandUseCase는 강의 상태를 변경하는 인터페이스
@@ -9,5 +9,5 @@ import com.wanted.momocity.lecture.domain.model.Lecture;
  */
 public interface LectureCommandUseCase {
     // 강의를 등록
-    Lecture createLecture(CreateLectureCommand command);
+    LectureAggregate createLecture(CreateLectureCommand command);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureAggregate.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureAggregate.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
  * JPA Entity가 아니므로 DB 어노테이션을 알지 않고,
  * 강의의 핵심 상태와 비즈니스 규칙만 표현한다.
  */
-public class Lecture {
+public class LectureAggregate {
 
     private final Long id;
     private final Long teacherId;
@@ -23,7 +23,7 @@ public class Lecture {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    private Lecture(
+    private LectureAggregate(
             Long id,
             Long teacherId,
             String title,
@@ -53,7 +53,7 @@ public class Lecture {
      * 생성 직후 id와 시간 값은 DB 저장 전이므로 null이다.
      * 수강 완료 인원 수는 처음 생성 시 0명으로 시작한다.
      */
-    public static Lecture create(
+    public static LectureAggregate create(
             Long teacherId,
             String title,
             String description,
@@ -65,7 +65,7 @@ public class Lecture {
         validateDescription(description);
         validateCategory(category);
 
-        return new Lecture(
+        return new LectureAggregate(
                 null,
                 teacherId,
                 title,
@@ -84,7 +84,7 @@ public class Lecture {
      *
      * JPA Entity에서 id, 생성일, 수정일을 포함해 Lecture로 변환할 때 호출한다.
      */
-    public static Lecture restore(
+    public static LectureAggregate restore(
             Long id,
             Long teacherId,
             String title,
@@ -96,7 +96,7 @@ public class Lecture {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new Lecture(
+        return new LectureAggregate(
                 id,
                 teacherId,
                 title,
@@ -116,7 +116,7 @@ public class Lecture {
      * 기존 강의의 id, teacherId, 상태, 생성일은 유지하고,
      * 제목/설명/썸네일/카테고리만 새 값으로 교체한다.
      */
-    public Lecture update(
+    public LectureAggregate update(
             String title,
             String description,
             String thumbnailUrl,
@@ -126,7 +126,7 @@ public class Lecture {
         validateDescription(description);
         validateCategory(category);
 
-        return new Lecture(
+        return new LectureAggregate(
                 id,
                 teacherId,
                 title,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LecturePage.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LecturePage.java
@@ -9,7 +9,7 @@ import java.util.List;
 public record LecturePage(
 
         // 현재 페이지의 강의 목록
-        List<Lecture> content,
+        List<LectureAggregate> content,
 
         // 전체 강의 개수
         long totalElements,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.lecture.domain.repository;
 
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LecturePage;
 
@@ -17,10 +17,10 @@ import java.util.Optional;
 public interface LectureRepository {
 
     // 강의를 저장
-    Lecture save(Lecture lecture);
+    LectureAggregate save(LectureAggregate lecture);
 
     // 강의 ID로 강의를 조회
-    Optional<Lecture> findById(Long lectureId);
+    Optional<LectureAggregate> findById(Long lectureId);
 
     /*
      * 학생용 강의 목록을 조회

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.lecture.infrastructure.persistence;
 
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LecturePage;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
@@ -26,7 +26,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
 
     // 강의를 저장합니다.
     @Override
-    public Lecture save(Lecture lecture) {
+    public LectureAggregate save(LectureAggregate lecture) {
         LectureJpaEntity entity = new LectureJpaEntity(
                 lecture.getTeacherId(),
                 lecture.getTitle(),
@@ -44,7 +44,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
     // 강의 ID로 강의를 조회합니다.
     @Override
     @Transactional(readOnly = true)
-    public Optional<Lecture> findById(Long lectureId) {
+    public Optional<LectureAggregate> findById(Long lectureId) {
         return repository.findById(lectureId)
                 .map(this::toDomain);
     }
@@ -70,7 +70,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
                 pageable
         );
 
-        List<Lecture> content = lecturePage.getContent().stream()
+        List<LectureAggregate> content = lecturePage.getContent().stream()
                 .map(this::toDomain)
                 .toList();
 
@@ -158,8 +158,8 @@ public class LectureRepositoryAdapter implements LectureRepository {
     }
 
     // JPA Entity를 도메인 모델로 변환합니다.
-    private Lecture toDomain(LectureJpaEntity entity) {
-        return Lecture.restore(
+    private LectureAggregate toDomain(LectureJpaEntity entity) {
+        return LectureAggregate.restore(
                 entity.getId(),
                 entity.getTeacherId(),
                 entity.getTitle(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -7,6 +7,8 @@ import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/lectures")
+@Tag(name = "Lecture", description = "학생용 강의 목록 조회 API")
 public class LectureController {
 
     // 강의 조회 UseCase입니다.
@@ -33,6 +36,10 @@ public class LectureController {
      * GET /api/v1/lectures?enrolled=true
      * GET /api/v1/lectures?category=STUDY&enrolled=false&page=0&size=10
      */
+    @Operation(
+            summary = "강의 목록 및 수강 내역 조회",
+            description = "학생용 강의 목록을 조회합니다. enrolled=true이면 내가 수강신청한 강의만 조회합니다."
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<LecturePageResponse>> getLectures(
             Authentication authentication,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -4,9 +4,11 @@ import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.presentation.api.request.CreateLectureRequest;
 import com.wanted.momocity.lecture.presentation.api.response.CreateLectureResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/teacher/lectures")
+@Tag(name = "Teacher Lecture", description = "강사용 강의 관리 API")
 public class TeacherLectureController {
 
     private final LectureCommandUseCase lectureCommandUseCase;
@@ -29,6 +32,10 @@ public class TeacherLectureController {
         this.s3UploadPort = s3UploadPort;
     }
 
+    @Operation(
+            summary = "강의 등록",
+            description = "강사가 새로운 강의를 등록합니다. 썸네일 이미지는 multipart/form-data로 업로드합니다."
+    )
     // Content-Type: multipart/form-data 즉, Json이 아닌 Form-data로 요청 받는다
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     // 실행 전 권한 검증
@@ -47,7 +54,7 @@ public class TeacherLectureController {
 
         String thumbnailUrl = s3UploadPort.upload(request.thumbnail());
 
-        Lecture lecture = lectureCommandUseCase.createLecture(
+        LectureAggregate lecture = lectureCommandUseCase.createLecture(
                 request.toCommand(teacherEmail, thumbnailUrl)
         );
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateLectureRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateLectureRequest.java
@@ -7,8 +7,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
+
 // CreateLectureRequest는 multipart/form-data 요청을 받는 DTO
 public record CreateLectureRequest(
+
         @NotBlank(message = "강의 제목은 필수입니다.")
         String title,
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/CreateLectureResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/CreateLectureResponse.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.lecture.presentation.api.response;
 
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 
 import java.time.LocalDateTime;
 
@@ -25,7 +25,7 @@ public record CreateLectureResponse(
      * 도메인 모델 Lecture를 응답 DTO로 변환
      * Controller에서 응답 객체를 직접 조립하지 않도록 변환 책임을 이곳에 둔다.
      */
-    public static CreateLectureResponse from(Lecture lecture) {
+    public static CreateLectureResponse from(LectureAggregate lecture) {
         return new CreateLectureResponse(
                 lecture.getId(),
                 lecture.getTeacherId(),

--- a/legend-momo-city/src/test/java/com/wanted/momocity/mosungjin/TeacherLectureAggregateRegisterTest.java
+++ b/legend-momo-city/src/test/java/com/wanted/momocity/mosungjin/TeacherLectureAggregateRegisterTest.java
@@ -2,7 +2,7 @@ package com.wanted.momocity.mosungjin;
 
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
-import com.wanted.momocity.lecture.domain.model.Lecture;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import com.wanted.momocity.lecture.presentation.api.TeacherLectureController;
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(TeacherLectureController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class TeacherLectureRegisterTest {
+class TeacherLectureAggregateRegisterTest {
 
     private static final String CREATE_LECTURE_URL = "/api/v1/teacher/lectures";
 
@@ -72,7 +72,7 @@ class TeacherLectureRegisterTest {
         /*
          * UseCase가 반환할 가짜 Lecture 객체를 준비한다.
          */
-        Lecture lecture = Lecture.restore(
+        LectureAggregate lecture = LectureAggregate.restore(
                 10L,
                 3L,
                 "Spring Boot 입문",


### PR DESCRIPTION
## 변경 사항

- 강의 등록, 수강신청, 수강내역 API에 Swagger 문서화를 추가했습니다.
- 강의 등록 요청/응답 설명을 추가했습니다.
- `lecture.domain.model.Lecture` 클래스명을 `LectureAggregate`로 변경했습니다.
- `viewing.domain.model.Lecture`와의 이름 중복으로 인한 혼동을 줄였습니다.
- 강의 등록 흐름에서 사용하는 Controller, UseCase, Service, Repository, Response, Test의 타입 참조를 수정했습니다.

## 변경 이유

기존에는 `lecture` 패키지와 `viewing` 패키지에 모두 `Lecture` 클래스가 존재했습니다.

close #111 