### PR TITLE
[PR] 챕터 등록 메서드 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/EnrollmentExceptionHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/EnrollmentExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 // enrollment 패키지에서 발생하는 예외를 API 응답으로 바꿔주는 클래스
+// @RestControllerAdvice : enrollment 패키지에서 발생한 예외만 잡아서 API 응답 형태로 바꿔주는 예외 처리기
 @RestControllerAdvice(basePackages = "com.wanted.momocity.enrollment")
 public class EnrollmentExceptionHandler {
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/CreateChapterCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/CreateChapterCommand.java
@@ -1,0 +1,18 @@
+package com.wanted.momocity.lecture.application.command;
+
+// CreateChapterCommand는 챕터 등록 유스케이스에 필요한 command
+public record CreateChapterCommand(
+        // 로그인한 강사의 email
+        // Authorization 토큰에서 꺼낸 값
+        String teacherEmail,
+
+        // 챕터를 등록할 강의 ID
+        Long lectureId,
+
+        // 챕터 제목
+        String title,
+
+        // 강의 안에서 챕터가 노출될 순서
+        int orderNo
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
@@ -1,0 +1,82 @@
+package com.wanted.momocity.lecture.application.service;
+
+import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
+import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
+import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
+import com.wanted.momocity.lecture.domain.exception.ChapterLimitExceededException;
+import com.wanted.momocity.lecture.domain.exception.DuplicateChapterOrderException;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
+import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// ChapterCommandService는 챕터 등록 유스케이스를 처리하는 Service
+@Service
+@Transactional
+public class ChapterCommandService implements ChapterCommandUseCase {
+
+    // 한 강의에 등록 가능한 최대 챕터 개수입니다.
+    private static final int MAX_CHAPTER_COUNT = 5;
+
+    private final ChapterRepository chapterRepository;
+    private final LectureRepository lectureRepository;
+    private final TeacherAccountPort teacherAccountPort;
+
+    public ChapterCommandService(
+            ChapterRepository chapterRepository,
+            LectureRepository lectureRepository,
+            TeacherAccountPort teacherAccountPort
+    ) {
+        this.chapterRepository = chapterRepository;
+        this.lectureRepository = lectureRepository;
+        this.teacherAccountPort = teacherAccountPort;
+    }
+
+    @Override
+    public LectureChapter createChapter(CreateChapterCommand command) {
+        // Authorization 토큰에서 가져온 email로 강사 ID를 조회합니다.
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+
+        // 챕터를 등록할 강의를 조회
+        LectureAggregate lecture = lectureRepository.findById(command.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 본인이 등록한 강의에만 챕터를 등록할 수 있음
+        if (!lecture.isOwnedBy(teacherId)) {
+            throw new AccessDeniedException("본인이 등록한 강의에만 챕터를 등록할 수 있습니다.");
+        }
+
+        // 현재 강의에 등록된 챕터 개수를 조회
+        int chapterCount = chapterRepository.countByLectureId(command.lectureId());
+
+        // 한 강의에는 최대 5개의 챕터만 등록할 수 있음.
+        if (chapterCount >= MAX_CHAPTER_COUNT) {
+            throw new ChapterLimitExceededException("챕터는 최대 5개까지만 등록할 수 있습니다.");
+        }
+
+        // 같은 강의 안에서 챕터 순서가 중복되는지 확인
+        boolean duplicatedOrderNo = chapterRepository.existsByLectureIdAndOrderNo(
+                command.lectureId(),
+                command.orderNo()
+        );
+
+        // 동일 강의 내 orderNo는 중복될 수 없음
+        if (duplicatedOrderNo) {
+            throw new DuplicateChapterOrderException("동일 강의 내 이미 사용 중인 챕터 순서입니다.");
+        }
+
+        // 챕터 도메인 객체를 생성합니다.
+        LectureChapter chapter = LectureChapter.create(
+                command.lectureId(),
+                command.title(),
+                command.orderNo()
+        );
+
+        // 생성된 챕터를 저장합니다.
+        return chapterRepository.save(chapter);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/ChapterCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/ChapterCommandUseCase.java
@@ -1,0 +1,11 @@
+package com.wanted.momocity.lecture.application.usecase;
+
+import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+// ChapterCommandUseCase는 챕터 상태를 변경하는 기능
+public interface ChapterCommandUseCase {
+
+    // 챕터를 등록
+    LectureChapter createChapter(CreateChapterCommand command);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/ChapterLimitExceededException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/ChapterLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.lecture.domain.exception;
+
+// 한 강의에 등록 가능한 챕터 개수를 초과했을 때 사용하는 예외
+public class ChapterLimitExceededException extends RuntimeException {
+
+    public ChapterLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/DuplicateChapterOrderException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/DuplicateChapterOrderException.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.lecture.domain.exception;
+
+// 같은 강의 안에서 챕터 순서가 중복될 때 사용하는 예외
+public class DuplicateChapterOrderException extends RuntimeException {
+
+    public DuplicateChapterOrderException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/LectureNotFoundException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/LectureNotFoundException.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.lecture.domain.exception;
+
+// 강의를 찾을 수 없을 때 사용하는 예외
+public class LectureNotFoundException extends RuntimeException {
+
+    public LectureNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureChapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureChapter.java
@@ -1,0 +1,177 @@
+package com.wanted.momocity.lecture.domain.model;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+
+
+import java.time.LocalDateTime;
+
+// LectureChapter는 강의에 소속된 챕터 도메인 모델입니다.
+// 챕터의 제목, 순서, 동영상 상태 정보를 관리합니다.
+public class LectureChapter {
+
+    private final Long id;
+    private final Long lectureId;
+    private final String title;
+    private final int orderNo;
+    private final String videoUrl;
+    private final Long videoSizeBytes;
+    private final Integer durationSec;
+    private final VideoStatus videoStatus;
+    private final String originalFilename;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    private LectureChapter(
+            Long id,
+            Long lectureId,
+            String title,
+            int orderNo,
+            String videoUrl,
+            Long videoSizeBytes,
+            Integer durationSec,
+            VideoStatus videoStatus,
+            String originalFilename,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        validateLectureId(lectureId);
+        validateTitle(title);
+        validateOrderNo(orderNo);
+        validateVideoStatus(videoStatus);
+
+        this.id = id;
+        this.lectureId = lectureId;
+        this.title = title;
+        this.orderNo = orderNo;
+        this.videoUrl = videoUrl;
+        this.videoSizeBytes = videoSizeBytes;
+        this.durationSec = durationSec;
+        this.videoStatus = videoStatus;
+        this.originalFilename = originalFilename;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // 새 챕터를 등록할 때 사용합니다.
+    // 동영상은 별도 API에서 등록하므로 여기서는 null로 시작합니다.
+    public static LectureChapter create(
+            Long lectureId,
+            String title,
+            int orderNo
+    ) {
+        return new LectureChapter(
+                null,
+                lectureId,
+                title,
+                orderNo,
+                null,
+                null,
+                null,
+                VideoStatus.UPLOADING,
+                null,
+                null,
+                null
+        );
+    }
+
+    // DB에서 조회한 챕터 정보를 도메인 모델로 복원할 때 사용합니다.
+    public static LectureChapter restore(
+            Long id,
+            Long lectureId,
+            String title,
+            int orderNo,
+            String videoUrl,
+            Long videoSizeBytes,
+            Integer durationSec,
+            VideoStatus videoStatus,
+            String originalFilename,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new LectureChapter(
+                id,
+                lectureId,
+                title,
+                orderNo,
+                videoUrl,
+                videoSizeBytes,
+                durationSec,
+                videoStatus,
+                originalFilename,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    // 챕터는 반드시 특정 강의에 소속되어야 합니다.
+    private static void validateLectureId(Long lectureId) {
+        if (lectureId == null) {
+            throw new DomainRuleViolationException("강의 ID는 필수입니다.");
+        }
+    }
+
+    // 챕터명은 필수입니다.
+    private static void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new DomainRuleViolationException("챕터명은 필수입니다.");
+        }
+    }
+
+    // 챕터 순서는 1 이상이어야 합니다.
+    private static void validateOrderNo(int orderNo) {
+        if (orderNo < 1) {
+            throw new DomainRuleViolationException("챕터 순서는 1 이상이어야 합니다.");
+        }
+    }
+
+    // 동영상 상태는 기본값을 포함해 항상 존재해야 합니다.
+    private static void validateVideoStatus(VideoStatus videoStatus) {
+        if (videoStatus == null) {
+            throw new DomainRuleViolationException("동영상 상태는 필수입니다.");
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getLectureId() {
+        return lectureId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getOrderNo() {
+        return orderNo;
+    }
+
+    public String getVideoUrl() {
+        return videoUrl;
+    }
+
+    public Long getVideoSizeBytes() {
+        return videoSizeBytes;
+    }
+
+    public Integer getDurationSec() {
+        return durationSec;
+    }
+
+    public VideoStatus getVideoStatus() {
+        return videoStatus;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/VideoStatus.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/VideoStatus.java
@@ -1,0 +1,16 @@
+package com.wanted.momocity.lecture.domain.model;
+
+// 챕터 동영상 처리 상태입니다.
+public enum VideoStatus {
+    // 챕터 생성 직후 또는 동영상 업로드 전 기본 상태
+    UPLOADING,
+
+    // 동영상 인코딩 중인 상태
+    ENCODING,
+
+    // 동영상 재생이 가능한 상태
+    READY,
+
+    // 업로드 또는 인코딩에 실패한 상태
+    FAILED
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
@@ -1,0 +1,20 @@
+package com.wanted.momocity.lecture.domain.repository;
+
+
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+
+// ChapterRepository는 챕터 도메인이 필요로 하는 저장소
+// 실제 JPA 구현은 infrastructure 계층에서 담당
+public interface ChapterRepository {
+
+    // 챕터를 저장
+    LectureChapter save(LectureChapter chapter);
+
+    // 특정 강의에 등록된 챕터 개수를 조회
+    int countByLectureId(Long lectureId);
+
+    // 같은 강의 안에서 동일한 orderNo가 이미 사용 중인지 확인
+    boolean existsByLectureIdAndOrderNo(Long lectureId, int orderNo);
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
@@ -1,0 +1,41 @@
+package com.wanted.momocity.lecture.infrastructure.adapter;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
+import com.wanted.momocity.lecture.infrastructure.persistence.ChapterJpaEntity;
+import com.wanted.momocity.lecture.infrastructure.persistence.SpringDataChapterRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+// ChapterRepositoryAdapter는 도메인 Repository를 JPA Repository와 연결합니다.
+@Repository
+public class ChapterRepositoryAdapter implements ChapterRepository {
+
+    private final SpringDataChapterRepository repository;
+
+    public ChapterRepositoryAdapter(SpringDataChapterRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public LectureChapter save(LectureChapter chapter) {
+        ChapterJpaEntity entity = ChapterJpaEntity.from(chapter);
+
+        ChapterJpaEntity saved = repository.save(entity);
+
+        return saved.toDomain();
+    }
+
+    @Override
+    public int countByLectureId(Long lectureId) {
+        return repository.countByLectureId(lectureId);
+    }
+
+    @Override
+    public boolean existsByLectureIdAndOrderNo(Long lectureId, int orderNo) {
+        return repository.existsByLectureIdAndOrderNo(lectureId, orderNo);
+    }
+    
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/ChapterJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/ChapterJpaEntity.java
@@ -1,0 +1,143 @@
+package com.wanted.momocity.lecture.infrastructure.persistence;
+
+import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
+import jakarta.persistence.*;
+
+// ChapterJpaEntity는 chapter 테이블과 매핑되는 JPA Entity입니다.
+// 도메인 모델이 아니라 DB 저장용 객체입니다.
+@Entity
+@Table(name = "chapter")
+public class ChapterJpaEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 강의에 소속된 챕터인지 나타냅니다.
+    @Column(name = "lecture_id", nullable = false)
+    private Long lectureId;
+
+    // 챕터 제목입니다.
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    // 강의 내 챕터 노출 순서입니다.
+    @Column(name = "order_no", nullable = false)
+    private int orderNo;
+
+    // 동영상 S3 URL입니다. 챕터 등록 시점에는 null일 수 있습니다.
+    @Column(name = "video_url", length = 500)
+    private String videoUrl;
+
+    // 동영상 파일 크기입니다. 동영상 등록 전에는 null일 수 있습니다.
+    @Column(name = "video_size_bytes")
+    private Long videoSizeBytes;
+
+    // 동영상 재생 시간입니다. 인코딩 전에는 null일 수 있습니다.
+    @Column(name = "duration_sec")
+    private Integer durationSec;
+
+    // 동영상 처리 상태입니다.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "video_status", nullable = false, length = 30)
+    private VideoStatus videoStatus;
+
+    // 원본 동영상 파일명입니다. 동영상 등록 전에는 null일 수 있습니다.
+    @Column(name = "original_filename", length = 255)
+    private String originalFilename;
+
+    protected ChapterJpaEntity() {
+    }
+
+    private ChapterJpaEntity(
+            Long id,
+            Long lectureId,
+            String title,
+            int orderNo,
+            String videoUrl,
+            Long videoSizeBytes,
+            Integer durationSec,
+            VideoStatus videoStatus,
+            String originalFilename
+    ) {
+        this.id = id;
+        this.lectureId = lectureId;
+        this.title = title;
+        this.orderNo = orderNo;
+        this.videoUrl = videoUrl;
+        this.videoSizeBytes = videoSizeBytes;
+        this.durationSec = durationSec;
+        this.videoStatus = videoStatus;
+        this.originalFilename = originalFilename;
+    }
+
+    // 도메인 모델을 JPA Entity로 변환합니다.
+    public static ChapterJpaEntity from(LectureChapter chapter) {
+        return new ChapterJpaEntity(
+                chapter.getId(),
+                chapter.getLectureId(),
+                chapter.getTitle(),
+                chapter.getOrderNo(),
+                chapter.getVideoUrl(),
+                chapter.getVideoSizeBytes(),
+                chapter.getDurationSec(),
+                chapter.getVideoStatus(),
+                chapter.getOriginalFilename()
+        );
+    }
+
+    // JPA Entity를 도메인 모델로 복원합니다.
+    public LectureChapter toDomain() {
+        return LectureChapter.restore(
+                id,
+                lectureId,
+                title,
+                orderNo,
+                videoUrl,
+                videoSizeBytes,
+                durationSec,
+                videoStatus,
+                originalFilename,
+                getCreatedAt(),
+                getUpdatedAt()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getLectureId() {
+        return lectureId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getOrderNo() {
+        return orderNo;
+    }
+
+    public String getVideoUrl() {
+        return videoUrl;
+    }
+
+    public Long getVideoSizeBytes() {
+        return videoSizeBytes;
+    }
+
+    public Integer getDurationSec() {
+        return durationSec;
+    }
+
+    public VideoStatus getVideoStatus() {
+        return videoStatus;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -172,4 +172,5 @@ public class LectureRepositoryAdapter implements LectureRepository {
                 entity.getUpdatedAt()
         );
     }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
@@ -1,0 +1,13 @@
+package com.wanted.momocity.lecture.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// SpringDataChapterRepository는 Spring Data JPA 전용 Repository
+public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEntity, Long> {
+
+    // 특정 강의에 등록된 챕터 개수를 조회
+    int countByLectureId(Long lectureId);
+
+    // 같은 강의 안에서 동일한 orderNo가 이미 있는지 확인
+    boolean existsByLectureIdAndOrderNo(Long lectureId, int orderNo);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureExceptionHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.wanted.momocity.lecture.presentation.api;
+
+import com.wanted.momocity.global.presentation.api.common.ApiErrorResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.domain.exception.ChapterLimitExceededException;
+import com.wanted.momocity.lecture.domain.exception.DuplicateChapterOrderException;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// lecture 패키지에서 발생하는 전용 예외를 API 응답으로 변환
+@RestControllerAdvice(basePackages = "com.wanted.momocity.lecture")
+public class LectureExceptionHandler {
+
+    // 강의를 찾을 수 없는 경우 404로 응답
+    @ExceptionHandler(LectureNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleLectureNotFound(
+            LectureNotFoundException exception
+    ) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.NOT_FOUND.value(),
+                        ApiResponseCode.NOT_FOUND,
+                        exception.getMessage()
+                ));
+    }
+
+    // 챕터 순서가 중복된 경우 409로 응답
+    @ExceptionHandler(DuplicateChapterOrderException.class)
+    public ResponseEntity<ApiErrorResponse> handleDuplicateChapterOrder(
+            DuplicateChapterOrderException exception
+    ) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.CONFLICT.value(),
+                        ApiResponseCode.DOMAIN_RULE_VIOLATION,
+                        exception.getMessage()
+                ));
+    }
+
+    // 챕터 최대 개수를 초과한 경우 409로 응답합니다.
+    @ExceptionHandler(ChapterLimitExceededException.class)
+    public ResponseEntity<ApiErrorResponse> handleChapterLimitExceeded(
+            ChapterLimitExceededException exception
+    ) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.CONFLICT.value(),
+                        ApiResponseCode.DOMAIN_RULE_VIOLATION,
+                        exception.getMessage()
+                ));
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -3,9 +3,13 @@ package com.wanted.momocity.lecture.presentation.api;
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.presentation.api.request.CreateChapterRequest;
 import com.wanted.momocity.lecture.presentation.api.request.CreateLectureRequest;
+import com.wanted.momocity.lecture.presentation.api.response.CreateChapterResponse;
 import com.wanted.momocity.lecture.presentation.api.response.CreateLectureResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,12 +27,15 @@ import org.springframework.web.bind.annotation.*;
 public class TeacherLectureController {
 
     private final LectureCommandUseCase lectureCommandUseCase;
+    private final ChapterCommandUseCase chapterCommandUseCase;
     private final S3UploadPort s3UploadPort;
     public TeacherLectureController(
             LectureCommandUseCase lectureCommandUseCase,
+            ChapterCommandUseCase chapterCommandUseCase,
             S3UploadPort s3UploadPort
     ) {
         this.lectureCommandUseCase = lectureCommandUseCase;
+        this.chapterCommandUseCase = chapterCommandUseCase;
         this.s3UploadPort = s3UploadPort;
     }
 
@@ -64,4 +71,33 @@ public class TeacherLectureController {
                         CreateLectureResponse.from(lecture)
                 ));
     }
+
+    // 챕터 등록 API
+    // 챕터 기본 정보만 JSON으로 받고, 동영상은 별도 API에서 form-data로 등록
+    @PostMapping("/{lectureId}/chapters")
+    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
+    public ResponseEntity<ApiResponse<CreateChapterResponse>> createChapter(
+            Authentication authentication,
+            @PathVariable Long lectureId,
+            @Valid @RequestBody CreateChapterRequest request
+    ) {
+        // Authorization 토큰에서 로그인한 강사의 email을 가져옴
+        String teacherEmail = authentication.getName();
+
+        // Request DTO를 application 계층의 Command로 변환
+        var command = request.toCommand(teacherEmail, lectureId);
+
+        // 챕터 등록 유스케이스를 실행
+        LectureChapter chapter = chapterCommandUseCase.createChapter(command);
+
+        // 201 Created 응답을 반환
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        ApiResponseCode.CREATED,
+                        "챕터가 등록되었습니다.",
+                        CreateChapterResponse.from(chapter)
+                ));
+    }
+
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateChapterRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateChapterRequest.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.lecture.presentation.api.request;
+
+import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+// CreateChapterRequest는 챕터 등록 JSON 요청을 받는 DTO
+public record CreateChapterRequest(
+        // 챕터명은 필수
+        @NotBlank(message = "챕터명은 필수입니다.")
+        String title,
+
+        // 챕터 순서는 1 이상
+        @Min(value = 1, message = "챕터 순서는 1 이상이어야 합니다.")
+        int orderNo
+) {
+
+    // Controller에서 받은 요청값을 application 계층의 Command로 변환
+    public CreateChapterCommand toCommand(String teacherEmail, Long lectureId) {
+        return new CreateChapterCommand(
+                teacherEmail,
+                lectureId,
+                title,
+                orderNo
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/CreateChapterResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/CreateChapterResponse.java
@@ -1,0 +1,38 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+import java.time.LocalDateTime;
+
+// CreateChapterResponse는 챕터 등록 성공 시 프론트에 내려주는 응답 DTO입니다.
+public record CreateChapterResponse(
+        Long chapterId,
+        Long lectureId,
+        String title,
+        int orderNo,
+        String videoUrl,
+        Long videoSizeBytes,
+        Integer durationSec,
+        String videoStatus,
+        String originalFilename,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    // 도메인 모델 LectureChapter를 응답 DTO로 변환합니다.
+    public static CreateChapterResponse from(LectureChapter chapter) {
+        return new CreateChapterResponse(
+                chapter.getId(),
+                chapter.getLectureId(),
+                chapter.getTitle(),
+                chapter.getOrderNo(),
+                chapter.getVideoUrl(),
+                chapter.getVideoSizeBytes(),
+                chapter.getDurationSec(),
+                chapter.getVideoStatus().name(),
+                chapter.getOriginalFilename(),
+                chapter.getCreatedAt(),
+                chapter.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 강사 챕터 등록 API를 추가했습니다.
- `POST /api/v1/teacher/lectures/{lectureId}/chapters` 경로로 챕터를 등록할 수 있도록 구현했습니다.
- 챕터 등록 요청은 `application/json`으로 처리합니다.
- 챕터 등록 시 `title`, `orderNo` 값을 받도록 구성했습니다.
- 챕터 도메인 모델 `LectureChapter`를 추가했습니다.
- 챕터 동영상 상태 enum `VideoStatus`를 추가했습니다.
- 챕터 저장을 위한 Repository, JPA Entity, Spring Data JPA Repository, Adapter를 추가했습니다.
- 챕터 등록 UseCase, Command, Service를 추가했습니다.
- 챕터 등록 응답 DTO를 추가했습니다.
- 챕터 등록 관련 예외를 추가하고 상태 코드에 맞게 응답하도록 처리했습니다.
---
## 처리 흐름

```text
Frontend
→ POST /api/v1/teacher/lectures/{lectureId}/chapters
→ Authorization: Bearer {access_token}
→ Content-Type: application/json
→ title, orderNo 전달
```
---

## 코드 흐름
TeacherLectureController
→ 로그인 강사 email 조회
→ CreateChapterRequest를 CreateChapterCommand로 변환
→ ChapterCommandUseCase 호출

ChapterCommandService
→ teacherEmail로 teacherId 조회
→ lectureId로 강의 조회
→ 본인 강의인지 확인
→ 현재 챕터 개수 확인
→ 최대 5개 초과 여부 확인
→ 동일 강의 내 orderNo 중복 확인
→ LectureChapter 생성
→ ChapterRepository 저장

ChapterRepositoryAdapter
→ LectureChapter를 ChapterJpaEntity로 변환
→ SpringDataChapterRepository로 저장
→ 저장된 Entity를 LectureChapter로 복원

Response
→ CreateChapterResponse 반환

---
##검증 사항
- 챕터명은 필수입니다.
- 챕터 순서는 1 이상이어야 합니다.
- 본인이 등록한 강의에만 챕터를 등록할 수 있습니다.
- 한 강의에는 최대 5개의 챕터만 등록할 수 있습니다.
- 동일 강의 내 orderNo는 중복될 수 없습니다.
- 존재하지 않는 강의에는 챕터를 등록할 수 없습니다.
---
## 예외 처리
- 입력값 검증 실패: 400 Bad Request
- 강의 없음: 404 Not Found
- 본인 강의가 아님: 403 Forbidden
- 챕터 순서 중복: 409 Conflict
- 챕터 최대 개수 초과: 409 Conflict