### PR TITLE
[PR] 수강 신청 후 이벤트 발행(모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentCommandService.java
@@ -4,63 +4,75 @@ import com.wanted.momocity.enrollment.application.command.CreateEnrollmentComman
 import com.wanted.momocity.enrollment.application.port.EnrollmentLecturePort;
 import com.wanted.momocity.enrollment.application.port.StudentAccountPort;
 import com.wanted.momocity.enrollment.application.usecase.EnrollmentCommandUseCase;
+import com.wanted.momocity.enrollment.domain.event.EnrollmentCompletedEvent;
 import com.wanted.momocity.enrollment.domain.exception.DuplicateEnrollmentException;
 import com.wanted.momocity.enrollment.domain.exception.InvalidEnrollmentLectureStatusException;
 import com.wanted.momocity.enrollment.domain.model.Enrollment;
 import com.wanted.momocity.enrollment.domain.repository.EnrollmentRepository;
-import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// EnrollmentCommandService는 수강신청 생성 로직을 처리하는 서비스입니다.
+// EnrollmentCommandService는 수강신청 생성 유스케이스를 처리하는 Application Service
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandService implements EnrollmentCommandUseCase {
 
-    // 수강신청
+    // 수강신청 저장소
     private final EnrollmentRepository enrollmentRepository;
+
+    // 로그인 사용자 email을 studentId로 변환하기 위한 포트
     private final StudentAccountPort studentAccountPort;
+
+    // 수강신청 대상 강의 상태를 조회하기 위한 포트
     private final EnrollmentLecturePort enrollmentLecturePort;
-    /*
-     * 수강신청을 생성
-     * 처리 순서:
-     *  1. 이미 수강신청한 강의인지 확인
-     *  2. 중복이면 예외 발생
-     *  3. Enrollment 도메인 객체 생성
-     *  4. 저장소에 저장
-     *  5. 저장된 Enrollment 반환
-     */
+
+    // 수강신청 완료 이벤트를 발행하기 위한 Spring 이벤트 발행기
+    private final ApplicationEventPublisher eventPublisher;
+
     @Override
     public Enrollment createEnrollment(CreateEnrollmentCommand command) {
-
+        // Authorization 토큰에서 꺼낸 email로 학생 ID를 조회
         Long userId = studentAccountPort.getStudentId(command.studentEmail());
+
+        // 수강신청 대상 강의의 현재 상태를 조회
         LectureStatus lectureStatus = enrollmentLecturePort.getLectureStatus(command.lectureId());
 
-        // 같은 사용자가 같은 강의를 이미 신청했는지 확인합니다.
+        // 같은 학생이 같은 강의를 이미 수강신청했는지 확인
         boolean alreadyEnrolled = enrollmentRepository.existsByUserIdAndLectureId(
                 userId,
                 command.lectureId()
         );
 
-        // 이미 신청했다면 409 Error 발생
+        // 이미 수강신청한 강의라면 중복 수강신청 예외를 발생
         if (alreadyEnrolled) {
             throw new DuplicateEnrollmentException("이미 수강신청한 강의입니다.");
         }
 
+        // ACTIVE 상태의 강의만 수강신청할 수 있음
         if (lectureStatus != LectureStatus.ACTIVE) {
             throw new InvalidEnrollmentLectureStatusException("진행 중인 강의만 수강신청할 수 있습니다.");
         }
 
-        // 새 수강신청 도메인 객체 생성
+        // 수강신청 도메인 객체를 생성
         Enrollment enrollment = Enrollment.create(
                 userId,
                 command.lectureId()
         );
 
-        // 수강신청 정보를 저장하고, 저장된 도메인 객체를 반환
-        return enrollmentRepository.save(enrollment);
+        // 수강신청 정보를 저장
+        Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
+
+        // 수강신청 완료 후 강사 자동 친구 추가를 위해 이벤트를 발행
+        eventPublisher.publishEvent(new EnrollmentCompletedEvent(
+                savedEnrollment.getUserId(),
+                savedEnrollment.getLectureId()
+        ));
+
+        // 저장된 수강신청 도메인 객체를 반환
+        return savedEnrollment;
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/event/EnrollmentCompletedEvent.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/event/EnrollmentCompletedEvent.java
@@ -1,0 +1,12 @@
+package com.wanted.momocity.enrollment.domain.event;
+
+// 수강신청 완료 후 다른 기능에서 사용할 이벤트
+// 예: 강사 자동 친구 추가
+public record EnrollmentCompletedEvent(
+        // 수강신청한 학생 ID
+        Long studentId,
+
+        // 수강신청한 강의 ID
+        Long lectureId
+) {
+}


### PR DESCRIPTION
close #118 

## 변경 사항

- 수강신청 완료 이벤트 `EnrollmentCompletedEvent`를 추가했습니다.
- 이벤트에 `studentId`, `lectureId`를 포함했습니다.
- 수강신청 저장 성공 후 `ApplicationEventPublisher`를 통해 이벤트를 발행하도록 변경했습니다.

## 변경 이유

수강신청 완료 후 강사 자동 친구 추가 기능과 연동하기 위해 이벤트 발행이 필요했습니다.

기존에는 수강신청이 완료되어도 다른 모듈에서 이를 감지할 수 있는 구조가 없었습니다.  
이번 변경으로 `enrollment` 모듈은 수강신청 완료 사실만 이벤트로 알리고, 실제 강사 자동 친구 추가 처리는 이벤트를 구독하는 모듈에서 담당할 수 있습니다.

## 처리 흐름

```text
수강신청 API 요청
→ EnrollmentCommandService
→ 학생 ID 조회
→ 강의 상태 확인
→ 중복 수강신청 검증
→ Enrollment 생성
→ Enrollment 저장
→ EnrollmentCompletedEvent 발행
→ 이벤트 수신 모듈에서 후속 처리