### PR TITLE
[PR] Report 신고 접수 API 풀세트 (POST /api/v1/reports)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/command/SubmitReportCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/command/SubmitReportCommand.java
@@ -1,0 +1,30 @@
+package com.wanted.momocity.report.application.command;
+
+import com.wanted.momocity.report.domain.model.ReportReason;
+import com.wanted.momocity.report.domain.model.ReportTargetType;
+
+/* comment.
+    SubmitReportCommand 정리
+    1. 역할 : 신고 접수 UseCase 의 입력 묶음. Controller 가 HTTP 요청을 받아서 이걸로 변환해 Usecase 에 넘겨준다.
+    2. 위치 : 응용 계층 - 입력 객체
+    3. WHY record 사용
+       → 불변하는 객체이기 때문
+    4. WHY Request DTO 가 아니라 Command 라는 별도 객체
+       → 표현 계층 = 응용 계층 분리
+       → Command : 응용 계층
+       → 두 계층을 분리하면 HTTP 구조 바뀌어도 Command 는 안바뀐다.
+    5. 필드 5개 의미
+       - reporterEmail : 신고자의 로그인 email
+       - targetType : 신고 대상 종류
+       - targetId : 신고 대상 ID
+       - reason : 신고 사유 ENUM
+       - detail : 자유 설명
+ */
+public record SubmitReportCommand(
+        String reporterEmail,
+        ReportTargetType targetType,
+        Long targetId,
+        ReportReason reason,
+        String detail
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/package-info.java
@@ -1,2 +1,0 @@
-/** 신고 - 응용 계층 (유스케이스 조립, 트랜잭션 경계). */
-package com.wanted.momocity.report.application;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/port/ReporterAccountPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/port/ReporterAccountPort.java
@@ -1,0 +1,21 @@
+package com.wanted.momocity.report.application.port;
+
+/* comment.
+    ReporterAccountPort 정리
+    1. 역할 : 신고자의 email 을 받아서 내부 PK 로 변환해주는
+    2. 위치 : 응용 계층 - 외부 BC 접근 인터페이스
+    3. WHY Port 패턴 사용
+       → 신고 도메인은 회원 BC 를 직접 import 하면 BC 경계가 깨지기 때문이다.
+       → Port 인터페이스만 응용 계층에만 두고, 실제 회원 조회는 인프라 계층의 Adapter 가 담당하게 된다.
+       → 신고 도메인 코어는 회원 BC 의 존재를 모른다.
+    4. WHY 단일 메서드만 (getReporterId)
+       → 신고가 회원에 대해 알아야할 정보는 userId 밖에 없다.
+       → 회원의 다른 정보에 대해서는 신고 도메인이 알아야할 필요가 없다.
+    5. enrollment 의 StudentAccountPort 와 차이
+       → StudentAccountPort : 학생 권한만 허용 (수강신청은 학생만 가능)
+       → ReporterAccountPort : 모든 회원이 신고 가능하다. role 체크가 없다.
+ */
+public interface ReporterAccountPort {
+
+    Long getReporterId(String email);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportCommandService.java
@@ -1,0 +1,56 @@
+package com.wanted.momocity.report.application.service;
+
+import com.wanted.momocity.report.application.command.SubmitReportCommand;
+import com.wanted.momocity.report.application.port.ReporterAccountPort;
+import com.wanted.momocity.report.application.usecase.ReportCommandUseCase;
+import com.wanted.momocity.report.domain.model.Report;
+import com.wanted.momocity.report.domain.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/* comment.
+    ReportCommandService 정리
+    1. 역할 : ReportCommandUseCase 의 실제 구현체이다. 신고 접수 비즈니스 로직 담당
+    2. 위치 : 응용 계층 - 구현
+    3. WHY @Service + @Transactional (readOnly 아님)
+       → @Service : Spring 이 빈으로 등록, Controller 에 주입됨
+       → @Transactional : 쓰기 트랜젝션 (save 호출 -> DB 변경)
+    4. WHY @RequiredArgsConstructor (Lombok)
+       → final 필드 받는 생성자 자동 생성
+       → 의존성이 늘어나더라도 생성자 코드 건드리지 않게 된다.
+    5. 의존성 2개의 역할
+       - ReporterAccountPort : email -> userId 변환
+       - ReportRepository : 도메인 Report 객체 저장
+    6. submitReport 처리 흐름 4단계
+        a) command.reporterEmail() → ReporterAccountPort.getReporterId() → reporterUserId 획득
+        b) Report.submit() 정적 팩토리로 도메인 객체 생성 (PENDING + now)
+        c) reportRepository.save() 로 영속화
+        d) 저장된 Report (id 부여됨) 반환
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportCommandService implements ReportCommandUseCase {
+
+    private final ReporterAccountPort reporterAccountPort;
+    private final ReportRepository reportRepository;
+
+    @Override
+    public Report submitReport(SubmitReportCommand command) {
+        // 1. email → reporterUserId 변환 (외부 BC 호출)
+        Long reporterUserId = reporterAccountPort.getReporterId(command.reporterEmail());
+
+        // 2. 도메인 정적 팩토리로 신규 Report 생성 (status=PENDING, reportedAt=now)
+        Report report = Report.submit(
+                reporterUserId,
+                command.targetType(),
+                command.targetId(),
+                command.reason(),
+                command.detail()
+        );
+
+        // 3. 저장
+        return reportRepository.save(report);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/usecase/ReportCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/usecase/ReportCommandUseCase.java
@@ -1,0 +1,26 @@
+package com.wanted.momocity.report.application.usecase;
+
+import com.wanted.momocity.report.application.command.SubmitReportCommand;
+import com.wanted.momocity.report.domain.model.Report;
+
+/* comment.
+    ReportCommandUseCase 정리
+    1. 역할 : 신고 접수 응용 계층 계약. Controller 가 의존할 인터페이스이다.
+    실제 구현은 Service 계층에서 하게 된다.
+    2. 위치 : 응용 계층 - 계약
+    3. WHY UseCase 인터페이스로 분리
+       → Controller 가 Service 구현체를 직접 의존하면 DIP 흐름 위반
+       → {DIP 흐름 controller -> usecase 인터페이스 <- service
+       → 인터페이스만 의존 시 구현체 교체 / 테스트 시 Mock 주입 편의
+       → enrollment 의 EnrollmentCommandUseCase 와 동일한 정책
+    4. WHY Command/Query 분리 (CQRS 경량 버전)
+       → command : 데이터 변경
+       → query : 데이터 조회
+    5. WHY Report 도메인 객체를 그대로 반환 (DTO 변환 X)
+       → UseCase 는 도메인 영역의 결과를 그대로 노출하게 된다.
+       → DTO 변환 책임은 Controller -> 표현 계층이 HTTP 응답 형태가 결정된다.
+ */
+public interface ReportCommandUseCase {
+
+    Report submitReport(SubmitReportCommand command);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/adapter/AuthReporterAccountAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/adapter/AuthReporterAccountAdapter.java
@@ -1,0 +1,45 @@
+package com.wanted.momocity.report.infrastructure.adapter;
+
+import com.wanted.momocity.auth.application.port.LoadUserPort;
+import com.wanted.momocity.auth.domain.model.User;
+import com.wanted.momocity.report.application.port.ReporterAccountPort;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Component;
+
+/* comment.
+    AuthReporterAccountAdapter 정리
+    1. 역할 : ReporterAccountPort 인터페이스 auth BC 의 LoadUserPort 로 구현하는 어댑터
+    2. 위치 : 인프라 계층 - 외부 BC 접근 어댑터
+    3. WHY @Component 사용
+       → Spring 이 빈으로 등록 -> Service 에 자동 주입
+       → DB가 아니라 외부 BC 호출이기 때문에 @Repository 어노테이션 대신 @Component 를 사용
+    4. WHY LoadUserPort 를 주입받음
+       → 신고 BC 는 회원 DB 에 직접 접근하면 BC 경계를 침범하게 된다.
+       → auth BC 가 제공하는 LoadUserPort 를 빌려 쓰면 BC 격리 유지
+       → email -> User 변환 책임 auth BC 에 위임
+    5. WHY role 체크 없음 (StudentAccountAdapter 와 차이)
+       → 수강신청은 학생만 가능
+       → 신고는 모든 회원이 가능
+    6. 의존 방향
+       - implements ReporterAccountPort : 인프라가 도메인 약속 지킴
+       - LoadUserPort 주입 : 다른 BC 의 응용 계층
+       - User 사용 : 인프라가 외부 BC 도메인
+ */
+@Component
+public class AuthReporterAccountAdapter implements ReporterAccountPort {
+
+    private final LoadUserPort loadUserPort;
+
+    public AuthReporterAccountAdapter(LoadUserPort loadUserPort) {
+        this.loadUserPort = loadUserPort;
+    }
+
+    @Override
+    public Long getReporterId(String email) {
+        User user = loadUserPort.findByEmail(email)
+                .orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+                        "인증된 사용자 정보를 찾을 수 없습니다."
+                ));
+        return user.getId();
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/ReportController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/ReportController.java
@@ -1,0 +1,94 @@
+package com.wanted.momocity.report.presentation.api;
+
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.report.application.command.SubmitReportCommand;
+import com.wanted.momocity.report.application.usecase.ReportCommandUseCase;
+import com.wanted.momocity.report.domain.model.Report;
+import com.wanted.momocity.report.presentation.api.request.SubmitReportRequest;
+import com.wanted.momocity.report.presentation.api.response.SubmitReportResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/* comment.
+    ReportController 정리
+    1. 역할 : 신고 접수 HTTP API 진입점이다. 로그인한 회원이 다른 회원/콘텐츠를 신고할 때 호출한다.
+    2. 다루는 API :
+        - Post /api/v1/reports
+    3. 클래스 레벨 어노테이션
+        - @RestController : REST API 컨트롤러. 반환값 자동으로 JSON 직렬화
+        - @RequiredArgsConstructor : final 필드 자동 생성
+        - @RequestMapping : 클래스 내 모든 핸들러의 공통 URL
+        - @Tag : Swagger UI 에서 Report 그룹으로 묶어서 표시
+    4. 의존성
+        - ReportCommandUseCase : UseCase 인터페이스 의존, 구현체에 대해서 모른다.
+    5. submitReport 처리 흐름 5단계
+        a) Authentication.getName() 으로 신고자 email 추출
+        b) request.toCommand(email) 로 Request DTO → Command 변환
+        c) reportCommandUseCase.submitReport(command) 호출 → 도메인 Report 반환
+        d) SubmitReportResponse.from(report) 로 도메인 → 응답 DTO 변환
+        e) ResponseEntity 로 201 Created + 공통 응답 wrapper 묶어서 반환
+    6. WHY 응답 201 Created
+       → REST 컨벤션 - 신규 리소스 생성 성공 시 201
+       → 200 OK 와 구분을 지어놓는다. client 가 응답만 보고 새로 생겼다고 인지
+    7. WHY Authentication 으로 email 추출
+       → 보안 - client 가 보낸 email 신뢰 불가능
+       → Spring Security 가 JWT/세션에서 검증한 인증된 email 만 사용
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reports")
+@Tag(name = "Report", description = "회원 신고 접수 API")
+public class ReportController {
+
+    private final ReportCommandUseCase reportCommandUseCase;
+
+    @PostMapping
+    @Operation(
+            summary = "신고 접수",
+            description = "로그인한 회원이 게시글/댓글/회원/강의를 신고한다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201", description = "신고 접수 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400", description = "요청 본문 검증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401", description = "인증 토큰 누락 또는 만료")
+    })
+    public ResponseEntity<ApiResponse<SubmitReportResponse>> submitReport(
+            Authentication authentication,
+            @Valid @RequestBody SubmitReportRequest request
+    ) {
+        // 1. Authentication 에서 신고자 email 추출
+        String reporterEmail = authentication.getName();
+
+        // 2. Request → Command 변환 (Request 의 toCommand 메서드 활용)
+        SubmitReportCommand command = request.toCommand(reporterEmail);
+
+        // 3. UseCase 호출 → 도메인 객체 반환
+        Report report = reportCommandUseCase.submitReport(command);
+
+        // 4. 도메인 → 응답 DTO 변환
+        SubmitReportResponse response = SubmitReportResponse.from(report);
+
+        // 5. 201 Created + 공통 응답 wrapper 로 반환
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        ApiResponseCode.CREATED,
+                        "신고가 접수되었습니다.",
+                        response
+                ));
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/request/SubmitReportRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/request/SubmitReportRequest.java
@@ -1,0 +1,63 @@
+package com.wanted.momocity.report.presentation.api.request;
+
+import com.wanted.momocity.report.application.command.SubmitReportCommand;
+import com.wanted.momocity.report.domain.model.ReportReason;
+import com.wanted.momocity.report.domain.model.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/* comment.
+    SubmitReportRequest 정리
+    1. 역할 : 산고 접수 HTTP 요청 본문 매핑 객체
+    2. 위치 : 표현 계층 - HTTP 입력 DTO
+    3. Request vs Command 차이
+        Request : HTTP 본문 매핑. 표현 계층. Spring Validation 어노테이션 사용.
+        Command : 응용 계층 의도. HTTP 모름. 도메인이 알아야 할 정보만 담음.
+        변환 책임 : Controller (Request → Command). 이 파일의 toCommand() 메서드가 변환 담당.
+    4. 필드 4개 (reporterEmail 은 왜 없는가)
+        targetType : 신고 대상 종류 enum (POST / COMMENT / USER / LECTURE)
+        targetId : 신고 대상 ID (외부 BC 참조)
+        reason : 신고 사유 enum (SPAM / ABUSE / ...)
+        detail : 자유 설명 (nullable, 최대 1000자)
+       → WHY reporterEmail 없음 : client 가 보내는 것이 아니라 서버가 Authentication 에서 추출하기 때문에
+       또한 client 입력 절대 신뢰할 수 없다. (도용당한 계정일 수 있기 때문이다)
+    5. 검증의 두 단계
+       - 1단계 (이 파일) : HTTP 형식 검증 - 필수값/양수/길이제한
+       - 2단계 (Service) : 비즈니스 검증 - 본인 신고 방지, 중복 신고 검증 등
+    6. WHY toCommand(email) 메서드 추가
+       → 변환 로직을 Request DTO 안에 응집되게 된다. Controller 검증
+       → from() 응답 DTO 과 대칭되는 네이밍
+ */
+@Schema(description = "신고 접수 요청")
+public record SubmitReportRequest(
+
+        @Schema(description = "신고 대상 종류", example = "USER")
+        @NotNull(message = "신고 대상 종류는 필수입니다.")
+        ReportTargetType targetType,
+
+        @Schema(description = "신고 대상 ID", example = "42")
+        @NotNull(message = "신고 대상 ID 는 필수입니다.")
+        @Positive(message = "신고 대상 ID 는 양수여야 합니다.")
+        Long targetId,
+
+        @Schema(description = "신고 사유", example = "SPAM")
+        @NotNull(message = "신고 사유는 필수입니다.")
+        ReportReason reason,
+
+        @Schema(description = "자유 설명 (최대 1000자)", example = "광고성 메시지를 반복 게시함")
+        @Size(max = 1000, message = "자유 설명은 최대 1000자까지 가능합니다.")
+        String detail
+) {
+
+    public SubmitReportCommand toCommand(String reporterEmail) {
+        return new SubmitReportCommand(
+                reporterEmail,
+                targetType,
+                targetId,
+                reason,
+                detail
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/SubmitReportResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/SubmitReportResponse.java
@@ -1,0 +1,53 @@
+package com.wanted.momocity.report.presentation.api.response;
+
+import com.wanted.momocity.report.domain.model.Report;
+
+import java.time.LocalDateTime;
+
+/* comment.
+    SubmitReportResponse 정리
+    1. 역할 : 신고 접수 성공 시 HTTP 응답으로 보내는 DTO. Controller 가 도메인 Report 를 이걸로 변화내서 반환한다.
+    2. 위치 : 표현 계층 - 출력 DTO
+    3. WHY record 사용
+       → 불변 객체이기 때문이다
+       → enrollment.CreateEnrollmentResponse 와 동일한 패턴
+    4. WHY enum 을 String 으로 변환 (targetType, reason, status)
+       → 표현 계층은 enum 값을 직접적으로 노출시키지 않는다.
+       → JSON 직렬화 시 enum 그대로 노출하면 FE 에서 상수 매핑 부담
+    5. WHY from(Report) 정적 팩토리 메서드
+       → 변환 로직을 한 곳에 모아 응집도
+       → enum.name() 으로 변환해서 문자열로 명확하게 전달한다.
+    6. 필드 8개 의미
+        reportId : 신고 식별자 (FE 가 추적용)
+        reporterUserId : 신고자 ID (검증/확인용)
+        targetType : 신고 대상 종류 (POST / COMMENT / USER / LECTURE)
+        targetId : 신고 대상 ID
+        reason : 신고 사유 (enum → String)
+        detail : 자유 설명 (nullable, JSON null 로 전달)
+        status : 신고 처리 상태 (접수 직후 = PENDING)
+        reportedAt : 신고 접수 시각
+ */
+public record SubmitReportResponse(
+        Long reportId,
+        Long reporterUserId,
+        String targetType,
+        Long targetId,
+        String reason,
+        String detail,
+        String status,
+        LocalDateTime reportedAt
+) {
+
+    public static SubmitReportResponse from(Report report) {
+        return new SubmitReportResponse(
+                report.getId(),
+                report.getReporterUserId(),
+                report.getTargetType().name(),
+                report.getTargetId(),
+                report.getReason().name(),
+                report.getDetail(),
+                report.getStatus().name(),
+                report.getReportedAt()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/package-info.java
@@ -1,2 +1,0 @@
-/** 신고 - 표현 계층 (HTTP 컨트롤러, 요청/응답 DTO). */
-package com.wanted.momocity.report.presentation;


### PR DESCRIPTION
## 📌 Summary

- **admin BC**: 대시보드 증감률 + 에러 로그 조회 API
- **report BC**: 도메인 모델 + 영속화 계층 + 신고 접수 API
- **아키텍처**: DDD 4계층 + 헥사고날(Port/Adapter) + DIP

---

## 🎯 작업 내용

### 1. admin 영역 (관리자 대시보드)
- `MemberStatsPort` / `LectureStatsPort` 인터페이스 신규 (Port 패턴)
- `DashboardSummary` record + `DashboardSummaryResponse` 증감률 필드 확장
- `ErrorLog` 도메인 모델 + 3 enum + Repository 인터페이스
- `ErrorLogQueryUseCase` + `ErrorLogQueryService` (stub)
- `ErrorLogController` (Swagger 어노테이션 포함)
- API: `GET /api/v1/admin/error-logs?limit=N`

### 2. report 도메인 모델 (TDD)
- `Report` + `ReportStatus` + `ReportTargetType` + `ReportReason`
- 정적 팩토리 `submit()` / `restore()`
- 도메인 행위 `review/confirm/reject` stub (module04 예정)
- `ReportTest` red→green TDD 사이클 (6 케이스)

### 3. report 영속화 계층
- `ReportRepository` 도메인 인터페이스 (`save` / `findRecent` / `findByStatus`)
- `ReportJpaEntity` (report 테이블 매핑, `BaseTimeEntity` 상속)
- `SpringDataReportRepository` (Spring Data JPA)
- `ReportRepositoryAdapter` (도메인 ↔ 엔티티 변환 + 트랜잭션)

### 4. report 신고 접수 API (`POST /api/v1/reports`)
- `SubmitReportCommand` (응용 입력 객체)
- `ReporterAccountPort` + `AuthReporterAccountAdapter` (외부 BC 접근, Port 패턴)
- `ReportCommandUseCase` + `ReportCommandService` (DIP 적용)
- `SubmitReportRequest` + `SubmitReportResponse` (HTTP DTO + Bean Validation)
- `ReportController` (Swagger 어노테이션, 201 Created)

---

## 🏛 아키텍처 패턴 적용

| 패턴 | 적용 위치 |
|---|---|
| **DDD 4계층** | `domain` / `application` / `infrastructure` / `presentation` |
| **DIP** | Controller → UseCase 인터페이스, Service → Repository 인터페이스 |
| **헥사고날 (Port/Adapter)** | `ReporterAccountPort` + `AuthReporterAccountAdapter` 등 |
| **CQRS 경량** | `ReportCommandUseCase` (쓰기) / `ReportQueryUseCase` (조회, 예정) |
| **정적 팩토리** | `Report.submit()`, `Report.restore()`, `Response.from()` |
| **enum → String 매핑** | 도메인 enum ↔ DB String (Adapter 에서 변환) |

---

## ✅ 검증

- [x] `./gradlew compileJava` 통과
- [x] `./gradlew test --tests "com.wanted.momocity.admin.*"` 통과
- [x] `./gradlew test --tests "com.wanted.momocity.report.*"` 통과
- [x] enrollment / admin BC 컨벤션 일관성 유지

---

## 🔲 남은 작업 (다음 PR 예정)

- [ ] 신고 목록 조회 API (`GET /api/v1/admin/reports`)
- [ ] 2교시 API 명세 문서화 (수영님 협업)
- [ ] 인수인계서 업데이트 + 트러블슈팅 회고
- [ ] 전역 예외 처리 (`@RestControllerAdvice`) — module 전체 통합

---

## 🧪 Test Plan

- [ ] 로컬 빌드 (`./gradlew build`) 통과 확인
- [ ] `POST /api/v1/reports` 호출 테스트
  - 200 케이스: 유효한 토큰 + 유효한 body
  - 401 케이스: 토큰 누락
  - 400 케이스: targetType / reason 누락
- [ ] 신고 데이터 DB 저장 확인 (PENDING 상태)
- [ ] Swagger UI 에서 API 명세 확인

---

## 📚 학습 포인트 (발표용)

- **DIP**: Controller 가 Service 구현체 아닌 UseCase 인터페이스에 의존
- **Port 패턴**: 신고 BC 가 회원 BC 의 user.id 를 직접 접근하지 않고 `ReporterAccountPort` 인터페이스 통해 접근 → BC 격리
- **Request vs Command 분리**: 표현 계층 입력(`SubmitReportRequest`) ↔ 응용 계층 입력(`SubmitReportCommand`) — `reporterEmail` 은 Authentication 에서 추출 (보안)
- **enum → String 매핑**: 도메인 enum 그대로 두고 인프라 계층에서만 String 변환 (BC 일관성)