### PR TITLE
[PR] ErrorLogQueryService stub 패턴 일관화 (AdminDashboardQueryService 와 정렬) (김민섭)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/ErrorLogQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/ErrorLogQueryService.java
@@ -1,7 +1,6 @@
 package com.wanted.momocity.admin.application.service;
 
 import com.wanted.momocity.admin.application.usecase.ErrorLogQueryUseCase;
-import com.wanted.momocity.admin.domain.audit.ErrorLogRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,10 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ErrorLogQueryService implements ErrorLogQueryUseCase {
 
-    private final ErrorLogRepository errorLogRepository;
+    /* comment.
+        m03 우선순위에서 추가될 의존성 :
+        - private final ErrorLogRepository errorLogRepository;
 
-    public ErrorLogQueryService(ErrorLogRepository errorLogRepository) {
-        this.errorLogRepository = errorLogRepository;
+        현재는 ErrorLogRepository 의 구현체(JPA Adapter)가 아직 없어서 주입 보류.
+        ErrorLogRepositoryAdapter 추가되면 생성자 주입으로 전환.
+        (AdminDashboardQueryService 와 동일 패턴 - stub 단계)
+     */
+    public ErrorLogQueryService() {
+        // m03 우선순위 - ErrorLogRepository 주입 예정
     }
 
     /* comment.

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/package-info.java
@@ -1,2 +1,0 @@
-/** 신고 - 도메인 계층 (순수 비즈니스 규칙. 데이터베이스/HTTP 의존성 없음). */
-package com.wanted.momocity.report.domain;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/repository/ReportRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/repository/ReportRepository.java
@@ -1,0 +1,28 @@
+package com.wanted.momocity.report.domain.repository;
+
+import com.wanted.momocity.report.domain.model.Report;
+import com.wanted.momocity.report.domain.model.ReportStatus;
+
+import java.util.List;
+
+/* comment.
+    ReportRepository 정리
+    1. 해당 클래스가 하는 일 : 신고(Report) 도메인 영속화 계약.
+    2. 도메인 계층에 인터페이스를 둠
+       → DIP. 도메인이 약속만 정의, 인프라가 구현.
+    3. limit(N) 방식
+       → 관리자 위젯이 작아 페이지네이션 불필요 (ErrorLogRepository 와 동일 정책).
+    4. findById / countByStatus 미선언
+       → YAGNI. module04 검토 기능 들어갈 때 추가.
+ */
+public interface ReportRepository {
+
+    // 신규 신고 저장
+    Report save(Report report);
+
+    // 최근 신고 N개 (reportedAt DESC)
+    List<Report> findRecent(int limit);
+
+    // 특정 상태의 최근 신고 N개
+    List<Report> findByStatus(ReportStatus status, int limit);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/package-info.java
@@ -1,2 +1,0 @@
-/** 신고 - 인프라 계층 (데이터베이스 어댑터, 외부 연동). */
-package com.wanted.momocity.report.infrastructure;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportJpaEntity.java
@@ -1,0 +1,105 @@
+package com.wanted.momocity.report.infrastructure.persistence;
+
+import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+/* comment.
+    ReportJpaEntity 정리
+    1. 역할 : report 테이블과 1:1 매핑되는 JPA 저장 모델
+    2. 신고 영역 단독 소유 : 다른 BC 는 이 클래스에 직접 매핑 금지
+    3. Report 도메인 모델과의 관계
+       - 같은 신고를 표현하지만 완전히 별개 클래스
+       - 변환 책임은 ReportRepositoryAdapter 가 가짐
+    4. WHY BaseTimeEntity 상속
+       → created_at / updated_at 자동 채움 (@CreatedDate / @LastModifiedDate)
+       → reportedAt 과는 의미 분리 (도메인 의도 vs DB row 메타)
+    5. WHY enum → String 매핑
+       → targetType / reason / status 는 도메인에서 enum, 여기선 String
+       → Adapter 가 enum.name() ↔ Enum.valueOf() 변환
+       → member / lecture 와 동일 정책 (일관성)
+ */
+@Entity
+@Table(name = "report")
+public class ReportJpaEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "reporter_user_id", nullable = false)
+    private Long reporterUserId;
+
+    @Column(name = "target_type", nullable = false, length = 20)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "reason", nullable = false, length = 30)
+    private String reason;
+
+    @Column(name = "detail", length = 1000)
+    private String detail;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "reported_at", nullable = false)
+    private LocalDateTime reportedAt;
+
+    @Column(name = "handled_at")
+    private LocalDateTime handledAt;
+
+    @Column(name = "handler_admin_id")
+    private Long handlerAdminId;
+
+    // JPA 기본 생성자 (protected) : 외부 직접 인스턴스화 차단, JPA 가 리플렉션으로 사용
+    protected ReportJpaEntity() {
+    }
+
+    // Adapter 의 toEntity() 가 호출하는 전체 필드 생성자
+    public ReportJpaEntity(Long id, Long reporterUserId, String targetType, Long targetId,
+                           String reason, String detail, String status,
+                           LocalDateTime reportedAt, LocalDateTime handledAt, Long handlerAdminId) {
+        this.id = id;
+        this.reporterUserId = reporterUserId;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.reason = reason;
+        this.detail = detail;
+        this.status = status;
+        this.reportedAt = reportedAt;
+        this.handledAt = handledAt;
+        this.handlerAdminId = handlerAdminId;
+    }
+
+    // 영속화 모델 메서드 (도메인 행위 아님)
+    // 도메인 검증/규칙은 Report.review / confirm / reject 가 담당, 여기는 단순 필드 변경만
+    public void changeStatus(String status) {
+        this.status = status;
+    }
+
+    public void markHandled(LocalDateTime handledAt, Long handlerAdminId) {
+        this.handledAt = handledAt;
+        this.handlerAdminId = handlerAdminId;
+    }
+
+    public Long getId() { return id; }
+    public Long getReporterUserId() { return reporterUserId; }
+    public String getTargetType() { return targetType; }
+    public Long getTargetId() { return targetId; }
+    public String getReason() { return reason; }
+    public String getDetail() { return detail; }
+    public String getStatus() { return status; }
+    public LocalDateTime getReportedAt() { return reportedAt; }
+    public LocalDateTime getHandledAt() { return handledAt; }
+    public Long getHandlerAdminId() { return handlerAdminId; }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportRepositoryAdapter.java
@@ -1,0 +1,97 @@
+package com.wanted.momocity.report.infrastructure.persistence;
+
+import com.wanted.momocity.report.domain.model.Report;
+import com.wanted.momocity.report.domain.model.ReportReason;
+import com.wanted.momocity.report.domain.model.ReportStatus;
+import com.wanted.momocity.report.domain.model.ReportTargetType;
+import com.wanted.momocity.report.domain.repository.ReportRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/* comment.
+    ReportRepositoryAdapter 정리
+    1. 역할 : 도메인 ReportRepository 인터페이스 JPA 로 구현하는 어댑터 역할
+    2. 위치 : 인프라 계층
+    3. 핵심 책임
+       - 도메인 Report 모델 <-> ReportJpaEntity 변환
+       - SpringDataRepository 호출을 감싸 도메인이 인프라를 모르게 격리해버린다.
+    4. WHY 의존 방향 (클린 아키텍처)
+       → SpringDataRepository 주입하고 같은 계층을 호출한다
+       → Report 사용을 하게 된다. 인프라는 도메인을 알아도 괜찮다.
+       → 하지만 도메인은 이 클래스의 존재를 몰라야한다. (오직 인터페이스만 봐야함)
+    5. WHY @Transactional 클래스 레벨 + 메서드 readOnly 오버라이드
+       → 클래스 레벨 : 쓰기 트랜젝션 기본값 save 같이 데이터 변경처럼 민감한 작업의 안정성 보장
+       → 조회 메서드만 오버라이드할 경우 성능 최적화가 가능하기 때문이다.
+ */
+@Repository
+@Transactional
+public class ReportRepositoryAdapter implements ReportRepository {
+
+    private final SpringDataReportRepository repository;
+
+    public ReportRepositoryAdapter(SpringDataReportRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Report save(Report report) {
+        ReportJpaEntity entity = toEntity(report);
+        ReportJpaEntity saved = repository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Report> findRecent(int limit) {
+        return repository.findAllByOrderByReportedAtDesc(PageRequest.of(0, limit))
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Report> findByStatus(ReportStatus status, int limit) {
+        return repository.findAllByStatusOrderByReportedAtDesc(status.name(), PageRequest.of(0, limit))
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    // === 변환 메서드 (도메인 ↔ 엔티티) ===
+
+    // 도메인 → 엔티티 (신규 저장 시 id=null, JPA 가 auto-increment 부여)
+    private ReportJpaEntity toEntity(Report report) {
+        return new ReportJpaEntity(
+                report.getId(),
+                report.getReporterUserId(),
+                report.getTargetType().name(),
+                report.getTargetId(),
+                report.getReason().name(),
+                report.getDetail(),
+                report.getStatus().name(),
+                report.getReportedAt(),
+                report.getHandledAt(),
+                report.getHandlerAdminId()
+        );
+    }
+
+    // 엔티티 → 도메인 (DB 복원 - Report.restore() 사용)
+    private Report toDomain(ReportJpaEntity entity) {
+        return Report.restore(
+                entity.getId(),
+                entity.getReporterUserId(),
+                ReportTargetType.valueOf(entity.getTargetType()),
+                entity.getTargetId(),
+                ReportReason.valueOf(entity.getReason()),
+                entity.getDetail(),
+                ReportStatus.valueOf(entity.getStatus()),
+                entity.getReportedAt(),
+                entity.getHandledAt(),
+                entity.getHandlerAdminId()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/SpringDataReportRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/SpringDataReportRepository.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.report.infrastructure.persistence;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/* comment.
+    SpringDataReportRepository 정리
+    1. 역할 : Spring Data Jpa 가 런타임에 자동으로 구현체를 만들어주는 저장소 인터페이스
+    2. 위치 : 인프라 계층
+    3. 누가 호출하는가 : ReportRepositoryAdapter 가 주입받아서 호출하게 된다. (외부에 노출되지 않는다)
+    4. WHY 도메인 ReportRepository 와 별도로 두는가
+       → ReportRepository : Report 도메인 모델을 다룬다
+       → Spring 기술 인터페이스, ReportJpaEntity 를 다룬다.
+       → 둘을 이어주는 다리가 ReportRepositoryAdapter 변환하고 격리하는 담당한다.
+    5. WHY Pageable 을 limit 처럼 쓰는가
+       → 전체 페이지네이션은 불필요하기 때문이다.
+ */
+public interface SpringDataReportRepository extends JpaRepository<ReportJpaEntity, Long> {
+
+    // 최근 N개 (reportedAt DESC) - Adapter 에서 PageRequest.of(0, limit) 으로 호출
+    List<ReportJpaEntity> findAllByOrderByReportedAtDesc(Pageable pageable);
+
+    // 특정 상태의 최근 N개 (reportedAt DESC)
+    List<ReportJpaEntity> findAllByStatusOrderByReportedAtDesc(String status, Pageable pageable);
+}


### PR DESCRIPTION
## 🚨 증상

`./gradlew bootRun` 실행 시 앱 부팅 실패.

```
APPLICATION FAILED TO START

Description:
Parameter 0 of constructor in 
com.wanted.momocity.admin.application.service.ErrorLogQueryService 
required a bean of type 
'com.wanted.momocity.admin.domain.audit.ErrorLogRepository' 
that could not be found.
```

자바 **컴파일은 통과**하지만 Spring 빈 등록 단계에서 런타임 실패.

---

## 🔍 원인

`ErrorLogQueryService` 는 module03 stub 단계 (본문이 `throw new UnsupportedOperationException(...)`) 임에도 **생성자에서 `ErrorLogRepository` 의존성을 받고 있음**.

```java
// 문제의 코드
private final ErrorLogRepository errorLogRepository;

public ErrorLogQueryService(ErrorLogRepository errorLogRepository) {
    this.errorLogRepository = errorLogRepository;
}
```

그러나 `ErrorLogRepository` 의 **구현체(JPA Adapter)는 아직 미작성** (m03 우선순위에서 채울 예정). Spring 이 인터페이스에 대한 빈을 찾지 못해 부팅 실패.

### 패턴 일관성 깨짐

같은 admin/ 영역의 `AdminDashboardQueryService` 는 **빈 생성자** 사용 (의존성 보류 패턴):

```java
public AdminDashboardQueryService() {
    // m03 우선순위 - 의존성 주입 예정
}
```

→ 두 서비스가 같은 stub 단계인데 패턴이 달라 일관성 깨짐.

---

## 🎯 해결 방향

`AdminDashboardQueryService` 와 동일한 stub 패턴 적용:

1. 의존성 필드 제거 (`private final ErrorLogRepository ...` 삭제)
2. 빈 생성자 사용
3. 미사용 import 정리 (`ErrorLogRepository`)
4. 주석으로 m03 우선순위에서 주입 예정임을 명시

---

## 📚 교훈

- **컴파일 통과 ≠ 런타임 정상** — Spring 빈 등록은 런타임 검증
- stub 단계에서는 **의존성 주입을 보류하는 패턴 일관 적용** 필수
- 한 영역 내에서 같은 단계의 서비스들은 같은 stub 패턴 사용

---

## 우선순위

**High** — 앱 부팅 자체가 막힘.