### PR TITLE
[PR] 수강 시청 시 사용자 정보를 찾을 수 없는 문제 해결 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/command/CreateEnrollmentCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/command/CreateEnrollmentCommand.java
@@ -2,7 +2,7 @@ package com.wanted.momocity.enrollment.application.command;
 
 public record CreateEnrollmentCommand(
         // 학생 Id
-        String studentEmail,
+        Long studentId,
         // 강의 Id
         Long lectureId
 ) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/port/StudentAccountPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/port/StudentAccountPort.java
@@ -2,5 +2,5 @@ package com.wanted.momocity.enrollment.application.port;
 
 public interface StudentAccountPort {
 
-    Long getStudentId(String email);
+    Long getStudentId(Long userId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentCommandService.java
@@ -36,7 +36,7 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
     @Override
     public Enrollment createEnrollment(CreateEnrollmentCommand command) {
         // Authorization 토큰에서 꺼낸 email로 학생 ID를 조회
-        Long userId = studentAccountPort.getStudentId(command.studentEmail());
+        Long userId = studentAccountPort.getStudentId(command.studentId());
 
         // 수강신청 대상 강의의 현재 상태를 조회
         LectureStatus lectureStatus = enrollmentLecturePort.getLectureStatus(command.lectureId());

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/adapter/AuthStudentAccountAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/adapter/AuthStudentAccountAdapter.java
@@ -18,9 +18,9 @@ public class AuthStudentAccountAdapter implements StudentAccountPort {
     }
 
     @Override
-    public Long getStudentId(String email) {
+    public Long getStudentId(Long userId) {
         // 인증 과정에서 전달받은 email로 사용자 정보를 조회한다.
-        User user = loadUserPort.findByEmail(email)
+        User user = loadUserPort.findById(userId)
                 .orElseThrow(() -> new AuthenticationCredentialsNotFoundException("인증된 사용자 정보를 찾을 수 없습니다."));
 
         // 조회된 사용자가 학생(STUDENT) 권한이 아니면 수강신청을 허용하지 않는다.

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/EnrollmentController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/EnrollmentController.java
@@ -36,11 +36,11 @@ public class EnrollmentController {
             @PathVariable Long lectureId
     ) {
         // Authorization 토큰에서 꺼낸 로그인 사용자 email
-        String userEmail = authentication.getName();
+        Long studentId = Long.parseLong(authentication.getName());
 
         // 수강신청에 필요한 값을 Command로 묶는다.
         CreateEnrollmentCommand command = new CreateEnrollmentCommand(
-                userEmail,
+                studentId,
                 lectureId
         );
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetLecturesQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetLecturesQuery.java
@@ -8,7 +8,7 @@ import com.wanted.momocity.lecture.domain.model.LectureCategory;
 public record GetLecturesQuery(
 
         // Authorization 토큰에서 꺼낸 로그인 사용자 email
-        String userEmail,
+        Long userId,
 
         // 강의 카테고리 필터
         // 값이 없으면 전체 카테고리를 조회
@@ -29,10 +29,9 @@ public record GetLecturesQuery(
 
 ) {
 
-    /**
+    /*
      * compact constructor -> 생성자를 풀지 않음 즉, 필드를 다시 적지 않고 짧게 쓸 수 있음
-     *
-     * record가 생성될 때 page, size 값이 정상인지 검사합니다.
+     * record가 생성될 때 page, size 값이 정상인지 검사
      */
     public GetLecturesQuery {
         if (page < 1) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -38,7 +38,7 @@ public class LectureQueryService implements LectureQueryUseCase {
     public LecturePageResponse getLectures(GetLecturesQuery query) {
 
         // Authorization 토큰에서 꺼낸 email로 userId를 조회
-        Long userId = studentAccountPort.getStudentId(query.userEmail());
+        Long userId = studentAccountPort.getStudentId(query.userId());
 
         // userId 기준으로 수강 신청한 강의 ID 목록을 조회
         List<Long> enrolledLectureIds = lectureEnrollmentQueryPort.findLectureIdsByUserId(userId);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -60,10 +60,10 @@ public class LectureController {
             // 페이지 크기입니다. 기본값은 10
             @RequestParam(defaultValue = "10") int size
     ) {
-        String userEmail = authentication.getName();
+        Long userId = Long.parseLong(authentication.getName());
 
         GetLecturesQuery query = new GetLecturesQuery(
-                userEmail,
+                userId,
                 parseCategory(category),
                 enrolled,
                 page,


### PR DESCRIPTION
## 작업 내용

- JWT 인증 토큰에서 꺼낸 로그인 사용자 식별값을 email 기준에서 userId 기준으로 변경했습니다.
- `authentication.getName()` 값이 email이 아닌 userId 문자열로 반환되는 구조에 맞춰 수강신청/수강 내역 조회 로직을 수정했습니다.
- 수강신청 생성 Command를 `studentEmail` 기준에서 `studentId` 기준으로 변경했습니다.
- `StudentAccountPort`와 `AuthStudentAccountAdapter`를 userId 기반 조회로 수정했습니다.
- 수강 내역 조회용 `GetLecturesQuery`도 userId 기준으로 변경했습니다.

## 수정 이유

현재 JWT subject에는 email이 아니라 로그인 사용자의 PK인 userId가 저장됩니다.

기존에는 아래처럼 `authentication.getName()` 값을 email로 가정했습니다.

```java
String userEmail = authentication.getName();


하지만 실제 값은 userId 문자열이기 때문에 findByEmail() 조회가 실패할 수 있었습니다.
이에 따라 인증 사용자 식별 방식을 userId 기준으로 통일했습니다.

close #152 