### PR TITLE
[PR] 동영상 등록 메서드 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/RegisterChapterVideoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/RegisterChapterVideoCommand.java
@@ -1,0 +1,22 @@
+package com.wanted.momocity.lecture.application.command;
+
+import org.springframework.web.multipart.MultipartFile;
+
+/*
+*   챕터 동영상 등록은 유스케이스에 필요한 값을 담은 command
+*   Controller는 HTTTP 요청을 받고, Service는 이 Commnad만 보고 비즈니스 로직 처리
+* */
+public record RegisterChapterVideoCommand(
+        // Authorization 토큰에서 꺼낸 로그인 강사 Email
+        String teacherEmail,
+        // 강의 Id
+        Long lectureId,
+        // 챕터 Id
+        Long chapterId,
+        // form-data로 받은 실제 동영상 파일
+        MultipartFile video,
+        // 동영상 재생 시간
+        Integer durationSec
+
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
@@ -1,11 +1,12 @@
 package com.wanted.momocity.lecture.application.service;
 
+import com.wanted.momocity.global.application.s3.S3UploadPort;
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
 import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
+import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
 import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
-import com.wanted.momocity.lecture.domain.exception.ChapterLimitExceededException;
-import com.wanted.momocity.lecture.domain.exception.DuplicateChapterOrderException;
-import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import com.wanted.momocity.lecture.domain.exception.*;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
 import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
@@ -21,19 +22,25 @@ public class ChapterCommandService implements ChapterCommandUseCase {
 
     // 한 강의에 등록 가능한 최대 챕터 개수입니다.
     private static final int MAX_CHAPTER_COUNT = 5;
+    // 챕터 동영상은 500MB까지만 업로드 가능
+    private static final long MAX_VIDEO_SIZE_BYTES = 500 * 1024 * 1024;
 
     private final ChapterRepository chapterRepository;
     private final LectureRepository lectureRepository;
     private final TeacherAccountPort teacherAccountPort;
+    private final S3UploadPort s3UploadPort;
+
 
     public ChapterCommandService(
             ChapterRepository chapterRepository,
             LectureRepository lectureRepository,
-            TeacherAccountPort teacherAccountPort
+            TeacherAccountPort teacherAccountPort,
+            S3UploadPort s3UploadPort
     ) {
         this.chapterRepository = chapterRepository;
         this.lectureRepository = lectureRepository;
         this.teacherAccountPort = teacherAccountPort;
+        this.s3UploadPort = s3UploadPort;
     }
 
     @Override
@@ -78,5 +85,58 @@ public class ChapterCommandService implements ChapterCommandUseCase {
 
         // 생성된 챕터를 저장합니다.
         return chapterRepository.save(chapter);
+    }
+
+    @Override
+    public LectureChapter registerChapterVideo(RegisterChapterVideoCommand command) {
+        // Authrization 토큰에서 가져온 email로 강사 Id 조회
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+
+        // 동영상을 등록할 강의를 조회
+        LectureAggregate lecture = lectureRepository.findById(command.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 본인이 등록한 강읭에만 동영상을 등록 할 수 있음
+        if (!lecture.isOwnedBy(teacherId)) {
+            throw new AccessDeniedException("본인이 등록한 강의의 챕터에만 동영상을 등록 할 수 있습니다.");
+        }
+
+        // 동영상을 등록할 챕터를 조회
+        LectureChapter chapter = chapterRepository.findById(command.chapterId())
+                .orElseThrow(() -> new ChapterNotFoundException("챕터를 찾을 수 없습니다."));
+
+        // 요청한 챕터가 요청한 강의에 속해 있는지 확인합니다.
+        if (!chapter.belongsTo(command.lectureId())) {
+            throw new ChapterNotFoundException("유효하지 않은 챕터 식별자입니다.");
+        }
+
+        // 하나의 챕터에는 하나의 동영상만 등록할 수 있습니다.
+        if (chapter.hasVideo()) {
+            throw new ChapterVideoAlreadyExistsException("이미 동영상이 등록된 챕터입니다.");
+        }
+
+        // 파일이 비어 있거나 전달되지 않은 경우를 막습니다.
+        if (command.video() == null || command.video().isEmpty()) {
+            throw new DomainRuleViolationException("동영상 파일은 필수입니다.");
+        }
+
+        // S3 업로드 전에 500MB 제한을 먼저 검증합니다.
+        if (command.video().getSize() > MAX_VIDEO_SIZE_BYTES) {
+            throw new DomainRuleViolationException("동영상 파일 크기는 500MB 이하만 가능합니다.");
+        }
+
+        // 모든 검증이 끝난 뒤 S3에 업로드합
+        String videoUrl = s3UploadPort.upload(command.video());
+
+        // S3 URL과 파일 정보를 챕터 도메인에 반영합니다.
+        LectureChapter updatedChapter = chapter.registerVideo(
+                videoUrl,
+                command.video().getSize(),
+                command.durationSec(),
+                command.video().getOriginalFilename()
+        );
+
+        // 변경된 챕터 정보를 저장합니다.
+        return chapterRepository.save(updatedChapter);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/ChapterCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/ChapterCommandUseCase.java
@@ -1,6 +1,7 @@
 package com.wanted.momocity.lecture.application.usecase;
 
 import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
+import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
 
 // ChapterCommandUseCase는 챕터 상태를 변경하는 기능
@@ -8,4 +9,7 @@ public interface ChapterCommandUseCase {
 
     // 챕터를 등록
     LectureChapter createChapter(CreateChapterCommand command);
+
+    // 동영상 등록
+    LectureChapter registerChapterVideo(RegisterChapterVideoCommand command);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/ChapterNotFoundException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/ChapterNotFoundException.java
@@ -1,0 +1,12 @@
+package com.wanted.momocity.lecture.domain.exception;
+
+/*
+ * 요청한 챕터를 찾을 수 없을 때 사용하는 예외
+ * 동영상 등록, 챕터 수정/삭제에서도 사용 가능
+ */
+public class ChapterNotFoundException extends RuntimeException {
+
+    public ChapterNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/ChapterVideoAlreadyExistsException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/exception/ChapterVideoAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.wanted.momocity.lecture.domain.exception;
+
+/*
+ * 이미 동영상이 등록된 챕터에 다시 동영상을 등록하려고 할 때 사용하는 예외
+ * 하나의 챕터에는 하나의 동영상만 연결할 수 있다는 정책을 표현
+ */
+public class ChapterVideoAlreadyExistsException extends RuntimeException {
+
+    public ChapterVideoAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureChapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureChapter.java
@@ -5,8 +5,8 @@ import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationExc
 
 import java.time.LocalDateTime;
 
-// LectureChapter는 강의에 소속된 챕터 도메인 모델입니다.
-// 챕터의 제목, 순서, 동영상 상태 정보를 관리합니다.
+// LectureChapter는 강의에 소속된 챕터 도메인
+// 챕터의 제목, 순서, 동영상 상태 정보를 관리
 public class LectureChapter {
 
     private final Long id;
@@ -52,8 +52,8 @@ public class LectureChapter {
         this.updatedAt = updatedAt;
     }
 
-    // 새 챕터를 등록할 때 사용합니다.
-    // 동영상은 별도 API에서 등록하므로 여기서는 null로 시작합니다.
+    // 새 챕터를 등록할 때 사용
+    // 동영상은 별도 API에서 등록하므로 여기서는 null로 시작
     public static LectureChapter create(
             Long lectureId,
             String title,
@@ -74,7 +74,7 @@ public class LectureChapter {
         );
     }
 
-    // DB에서 조회한 챕터 정보를 도메인 모델로 복원할 때 사용합니다.
+    // DB에서 조회한 챕터 정보를 도메인 모델로 복원할 때 사용
     public static LectureChapter restore(
             Long id,
             Long lectureId,
@@ -103,31 +103,108 @@ public class LectureChapter {
         );
     }
 
-    // 챕터는 반드시 특정 강의에 소속되어야 합니다.
+    /*
+     * 챕터에 동영상을 등록합니다.
+     * 기존 챕터 정보를 유지하면서 동영상 관련 값만 채운 새로운 LectureChapter 객체를 반환합니다.
+     */
+    public LectureChapter registerVideo(
+            String videoUrl,
+            Long videoSizeBytes,
+            Integer durationSec,
+            String originalFilename
+    ) {
+        validateVideoUrl(videoUrl);
+        validateVideoSizeBytes(videoSizeBytes);
+        validateDurationSec(durationSec);
+        validateOriginalFilename(originalFilename);
+
+        return new LectureChapter(
+                id,
+                lectureId,
+                title,
+                orderNo,
+                videoUrl,
+                videoSizeBytes,
+                durationSec,
+                VideoStatus.UPLOADING,
+                originalFilename,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    /*
+     * 이미 동영상이 등록된 챕터인지 확인
+     * 서비스에서 중복 등록을 막을 때 사용
+     */
+    public boolean hasVideo() {
+        return videoUrl != null && !videoUrl.isBlank();
+    }
+
+    /*
+     * 이 챕터가 요청한 강의에 속한 챕터인지 확인
+     * 다른 강의의 챕터에 영상을 등록하는 것을 막기 위해 사용
+     */
+    public boolean belongsTo(Long lectureId) {
+        return this.lectureId.equals(lectureId);
+    }
+
+    // 챕터는 반드시 특정 강의에 소속
     private static void validateLectureId(Long lectureId) {
         if (lectureId == null) {
             throw new DomainRuleViolationException("강의 ID는 필수입니다.");
         }
     }
 
-    // 챕터명은 필수입니다.
+    // 챕터명은 필수
     private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new DomainRuleViolationException("챕터명은 필수입니다.");
         }
     }
 
-    // 챕터 순서는 1 이상이어야 합니다.
+    // 챕터 순서는 1 이상
     private static void validateOrderNo(int orderNo) {
         if (orderNo < 1) {
             throw new DomainRuleViolationException("챕터 순서는 1 이상이어야 합니다.");
         }
     }
 
-    // 동영상 상태는 기본값을 포함해 항상 존재해야 합니다.
+    // 동영상 상태는 기본값을 포함해 항상 존재
     private static void validateVideoStatus(VideoStatus videoStatus) {
         if (videoStatus == null) {
             throw new DomainRuleViolationException("동영상 상태는 필수입니다.");
+        }
+    }
+
+    // S3 업로드 후 반환된 동영상 URL은 필수
+    private static void validateVideoUrl(String videoUrl) {
+        if (videoUrl == null || videoUrl.isBlank()) {
+            throw new DomainRuleViolationException("동영상 URL은 필수입니다.");
+        }
+    }
+
+    /*
+     * 동영상 파일 크기는 1byte 이상
+     * 500MB 초과 검증은 S3 업로드 전 서비스에서 먼저 처리
+     */
+    private static void validateVideoSizeBytes(Long videoSizeBytes) {
+        if (videoSizeBytes == null || videoSizeBytes < 1) {
+            throw new DomainRuleViolationException("동영상 파일 크기는 1MB 이상이어야 합니다.");
+        }
+    }
+
+    // 동영상 재생 시간은 1초 이상
+    private static void validateDurationSec(Integer durationSec) {
+        if (durationSec == null || durationSec < 1) {
+            throw new DomainRuleViolationException("동영상 재생 시간은 1초 이상이어야 합니다.");
+        }
+    }
+
+    // 원본 파일명은 응답과 관리 목적에 필요하므로 필수로 받음
+    private static void validateOriginalFilename(String originalFilename) {
+        if (originalFilename == null || originalFilename.isBlank()) {
+            throw new DomainRuleViolationException("원본 파일명은 필수입니다.");
         }
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
@@ -3,6 +3,8 @@ package com.wanted.momocity.lecture.domain.repository;
 
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
 
+import java.util.Optional;
+
 
 // ChapterRepository는 챕터 도메인이 필요로 하는 저장소
 // 실제 JPA 구현은 infrastructure 계층에서 담당
@@ -17,4 +19,7 @@ public interface ChapterRepository {
     // 같은 강의 안에서 동일한 orderNo가 이미 사용 중인지 확인
     boolean existsByLectureIdAndOrderNo(Long lectureId, int orderNo);
 
+    // chapterId로 기존 챕터를 조회
+    // 동영상 등록은 기존 챕터에 영상 정보를 채우는 작업이라 단건 조회가 필요
+    Optional<LectureChapter> findById(Long chapterId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
@@ -37,5 +37,11 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
     public boolean existsByLectureIdAndOrderNo(Long lectureId, int orderNo) {
         return repository.existsByLectureIdAndOrderNo(lectureId, orderNo);
     }
+
+    @Override
+    public Optional<LectureChapter> findById(Long chapterId) {
+        return repository.findById(chapterId)
+                .map(ChapterJpaEntity::toDomain);
+    }
     
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureExceptionHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureExceptionHandler.java
@@ -2,9 +2,7 @@ package com.wanted.momocity.lecture.presentation.api;
 
 import com.wanted.momocity.global.presentation.api.common.ApiErrorResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
-import com.wanted.momocity.lecture.domain.exception.ChapterLimitExceededException;
-import com.wanted.momocity.lecture.domain.exception.DuplicateChapterOrderException;
-import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import com.wanted.momocity.lecture.domain.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -45,6 +43,32 @@ public class LectureExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleChapterLimitExceeded(
             ChapterLimitExceededException exception
     ) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.CONFLICT.value(),
+                        ApiResponseCode.DOMAIN_RULE_VIOLATION,
+                        exception.getMessage()
+                ));
+    }
+
+    /*
+     * 챕터를 찾을 수 없을 때 404 응답을 반환합니다.
+     */
+    @ExceptionHandler(ChapterNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleChapterNotFound(ChapterNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.NOT_FOUND.value(),
+                        ApiResponseCode.NOT_FOUND,
+                        exception.getMessage()
+                ));
+    }
+
+    /*
+     * 이미 동영상이 등록된 챕터에 다시 등록 요청이 들어오면 409 응답을 반환합니다.
+     */
+    @ExceptionHandler(ChapterVideoAlreadyExistsException.class)
+    public ResponseEntity<ApiErrorResponse> handleChapterVideoAlreadyExists(ChapterVideoAlreadyExistsException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ApiErrorResponse.of(
                         HttpStatus.CONFLICT.value(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -3,14 +3,17 @@ package com.wanted.momocity.lecture.presentation.api;
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
 import com.wanted.momocity.lecture.presentation.api.request.CreateChapterRequest;
 import com.wanted.momocity.lecture.presentation.api.request.CreateLectureRequest;
+import com.wanted.momocity.lecture.presentation.api.request.RegisterChapterVideoRequest;
 import com.wanted.momocity.lecture.presentation.api.response.CreateChapterResponse;
 import com.wanted.momocity.lecture.presentation.api.response.CreateLectureResponse;
+import com.wanted.momocity.lecture.presentation.api.response.RegisterChapterVideoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -74,6 +77,10 @@ public class TeacherLectureController {
 
     // 챕터 등록 API
     // 챕터 기본 정보만 JSON으로 받고, 동영상은 별도 API에서 form-data로 등록
+    @Operation(
+            summary = "챕터 등록",
+            description = "강사가 새로운 챕터를 등록합니다. 챕터는 최소 1개는 무조건 넣어야 되며 최대 5개까지 추가할 수 있습니다."
+    )
     @PostMapping("/{lectureId}/chapters")
     @PreAuthorize("hasAuthority('ROLE_TEACHER')")
     public ResponseEntity<ApiResponse<CreateChapterResponse>> createChapter(
@@ -99,5 +106,46 @@ public class TeacherLectureController {
                 ));
     }
 
+    /*
+     * 챕터 동영상 등록 API
+     * 동영상 파일은 JSON이 아니라 multipart/form-data로 받는다.
+     */
+    @Operation(
+            summary = "동영상 등록",
+            description = "강사가 1개의 챕터에는 무조건 동영상을 추가해야 됩니다. 영상은 최대 500MB까지만 지원 가능합니다." +
+                    "영상을 받을 때는 Form-data로 받습니다."
+    )
+    @PatchMapping(
+            value = "/{lectureId}/chapters/{chapterId}/video",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
+    public ResponseEntity<ApiResponse<RegisterChapterVideoResponse>> registerChapterVideo(
+            Authentication authentication,
+            @PathVariable Long lectureId,
+            @PathVariable Long chapterId,
+            @Valid @ModelAttribute RegisterChapterVideoRequest request
+    ) {
+        // Authorization 토큰에서 로그인한 강사의 email을 가져옵니다.
+        String teacherEmail = authentication.getName();
+
+        // 요청 DTO를 Application 계층에서 사용할 Command로 변환합니다.
+        RegisterChapterVideoCommand command = request.toCommand(
+                teacherEmail,
+                lectureId,
+                chapterId
+        );
+
+        // 챕터 동영상 등록 유스케이스를 실행합니다.
+        LectureChapter chapter = chapterCommandUseCase.registerChapterVideo(command);
+
+        // 200 OK 응답을 반환합니다.
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(
+                        ApiResponseCode.SUCCESS,
+                        "챕터 동영상이 등록되었습니다.",
+                        RegisterChapterVideoResponse.from(chapter)
+                ));
+    }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/RegisterChapterVideoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/RegisterChapterVideoRequest.java
@@ -1,0 +1,44 @@
+package com.wanted.momocity.lecture.presentation.api.request;
+
+import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+/*
+ * 챕터 동영상 등록 요청 DTO입니다.
+ * multipart/form-data 요청에서 video 파일과 durationSec 값을 받습니다.
+ */
+public record RegisterChapterVideoRequest(
+
+        // 업로드할 동영상 파일입니다.
+        @Schema(description = "업로드할 동영상 파일", type = "string", format = "binary")
+        @NotNull(message = "동영상 파일은 필수입니다.")
+        MultipartFile video,
+
+        // 동영상 재생 시간입니다. 1초 이상이어야 합니다.
+        @Schema(description = "동영상 재생 시간(초)", example = "600")
+        @NotNull(message = "동영상 재생 시간은 필수입니다.")
+        @Min(value = 1, message = "동영상 재생 시간은 1초 이상이어야 합니다.")
+        Integer durationSec
+) {
+
+    /*
+     * Presentation 계층의 요청 DTO를 Application 계층의 Command로 변환합니다.
+     * Controller는 HTTP 요청만 알고, Service는 Command만 보고 처리하게 분리합니다.
+     */
+    public RegisterChapterVideoCommand toCommand(
+            String teacherEmail,
+            Long lectureId,
+            Long chapterId
+    ) {
+        return new RegisterChapterVideoCommand(
+                teacherEmail,
+                lectureId,
+                chapterId,
+                video,
+                durationSec
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/RegisterChapterVideoResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/RegisterChapterVideoResponse.java
@@ -1,0 +1,41 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+import java.time.LocalDateTime;
+
+/*
+ * 챕터 동영상 등록 성공 응답 DTO
+ * 도메인 모델 LectureChapter에서 프론트에 필요한 값만 꺼내 응답
+ */
+public record RegisterChapterVideoResponse(
+        Long chapterId,
+        Long lectureId,
+        String title,
+        int orderNo,
+        String videoUrl,
+        Long videoSizeBytes,
+        Integer durationSec,
+        String videoStatus,
+        String originalFilename,
+        LocalDateTime updatedAt
+) {
+
+    /*
+     * LectureChapter 도메인 모델을 응답 DTO로 변환합니다.
+     */
+    public static RegisterChapterVideoResponse from(LectureChapter chapter) {
+        return new RegisterChapterVideoResponse(
+                chapter.getId(),
+                chapter.getLectureId(),
+                chapter.getTitle(),
+                chapter.getOrderNo(),
+                chapter.getVideoUrl(),
+                chapter.getVideoSizeBytes(),
+                chapter.getDurationSec(),
+                chapter.getVideoStatus().name(),
+                chapter.getOriginalFilename(),
+                chapter.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

챕터 동영상 등록 API를 추가했습니다.
기존 챕터 등록은 챕터 기본 정보만 생성하고, 동영상 등록은 별도 API에서 처리하도록 분리했습니다.
동영상 파일은 multipart/form-data로 전달받고, 서버에서 S3에 업로드한 뒤 반환된 URL과 파일 정보를 chapter 테이블의 영상 관련 컬럼에 저장합니다.

---

## 구현 흐름

PATCH /api/v1/teacher/lectures/{lectureId}/chapters/{chapterId}/video
→ Authorization 토큰에서 강사 email 조회
→ email 기준 teacherId 조회
→ 강의 존재 여부 확인
→ 본인이 등록한 강의인지 확인
→ 챕터 존재 여부 확인
→ 챕터가 해당 강의에 속하는지 확인
→ 이미 동영상이 등록된 챕터인지 확인
→ 동영상 파일 필수 여부 확인
→ 동영상 파일 크기 500MB 이하 검증
→ S3 업로드
→ chapter 영상 컬럼 업데이트
→ 응답 반환

---

## 참고 사항

- 현재 ERD 기준 별도 video 테이블은 없고, 영상 정보는 chapter 테이블에 저장합니다.
- 하나의 챕터에는 하나의 동영상만 등록할 수 있습니다.
- S3 업로드는 권한/강의/챕터/파일 크기 검증이 끝난 뒤 실행합니다.
- 동영상 파일 크기는 최대 500MB까지 허용합니다.
- 강의가 최종적으로 공개 가능한지는 추후 강의 상태 변경 API에서 아래 조건으로 검증할 예정입니다.
- 챕터 최소 1개 존재
- 모든 챕터에 동영상 등록 완료
- 

close #134 