### PR TITLE
[PR] 강의 상태 변경 메서드 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/ChangeLectureStatusCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/ChangeLectureStatusCommand.java
@@ -1,0 +1,11 @@
+package com.wanted.momocity.lecture.application.command;
+
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+
+// 강의 상태 변경에 필요한 값을 담는 Command
+public record ChangeLectureStatusCommand(
+        String teacherEmail,
+        Long lectureId,
+        LectureStatus lectureStatus
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
@@ -139,4 +139,6 @@ public class ChapterCommandService implements ChapterCommandUseCase {
         // 변경된 챕터 정보를 저장합니다.
         return chapterRepository.save(updatedChapter);
     }
+
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
@@ -1,10 +1,16 @@
 package com.wanted.momocity.lecture.application.service;
 
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.command.ChangeLectureStatusCommand;
 import com.wanted.momocity.lecture.application.command.CreateLectureCommand;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,13 +23,16 @@ public class LectureCommandService implements LectureCommandUseCase {
 
     private final LectureRepository lectureRepository;
     private final TeacherAccountPort teacherAccountPort;
+    private final ChapterRepository chapterRepository;
 
     public LectureCommandService(
             LectureRepository lectureRepository,
-            TeacherAccountPort teacherAccountPort
+            TeacherAccountPort teacherAccountPort,
+            ChapterRepository chapterRepository
     ) {
         this.lectureRepository = lectureRepository;
         this.teacherAccountPort = teacherAccountPort;
+        this.chapterRepository = chapterRepository;
     }
 
     @Override
@@ -43,5 +52,59 @@ public class LectureCommandService implements LectureCommandUseCase {
         );
 
         return lectureRepository.save(lecture);
+    }
+
+    @Override
+    public LectureAggregate changeLectureStatus(ChangeLectureStatusCommand command) {
+        /*
+         * Authorization 토큰에서 얻은 email로 강사 id를 조회합니다.
+         */
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+
+        // 상태를 변경할 강의를 조회합니다.
+        LectureAggregate lecture = lectureRepository.findById(command.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 본인이 등록한 강의만 상태를 변경할 수 있습니다.
+        if (!lecture.isOwnedBy(teacherId)) {
+            throw new AccessDeniedException("본인이 등록한 강의만 상태를 변경할 수 있습니다.");
+        }
+
+        /*
+         * ACTIVE 상태는 학생에게 공개되는 상태입니다.
+         * 그래서 공개 전 챕터와 동영상이 모두 준비되어 있는지 확인합니다.
+         */
+        if (command.lectureStatus() == LectureStatus.ACTIVE) {
+            validateLectureReadyForActive(command.lectureId());
+        }
+
+        // 도메인 모델에 상태 변경을 요청합니다.
+        LectureAggregate changedLecture = lecture.changeStatus(command.lectureStatus());
+
+        // 변경된 강의를 저장합니다.
+        return lectureRepository.save(changedLecture);
+    }
+
+    /*
+     * 강의를 ACTIVE 상태로 변경할 수 있는지 검증합니다.
+     * 조건:
+     * 1. 챕터가 최소 1개 이상 있어야 합니다.
+     * 2. 모든 챕터에 동영상이 등록되어 있어야 합니다.
+     */
+    private void validateLectureReadyForActive(Long lectureId) {
+        // 강의에 등록된 챕터 개수를 조회합니다.
+        int chapterCount = chapterRepository.countByLectureId(lectureId);
+
+        if (chapterCount < 1) {
+            throw new DomainRuleViolationException("강의를 공개하려면 챕터가 최소 1개 이상 필요합니다.");
+        }
+
+        // videoUrl이 없는 챕터가 있는지 확인합니다.
+        boolean hasChapterWithoutVideo =
+                chapterRepository.existsByLectureIdAndVideoUrlIsNull(lectureId);
+
+        if (hasChapterWithoutVideo) {
+            throw new DomainRuleViolationException("강의를 공개하려면 모든 챕터에 동영상이 등록되어야 합니다.");
+        }
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
@@ -70,12 +70,17 @@ public class LectureCommandService implements LectureCommandUseCase {
             throw new AccessDeniedException("본인이 등록한 강의만 상태를 변경할 수 있습니다.");
         }
 
+        // 강사는 검수 요청 상태인 WAITING으로만 변경
+        if (command.lectureStatus() != LectureStatus.WAITING) {
+            throw new DomainRuleViolationException("강사는 강의를 검수 요청 상태로만 변경할 수 있습니다.");
+        }
+
         /*
-         * ACTIVE 상태는 학생에게 공개되는 상태입니다.
-         * 그래서 공개 전 챕터와 동영상이 모두 준비되어 있는지 확인합니다.
+         * WAITING은 강사가 강의를 등록 하자마자 대기 상태로 변한다.
+         * 관리자가 승인 해줘야 ACTIVE로 학생에게 공개된다.
          */
-        if (command.lectureStatus() == LectureStatus.ACTIVE) {
-            validateLectureReadyForActive(command.lectureId());
+        if (command.lectureStatus() == LectureStatus.WAITING) {
+            validateLectureReadyForReview(command.lectureId());
         }
 
         // 도메인 모델에 상태 변경을 요청합니다.
@@ -86,25 +91,23 @@ public class LectureCommandService implements LectureCommandUseCase {
     }
 
     /*
-     * 강의를 ACTIVE 상태로 변경할 수 있는지 검증합니다.
+     * 강의를 ACTIVE 상태로 변경할 수 있는지 검증
      * 조건:
      * 1. 챕터가 최소 1개 이상 있어야 합니다.
      * 2. 모든 챕터에 동영상이 등록되어 있어야 합니다.
      */
-    private void validateLectureReadyForActive(Long lectureId) {
-        // 강의에 등록된 챕터 개수를 조회합니다.
+    private void validateLectureReadyForReview(Long lectureId) {
         int chapterCount = chapterRepository.countByLectureId(lectureId);
 
         if (chapterCount < 1) {
-            throw new DomainRuleViolationException("강의를 공개하려면 챕터가 최소 1개 이상 필요합니다.");
+            throw new DomainRuleViolationException("강의를 검수 요청하려면 챕터가 최소 1개 이상 필요합니다.");
         }
 
-        // videoUrl이 없는 챕터가 있는지 확인합니다.
         boolean hasChapterWithoutVideo =
                 chapterRepository.existsByLectureIdAndVideoUrlIsNull(lectureId);
 
         if (hasChapterWithoutVideo) {
-            throw new DomainRuleViolationException("강의를 공개하려면 모든 챕터에 동영상이 등록되어야 합니다.");
+            throw new DomainRuleViolationException("강의를 검수 요청하려면 모든 챕터에 동영상이 등록되어야 합니다.");
         }
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureCommandUseCase.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.lecture.application.usecase;
 
+import com.wanted.momocity.lecture.application.command.ChangeLectureStatusCommand;
 import com.wanted.momocity.lecture.application.command.CreateLectureCommand;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 
@@ -10,4 +11,6 @@ import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 public interface LectureCommandUseCase {
     // 강의를 등록
     LectureAggregate createLecture(CreateLectureCommand command);
+
+    LectureAggregate changeLectureStatus(ChangeLectureStatusCommand command);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureAggregate.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureAggregate.java
@@ -141,6 +141,27 @@ public class LectureAggregate {
     }
 
     /*
+     * 강의 상태를 변경
+     * 강의의 기본 정보는 유지하고 status 값만 새로운 상태로 교체합니다.
+     */
+    public LectureAggregate changeStatus(LectureStatus newStatus) {
+        validateStatus(newStatus);
+
+        return new LectureAggregate(
+                id,
+                teacherId,
+                title,
+                description,
+                thumbnailUrl,
+                category,
+                newStatus,
+                completedUserCount,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    /*
      * 요청한 teacherId가 이 강의의 소유자인지 확인
      * 수정/삭제 권한 검증에서 사용
      */
@@ -157,30 +178,31 @@ public class LectureAggregate {
         }
     }
 
-    /*
-     * 강의 제목은 필수 입력값
-     */
+    // 강의 제목은 필수 입력값
     private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new DomainRuleViolationException("강의 제목은 필수입니다.");
         }
     }
 
-    /*
-     * 강의 설명은 필수 입력값
-     */
+    // 강의 설명은 필수 입력값
     private static void validateDescription(String description) {
         if (description == null || description.isBlank()) {
             throw new DomainRuleViolationException("강의 설명은 필수입니다.");
         }
     }
 
-    /*
-     * 강의 카테고리는 필수 입력값
-     */
+    // 강의 카테고리는 필수 입력값
     private static void validateCategory(LectureCategory category) {
         if (category == null) {
             throw new DomainRuleViolationException("강의 카테고리는 필수입니다.");
+        }
+    }
+
+    // 강의 상태값은 필수
+    private static void validateStatus(LectureStatus status) {
+        if (status == null) {
+            throw new DomainRuleViolationException("강의 상태는 필수입니다.");
         }
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
@@ -22,4 +22,7 @@ public interface ChapterRepository {
     // chapterId로 기존 챕터를 조회
     // 동영상 등록은 기존 챕터에 영상 정보를 채우는 작업이라 단건 조회가 필요
     Optional<LectureChapter> findById(Long chapterId);
+
+    // 특정 강의에 동영상이 등록되지 않은 챕터가 있는지 확인
+    boolean existsByLectureIdAndVideoUrlIsNull(Long lectureId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
@@ -45,7 +45,7 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
     }
 
     @Override
-    public boolean existsByLecutreIdAndVideoUrlIsNull(Long lectureId) {
+    public boolean existsByLectureIdAndVideoUrlIsNull(Long lectureId) {
         return repository.existsByLectureIdAndVideoUrlIsNull(lectureId);
     }
     

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
@@ -43,5 +43,10 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
         return repository.findById(chapterId)
                 .map(ChapterJpaEntity::toDomain);
     }
+
+    @Override
+    public boolean existsByLecutreIdAndVideoUrlIsNull(Long lectureId) {
+        return repository.existsByLectureIdAndVideoUrlIsNull(lectureId);
+    }
     
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureJpaEntity.java
@@ -87,4 +87,12 @@ public class LectureJpaEntity extends BaseTimeEntity {
     public int getCompletedUserCount() {
         return completedUserCount;
     }
+
+    /*
+     * JPA Entity의 상태값을 변경
+     * 트랜잭션 안에서 호출하면 dirty checking으로 DB에 반영
+     */
+    public void changeStatus(LectureStatus status) {
+        this.status = status;
+    }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -25,8 +25,24 @@ public class LectureRepositoryAdapter implements LectureRepository {
     }
 
     // 강의를 저장합니다.
+    /* 강의 등록
+    *    → id null
+    *   → 새 row 저장
+    * 강의 상태 변경
+    *   → id 있음
+    *   → 기존 row 조회 후 status만 변경
+    */
     @Override
     public LectureAggregate save(LectureAggregate lecture) {
+        if (lecture.getId() != null) {
+            LectureJpaEntity entity = repository.findById(lecture.getId())
+                    .orElseThrow(() -> new IllegalArgumentException("강의를 찾을 수 없습니다."));
+
+            entity.changeStatus(lecture.getStatus());
+
+            return toDomain(entity);
+        }
+
         LectureJpaEntity entity = new LectureJpaEntity(
                 lecture.getTeacherId(),
                 lecture.getTitle(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
@@ -10,4 +10,7 @@ public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEnt
 
     // 같은 강의 안에서 동일한 orderNo가 이미 있는지 확인
     boolean existsByLectureIdAndOrderNo(Long lectureId, int orderNo);
+
+    // 강의에 videoUrl이 비어있는 챕터가  있는지 확인
+    boolean existsByLectureIdAndVideoUrlIsNull(Long lectureId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -3,14 +3,17 @@ package com.wanted.momocity.lecture.presentation.api;
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.application.command.ChangeLectureStatusCommand;
 import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.presentation.api.request.ChangeLectureStatusRequest;
 import com.wanted.momocity.lecture.presentation.api.request.CreateChapterRequest;
 import com.wanted.momocity.lecture.presentation.api.request.CreateLectureRequest;
 import com.wanted.momocity.lecture.presentation.api.request.RegisterChapterVideoRequest;
+import com.wanted.momocity.lecture.presentation.api.response.ChangeLectureStatusResponse;
 import com.wanted.momocity.lecture.presentation.api.response.CreateChapterResponse;
 import com.wanted.momocity.lecture.presentation.api.response.CreateLectureResponse;
 import com.wanted.momocity.lecture.presentation.api.response.RegisterChapterVideoResponse;
@@ -145,6 +148,43 @@ public class TeacherLectureController {
                         ApiResponseCode.SUCCESS,
                         "챕터 동영상이 등록되었습니다.",
                         RegisterChapterVideoResponse.from(chapter)
+                ));
+    }
+
+    // 강의 상태 변경 API
+    @Operation(
+            summary = "강의 상태 변경",
+            description = """
+                강사가 본인이 등록한 강의의 상태를 변경합니다.
+                ACTIVE 상태로 변경하려면 챕터가 최소 1개 이상 있어야 하고,
+                모든 챕터에 동영상이 등록되어 있어야 합니다.
+                """
+    )
+    @PatchMapping("/{lectureId}/status")
+    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
+    public ResponseEntity<ApiResponse<ChangeLectureStatusResponse>> changeLectureStatus(
+            Authentication authentication,
+            @PathVariable Long lectureId,
+            @Valid @RequestBody ChangeLectureStatusRequest request
+    ) {
+        // Authorization 토큰에서 로그인한 강사의 email을 가져옴
+        String teacherEmail = authentication.getName();
+
+        // Request DTO를 Application 계층에서 사용할 Command로 변환
+        ChangeLectureStatusCommand command = request.toCommand(
+                teacherEmail,
+                lectureId
+        );
+
+        // 강의 상태 변경 유스케이스를 실행
+        LectureAggregate lecture = lectureCommandUseCase.changeLectureStatus(command);
+
+        // 200 OK 응답을 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(
+                        ApiResponseCode.SUCCESS,
+                        "강의 상태가 변경되었습니다.",
+                        ChangeLectureStatusResponse.from(lecture)
                 ));
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/ChangeLectureStatusRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/ChangeLectureStatusRequest.java
@@ -1,0 +1,39 @@
+package com.wanted.momocity.lecture.presentation.api.request;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.command.ChangeLectureStatusCommand;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import jakarta.validation.constraints.NotBlank;
+
+// 강의 상태 변경 요청 DTO
+public record ChangeLectureStatusRequest(
+
+        // 변경할 강의 상태입니다. 예: ACTIVE, HOLD, DELETED, WAITING
+        @NotBlank(message = "강의 상태는 필수입니다.")
+        String lectureStatus
+) {
+
+    // 문자열로 받은 상태값을 LectureStatus enum으로 변환한 뒤 Command로 만든다.
+    public ChangeLectureStatusCommand toCommand(
+            String teacherEmail,
+            Long lectureId
+    ) {
+        return new ChangeLectureStatusCommand(
+                teacherEmail,
+                lectureId,
+                parseLectureStatus()
+        );
+    }
+
+    /*
+     * 요청 상태값을 LectureStatus enum으로 변환
+     * 허용되지 않은 값이면 400으로 처리될 도메인 예외를 던집니다.
+     */
+    private LectureStatus parseLectureStatus() {
+        try {
+            return LectureStatus.valueOf(lectureStatus.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new DomainRuleViolationException("허용되지 않은 강의 상태입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/ChangeLectureStatusResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/ChangeLectureStatusResponse.java
@@ -1,0 +1,22 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+
+import java.time.LocalDateTime;
+
+// 강의 상태 변경 성공 응답 DTO.
+public record ChangeLectureStatusResponse(
+        Long lectureId,
+        String lectureStatus,
+        LocalDateTime updatedAt
+) {
+
+    // LectureAggregate 도메인 모델을 응답 DTO로 변환
+    public static ChangeLectureStatusResponse from(LectureAggregate lecture) {
+        return new ChangeLectureStatusResponse(
+                lecture.getId(),
+                lecture.getStatus().name(),
+                lecture.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
##작업 내용

강사 기준 강의 상태 변경 API를 구현했습니다.
강사는 본인이 등록한 강의를 검수 요청 상태인 WAITING으로만 변경할 수 있으며, 검수 요청 전 아래 조건을 검증합니다.

```text
- 챕터가 최소 1개 이상 존재해야 함
- 모든 챕터에 동영상이 등록되어 있어야 함
```
 

## 구현 흐름

PATCH /api/v1/teacher/lectures/{lectureId}/status
→ Authorization 토큰에서 강사 email 조회
→ email 기준 teacherId 조회
→ 강의 존재 여부 확인
→ 본인이 등록한 강의인지 확인
→ 강사는 WAITING 상태로만 변경 가능하도록 검증
→ 챕터 최소 1개 존재 여부 확인
→ 동영상이 없는 챕터 존재 여부 확인
→ 기존 lecture row의 status 변경
→ 응답 반환


## 참고 사항

강사는 ACTIVE, HOLD, DELETED 상태로 직접 변경할 수 없습니다.
강사 API에서의 상태 변경은 실질적으로 “검수 요청” 역할입니다.
관리자 승인/보류 기능은 추후 관리자 API에서 ACTIVE, HOLD 처리를 담당합니다.
reason은 관리자 보류 처리에서 다룰 값이므로 이번 강사 API에서는 제외했습니다.
학생 강의 목록에는 기존 정책대로 ACTIVE 상태의 강의만 노출됩니다.