### PR TITLE
[PR] 신고 목록 조회 API + admin 영역 마무리 (ErrorLog 인프라 / BC 정합) (김민섭)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/port/ReportStatsPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/port/ReportStatsPort.java
@@ -1,0 +1,18 @@
+package com.wanted.momocity.admin.application.port;
+
+/* comment.
+    ReportStatsPort 정리
+    1. 역할 : admin BC 가 report BC 의 신고 통계를 가져오기 위한 외부 BC 접근 계약
+    2. 위치 : admin/application/port (응용 계층 - 외부 BC 접근 인터페이스)
+    3. WHY Port 패턴 사용 (직접 의존 X)
+       → admin BC 는 report BC 의 내부 구현을 모름 (BC 격리)
+       → MemberStatsPort / LectureStatsPort 와 동일 패턴 → BC 정합성
+    4. WHY countAll 단일 메서드
+       → 대시보드 위젯이 필요한 정보는 "전체 신고 수" 하나
+       → 추가 통계 필요 시 메서드 확장 (예: countByStatus)
+ */
+public interface ReportStatsPort {
+
+    /** 전체 신고 수 (대시보드 통계용) */
+    long countAll();
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/AdminDashboardQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/AdminDashboardQueryService.java
@@ -18,19 +18,20 @@ public class AdminDashboardQueryService implements AdminDashboardQueryUseCase {
 
     /* comment.
         m03 우선순위에서 추가될 의존성 :
-        - private final MemberStatsPort memberStatsPort;       (외부 BC 회원 - PORT 패턴, 어댑터는 회원팀 제공)
-        - private final LectureStatsPort lectureStatsPort;     (외부 BC 강의 - PORT 패턴, 어댑터는 성진 제공)
-        - private final ReportQueryUseCase reportQueryUseCase; (자기 영역 report/ - 작업 ⑤ 완료 후 직접 호출)
+        - private final MemberStatsPort memberStatsPort;   (외부 BC 회원 - PORT 패턴, 어댑터는 회원팀 제공)
+        - private final LectureStatsPort lectureStatsPort; (외부 BC 강의 - PORT 패턴, 어댑터는 성진 제공)
+        - private final ReportStatsPort reportStatsPort;   (외부 BC 신고 - PORT 패턴, 어댑터는 report BC 가 제공)
         *
-        의존성 두 종류 - PORT vs 직접 호출 :
-        - 외부 BC (회원/강의) : admin 이 PORT 정의 → 외부 팀이 어댑터 제공 (DIP, BC 경계 격리)
-        - 자기 영역 (report) : 직접 의존 가능 (BC 경계 안이라 자유)
+        BC 정합 - 3개 모두 외부 BC 라 PORT 패턴 일관 적용 :
+        - admin BC 는 다른 BC 의 내부 구현을 모름 (BC 격리)
+        - 각 Port 의 어댑터는 데이터 소유자 BC 가 제공 (member / lecture / report 모두 동일)
         *
-        현재는 PORT 어댑터 + report UseCase 미구현 상태라 주입 보류.
-        모두 준비되면 생성자 주입으로 추가.
+        현재는 회원/강의 어댑터 미구현 상태라 주입 보류.
+        ReportStatsPort 는 어댑터(ReportStatsAdapter) 완성됨 → 즉시 주입 가능.
+        모두 준비되면 생성자 주입 + 메서드 본문 실구현 예정.
  */
     public AdminDashboardQueryService() {
-        // m03 우선순위 - 위 3개 서비스 생성자 주입 예정
+        // m03 우선순위 - 위 3개 Port 생성자 주입 예정
     }
 
     /* comment.

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/ErrorLogQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/service/ErrorLogQueryService.java
@@ -1,42 +1,30 @@
 package com.wanted.momocity.admin.application.service;
 
 import com.wanted.momocity.admin.application.usecase.ErrorLogQueryUseCase;
+import com.wanted.momocity.admin.domain.audit.ErrorLogRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /* comment.
     ErrorLogQueryService 정리
-    1. 이 클래스의 역할 : ErrorLogQueryUseCase 의 실내 구현체 / Repository 에 조회 위임 + UseCase 의 출력 형식으로 변환
+    1. 이 클래스의 역할 : ErrorLogQueryUseCase 의 실 구현체. Repository 에 조회 위임 + UseCase 의 출력 형식으로 변환
     2. 위치 : admin/application/service (응용 계층 - 구현)
     3. 왜 @Transactional(readOnly = true) 인가 : Query 라서 쓰기 작업이 존재하지 않는다.
     4. 왜 ErrorLogRepository 에 직접 의존 (PORT 패턴 안 씀) : ErrorLog 는 admin 자체 도메인이다.
-    -> 외부 BC 가 아니라 BC 경게 격리 불필요 -> 도메인 Repository 인터페이스 직접 의존 가능하다.
+    -> 외부 BC 가 아니라 BC 경계 격리 불필요 -> 도메인 Repository 인터페이스 직접 의존 가능하다.
     5. AdminDashboardQueryService 와의 핵심 차이 (의존 방식) : 의존성의 종류가 다르다. AdminDashboard 는 외부 BC
     의존이기 때문에 PORT 방식, ErrorLog 는 자체 도메인이라 Repository 사용
  */
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ErrorLogQueryService implements ErrorLogQueryUseCase {
 
-    /* comment.
-        m03 우선순위에서 추가될 의존성 :
-        - private final ErrorLogRepository errorLogRepository;
+    private final ErrorLogRepository errorLogRepository;
 
-        현재는 ErrorLogRepository 의 구현체(JPA Adapter)가 아직 없어서 주입 보류.
-        ErrorLogRepositoryAdapter 추가되면 생성자 주입으로 전환.
-        (AdminDashboardQueryService 와 동일 패턴 - stub 단계)
-     */
-    public ErrorLogQueryService() {
-        // m03 우선순위 - ErrorLogRepository 주입 예정
-    }
-
-    /* comment.
-        실제 구현 시 흐름 (m03 우선순위) :
-        1. List<ErrorLog> errorLogs = errorLogRepository.findRecent(limit);
-        2. return new ErrorLogList(errorLogs);
-     */
     @Override
     public ErrorLogList getRecent(int limit) {
-        throw new UnsupportedOperationException("TODO: m03 우선순위 - 에러 로그 조회 구현");
+        return new ErrorLogList(errorLogRepository.findRecent(limit));
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/package-info.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/package-info.java
@@ -1,2 +1,0 @@
-/** 관리자 페이지 - 인프라 계층 (access_log 어댑터, 타 영역 집계 어댑터). */
-package com.wanted.momocity.admin.infrastructure;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/persistence/ErrorLogJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/persistence/ErrorLogJpaEntity.java
@@ -1,0 +1,67 @@
+package com.wanted.momocity.admin.infrastructure.persistence;
+
+import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+/* comment.
+    ErrorLogJpaEntity 정리
+    1. 역할 : Error_log 테이블과 1대1 맵핑되는 JPA 저장 모델 (시스템 에러 감사 로그이다)
+    2. 위치 : 인프라 계층
+    3. WHY 변경 메서드 없음 (Report 와 차이)
+       → ErrorLog 도메인이 모든 필드 final 완전 불변 상태이기 때문이다.
+       → audit 로그 특성 상 한 번 기록되면 절대 변경이 금지된다.
+    4. WHY enum → String 매핑
+       → level 은 도메인에서 ErrorLevel enum 종류가 (Critical / error / warning) 이다.
+       → 여기서는 String 으로 저장되며, Adapter 가 enum.name() <-> Enum.ValueOf() 변환이 된다.
+    5. WHY occurredAt 과 createdAt 둘 다 보존
+       → occurredAt : 도메인 의도 (실제 Error 발생 시점) - ErrorLog.occur() 에서 now() 로 채우게 된다.
+       → createdAt : 인프라 메타 (DB 의 행 생성 시점) - BaseTimeEntity 가 자동으로 생기게 된다.
+    6. WHY message 컬럼 길이 1000
+       → TEXT 타입을 쓰지 않는 이유는 인덱싱과 조회 효율을 극한까지 끌어올리기 위해서 사용한다.
+       →
+ */
+@Entity
+@Table(name = "error_log")
+public class ErrorLogJpaEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "level", nullable = false, length = 20)
+    private String level;
+
+    @Column(name = "source", nullable = false, length = 50)
+    private String source;
+
+    @Column(name = "message", nullable = false, length = 1000)
+    private String message;
+
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+
+    protected ErrorLogJpaEntity() {
+    }
+
+    public ErrorLogJpaEntity(Long id, String level, String source, String message, LocalDateTime occurredAt) {
+        this.id = id;
+        this.level = level;
+        this.source = source;
+        this.message = message;
+        this.occurredAt = occurredAt;
+    }
+
+    public Long getId() { return id; }
+    public String getLevel() { return level; }
+    public String getSource() { return source; }
+    public String getMessage() { return message; }
+    public LocalDateTime getOccurredAt() { return occurredAt; }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/persistence/ErrorLogRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/persistence/ErrorLogRepositoryAdapter.java
@@ -1,0 +1,87 @@
+package com.wanted.momocity.admin.infrastructure.persistence;
+
+import com.wanted.momocity.admin.domain.audit.ErrorLevel;
+import com.wanted.momocity.admin.domain.audit.ErrorLog;
+import com.wanted.momocity.admin.domain.audit.ErrorLogRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/* comment.
+    ErrorLogRepositoryAdapter 정리
+    1. 역할 : 도메인 ErrorLogRepository 인터페이스를 JPA 로 구현하는 어댑터
+    2. 위치 : 인프라 계층
+    3. 핵심 책임
+       - 도메인 ErrorLog <-> ErrorLogJpaEntity 변환
+       - SpringDataErrorLogRepository 호출을 감싸 도메인이 인프라를 모르게 처리하는 방식
+    4. WHY 의존 방향 (클린 아키텍처)
+        - implements ErrorLogRepository (도메인 인터페이스) ← 인프라가 도메인 약속 지킴
+        - SpringDataErrorLogRepository 주입 (인프라 → 인프라) ← 같은 계층
+        - ErrorLog 사용 (인프라 → 도메인) ← OK
+        - 도메인은 이 클래스의 존재를 모름 (인터페이스만 봄)
+    5. ReportRepositoryAdapter 와의 차이
+       → 같은 구조 (Repository + Spring Data + Adapter 3 파일 패턴)
+       → 다른 점 :
+            정렬 키, 필터 컬럼, 도메인 변환 시
+ */
+@Repository
+@Transactional
+public class ErrorLogRepositoryAdapter implements ErrorLogRepository {
+
+    private final SpringDataErrorLogRepository repository;
+
+    public ErrorLogRepositoryAdapter(SpringDataErrorLogRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public ErrorLog save(ErrorLog errorLog) {
+        ErrorLogJpaEntity entity = toEntity(errorLog);
+        ErrorLogJpaEntity saved = repository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ErrorLog> findRecent(int limit) {
+        return repository.findAllByOrderByOccurredAtDesc(PageRequest.of(0, limit))
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ErrorLog> findByLevel(ErrorLevel level, int limit) {
+        return repository.findAllByLevelOrderByOccurredAtDesc(level.name(), PageRequest.of(0, limit))
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    // === 변환 메서드 (도메인 ↔ 엔티티) ===
+
+    // 도메인 → 엔티티 (신규 저장 시 id=null, JPA 가 auto-increment 부여)
+    private ErrorLogJpaEntity toEntity(ErrorLog errorLog) {
+        return new ErrorLogJpaEntity(
+                errorLog.getId(),
+                errorLog.getLevel().name(),
+                errorLog.getSource(),
+                errorLog.getMessage(),
+                errorLog.getOccurredAt()
+        );
+    }
+
+    // 엔티티 → 도메인 (DB 복원 - ErrorLog.restore() 사용)
+    private ErrorLog toDomain(ErrorLogJpaEntity entity) {
+        return ErrorLog.restore(
+                entity.getId(),
+                ErrorLevel.valueOf(entity.getLevel()),
+                entity.getSource(),
+                entity.getMessage(),
+                entity.getOccurredAt()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/persistence/SpringDataErrorLogRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/infrastructure/persistence/SpringDataErrorLogRepository.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.admin.infrastructure.persistence;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/* comment.
+    SpringDataErrorLogRepository 정리
+    1. 역할 : Spring Data Jpa 가 런타임에 자동으로 구현체를 만들어주는 저장소 인터페이스이다.
+    2. 위치 : 인프라 계층
+    3. 누가 호출하는가 : ErrorLogRepositoryAdapter 가 주입받아 호출하게 된다. (외부에 직접적으로 노출 X)
+    4. WHY 도메인 ErrorLogRepository 와 별도로 두는가
+       → ErrorLogRepository (도메인) : 비즈니스 약속, ErrorLog 도메인 모델을 다룬다.
+       → SpringDataErrorLogRepository (인프라) : Spring 기술 인터페이스, ErrorLogJpaEntity 를 다룬다.
+    5. 메서드 2개 시그니처 의미
+       - findAllByOrderByOccurredAtDesc : findAll + OrderBy + OccurredAt + Desc  정렬만 진행하고 필터는 존재하지 않는다.
+       - findAllByLevelOrderByOccurredAtDesc : 반대로 level 필터 + 정렬이 있다.
+ */
+public interface SpringDataErrorLogRepository extends JpaRepository<ErrorLogJpaEntity, Long> {
+
+    // 최근 N개 (occurredAt DESC) - Adapter 에서 PageRequest.of(0, limit) 으로 호출
+    List<ErrorLogJpaEntity> findAllByOrderByOccurredAtDesc(Pageable pageable);
+
+    // 특정 레벨의 최근 N개 (occurredAt DESC)
+    List<ErrorLogJpaEntity> findAllByLevelOrderByOccurredAtDesc(String level, Pageable pageable);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/AdminDashboardController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/AdminDashboardController.java
@@ -2,6 +2,7 @@ package com.wanted.momocity.admin.presentation.api;
 
 import com.wanted.momocity.admin.application.usecase.AdminDashboardQueryUseCase;
 import com.wanted.momocity.admin.presentation.api.response.DashboardSummaryResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -56,7 +57,7 @@ public class AdminDashboardController {
             summary = "관리자 대시보드 요약 통계",
             description = "회원 / 신고 / 강의 총 개수를 한 번에 조회한다. FE 대시보드 페이지 진입 시 호출."
     )
-    public ResponseEntity<DashboardSummaryResponse> getDashboardSummary() {
+    public ResponseEntity<ApiResponse<DashboardSummaryResponse>> getDashboardSummary() {
         throw new UnsupportedOperationException("TODO: m03 우선순위 - admin 대시보드 요약 통계 컨트롤러 구현");
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/ErrorLogController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/ErrorLogController.java
@@ -1,10 +1,12 @@
 package com.wanted.momocity.admin.presentation.api;
 
 import com.wanted.momocity.admin.application.usecase.ErrorLogQueryUseCase;
+import com.wanted.momocity.admin.domain.audit.ErrorLog;
 import com.wanted.momocity.admin.presentation.api.response.ErrorLogResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /* comment.
     ErrorLogController 정리
@@ -31,10 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
         b) UseCase 호출
         c) Result → Item DTO 변환 (stream map)
         d) ErrorLogResponse 로 묶기
-        e) ResponseEntity 로 반환
-    6. MS-6 / 대시보드 Controller 와 차이 :
-        - HTTP 메서드 : GET (조회)
-        - 입력 : @RequestParam (쿼리 파라미터), path variable / body 없음
+        e) ApiResponse wrapper 로 감싸 ResponseEntity 반환 (전 컨트롤러 일관성)
  */
 @RestController
 @RequestMapping("/api/v1/admin")
@@ -48,38 +49,49 @@ public class ErrorLogController {
         this.errorLogQueryUseCase = errorLogQueryUseCase;
     }
 
-    /* comment.
-        실제 구현 시 흐름 (m03 우선순위) :
-        1. ErrorLogList result = errorLogQueryUseCase.getRecent(limit);
-        2. List<Item> items = result.errorLogs().stream()
-                                    .map(this::toItem)
-                                    .toList();
-        3. ErrorLogResponse response = new ErrorLogResponse(items);
-        4. return ResponseEntity.ok(response);
-
-        // 헬퍼 (private Item toItem(ErrorLog log))
-        // return new Item(
-        //     log.getId(),
-        //     log.getLevel().name(),   // enum → String
-        //     log.getSource(),
-        //     log.getMessage(),
-        //     log.getOccurredAt()
-        // );
-     */
     @GetMapping("/error-logs")
     @Operation(
             summary = "관리자 에러 로그 조회",
             description = "최근 N개의 에러 로그를 조회한다. FE 대시보드 에러 로그 위젯이 호출."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "에러 로그 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 또는 만료"),
-            @ApiResponse(responseCode = "403", description = "ADMIN 권한 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200", description = "에러 로그 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401", description = "인증 토큰 누락 또는 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403", description = "ADMIN 권한 없음")
     })
-    public ResponseEntity<ErrorLogResponse> getRecentErrorLogs(
+    public ResponseEntity<ApiResponse<ErrorLogResponse>> getRecentErrorLogs(
             @Parameter(description = "조회할 최대 개수", example = "10")
             @RequestParam(defaultValue = "10") int limit
     ) {
-        throw new UnsupportedOperationException("TODO: m03 우선순위 - 에러 로그 조회 컨트롤러 구현");
+        // 1. UseCase 호출 → 도메인 리스트 받기
+        ErrorLogQueryUseCase.ErrorLogList result = errorLogQueryUseCase.getRecent(limit);
+
+        // 2. 도메인 → 응답 Item 변환 (stream map)
+        List<ErrorLogResponse.Item> items = result.errorLogs().stream()
+                .map(this::toItem)
+                .toList();
+
+        // 3. ApiResponse wrapper 로 감싸 200 OK 반환
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ApiResponseCode.SUCCESS,
+                        "에러 로그 조회 성공",
+                        new ErrorLogResponse(items)
+                )
+        );
+    }
+
+    // 도메인 ErrorLog → 응답 Item 변환 헬퍼 (enum → String)
+    private ErrorLogResponse.Item toItem(ErrorLog log) {
+        return new ErrorLogResponse.Item(
+                log.getId(),
+                log.getLevel().name(),
+                log.getSource(),
+                log.getMessage(),
+                log.getOccurredAt()
+        );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportQueryService.java
@@ -1,0 +1,43 @@
+package com.wanted.momocity.report.application.service;
+
+import com.wanted.momocity.report.application.usecase.ReportQueryUseCase;
+import com.wanted.momocity.report.domain.model.ReportStatus;
+import com.wanted.momocity.report.domain.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/* comment.
+    ReportQueryService 정리
+    1. 역할 : ReportQueryUseCase 의 구현체. Repository 에 조회를 위임하고 UseCase 출력 형식으로 감싸서 반환
+    2. 위치 : 응용 계층 - 구현
+    3. WHY @Transactional(readOnly = true) 클래스 레벨
+       → 모든 메서드가 조회 전용이기 때문에 데이터가 변경될 위험은 없다
+       → 실수로 save 호출 시 즉시 예외가 발생하게 된다.
+    4. WHY ReportRepository 에 직접 의존 (Port 패턴 안 씀)
+       → Report 는 신고 BC 자체 도메인이다. 외부 BC 가 아니다.
+       → BC 경계 격리 불필요하다.
+    5. ReportCommandService 와 의존성/트랜잭션 차이
+       - 의존성 : Command 는 ReporterAccountPort + ReportRepository 둘 다, Query 는 ReportRepository 만
+       - 트랜잭션 : Command 는 쓰기(@Transactional), Query 는 읽기(@Transactional(readOnly = true))
+    6. 메서드 2개 처리 흐름
+       a) getRecent(limit) : repository.findRecent(limit) 호출 → List<Report> 받음 → ReportList 로 감싸 반환
+       b) getByStatus(status, limit) : repository.findByStatus(status, limit) 호출 → 동일하게 감싸 반환
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportQueryService implements ReportQueryUseCase {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public ReportList getRecent(int limit) {
+        return new ReportList(reportRepository.findRecent(limit));
+    }
+
+    @Override
+    public ReportList getByStatus(ReportStatus status, int limit) {
+        return new ReportList(reportRepository.findByStatus(status, limit));
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/usecase/ReportQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/usecase/ReportQueryUseCase.java
@@ -1,0 +1,46 @@
+package com.wanted.momocity.report.application.usecase;
+
+import com.wanted.momocity.report.domain.model.Report;
+import com.wanted.momocity.report.domain.model.ReportStatus;
+
+import java.util.List;
+
+/* comment.
+    ReportQueryUseCase 정리
+    1. 역할 : 신고 목록 조회(읽기) 응용 계층 계약
+    2. 위치 : 응용 계층 - 계약
+    3. WHY Query 전용 (Command 와 분리)
+        Query: 데이터 조회 → 읽기 전용 트랜잭션 (@Transactional(readOnly = true))
+        Command: 데이터 변경 → 쓰기 트랜잭션
+        CQRS 경량 적용 → 책임/트랜잭션 정책 분리
+    4. WHY 메서드 2개 (getRecent + getByStatus)
+        getRecent : 전체 최근 N개 (status 필터 없음)
+        getByStatus : 특정 상태(예: PENDING) 의 최근 N개
+    5. WHY ReportList record 를 내부에 두는가
+        UseCase 의 출력 계약을 같은 파일에 두면 한눈에 파악
+        ErrorLogQueryUseCase 의 ErrorLogList 와 동일 패턴
+        외부에서 ReportQueryUseCase.ReportList 로 명확히 참조
+    6. WHY 도메인 객체(Report) 그대로 노출
+       → UseCase 는 응용 계층의 결과를 그대로 노출하게 된다.
+       → DTO 변환 책임은 Controller 가 담당하게 된다.
+ */
+public interface ReportQueryUseCase {
+
+    ReportList getRecent(int limit);
+
+    ReportList getByStatus(ReportStatus status, int limit);
+
+    /* comment.
+        ReportList 정리
+        1. 역할 : 신고 목록 데이터 묶음. UseCase 출력 계약
+        2. WHY List 만 있는데 record 로 감싸는가
+           → 지금은 List<Report> 하나만 있지만 향후 데이터 추가 시 시그니처가 바뀌지 않는다
+           → 메서드 반환 타입을 record 로 두면 의미가 명확해진다.
+        3. 향후 확장 여지
+           → totalCount : 전체 신고 수
+           → hasMore : 다음페이지가 있는지
+     */
+    record ReportList(
+            List<Report> reports
+    ) { }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/repository/ReportRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/repository/ReportRepository.java
@@ -25,4 +25,7 @@ public interface ReportRepository {
 
     // 특정 상태의 최근 신고 N개
     List<Report> findByStatus(ReportStatus status, int limit);
+
+    // 전체 신고 수 (대시보드 통계용 - ReportStatsAdapter 가 호출)
+    long countAll();
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/adapter/ReportStatsAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/adapter/ReportStatsAdapter.java
@@ -1,0 +1,32 @@
+package com.wanted.momocity.report.infrastructure.adapter;
+
+import com.wanted.momocity.admin.application.port.ReportStatsPort;
+import com.wanted.momocity.report.domain.repository.ReportRepository;
+import org.springframework.stereotype.Component;
+
+/* comment.
+    ReportStatsAdapter 정리
+    1. 역할 : admin BC 의 ReportStatsPort 를 report BC 의 ReportRepository 로 구현하는 어댑터
+    2. 위치 : report/infrastructure/adapter (인프라 계층 - 외부 BC Port 구현)
+    3. WHY report BC 에 위치 (admin 아님)
+       → 데이터 소유자(report) 가 어댑터를 제공하는 패턴
+       → member / lecture 가 자기 어댑터 제공하는 것과 동일 정책
+       → admin BC 는 ReportStatsPort 인터페이스만 보고 구현체 모름
+    4. WHY ReportRepository 직접 사용
+       → 자체 BC 내부 의존 → 도메인 Repository 직접 사용 OK
+       → ReporterAccountPort 와 다른 점 : ReporterAccountPort 는 외부 BC(auth) 사용이라 Port 패턴
+ */
+@Component
+public class ReportStatsAdapter implements ReportStatsPort {
+
+    private final ReportRepository reportRepository;
+
+    public ReportStatsAdapter(ReportRepository reportRepository) {
+        this.reportRepository = reportRepository;
+    }
+
+    @Override
+    public long countAll() {
+        return reportRepository.countAll();
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportRepositoryAdapter.java
@@ -61,6 +61,12 @@ public class ReportRepositoryAdapter implements ReportRepository {
                 .toList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public long countAll() {
+        return repository.count();
+    }
+
     // === 변환 메서드 (도메인 ↔ 엔티티) ===
 
     // 도메인 → 엔티티 (신규 저장 시 id=null, JPA 가 auto-increment 부여)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
@@ -1,0 +1,90 @@
+package com.wanted.momocity.report.presentation.api;
+
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.report.application.usecase.ReportQueryUseCase;
+import com.wanted.momocity.report.domain.model.ReportStatus;
+import com.wanted.momocity.report.presentation.api.response.ReportListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/* comment.
+    AdminReportController 정리
+    1. 역할 : 관리자 신고 목록 조회 HTTP API 진입점 (ADMIN 권한 가진 사용자만 접근 가능)
+    2. 다루는 API : GET /api/v1/admin/reports?limit=N&status=PENDING
+    3. 클래스 레벨 어노테이션
+       - @RestController : REST API 컨트롤러. 반환값 자동 JSON 직렬화.
+       - @RequiredArgsConstructor : final 필드 생성자 자동 생성 (Lombok).
+       - @RequestMapping("/api/v1/admin/reports") : 공통 URL prefix.
+       - @PreAuthorize("hasRole('ADMIN')") : 모든 핸들러 호출 전 ADMIN 권한 검사. 미충족 시 403.
+       - @Tag : Swagger UI 에서 "Admin - 신고" 그룹.
+    4. 의존성
+        - ReportQueryUseCase : UseCase 인터페이스 의존. 구현체는 ReportQueryService 모르고있는 상태
+    5. getReports 처리 흐름 4단계
+        a) HTTP 요청 받기 (limit + status query param)
+        b) status null 여부에 따라 getRecent 또는 getByStatus 선택 호출
+        c) UseCase 출력(ReportList) → ReportListResponse.from() 으로 응답 DTO 변환
+        d) ResponseEntity.ok() + 공통 응답 wrapper 로 반환
+    6. WHY status 파라미터가 optional (required = false)
+       → 호출자 의도 에 따라 두 가지 사용 패턴이 지원된다
+            1. status 없음 : 전체 최근 N개
+            2. status 있음 : 특정 상태의 최근 N개
+       → 한 엔드포인트를 통해서 두 케이스를 처리한다.
+    7. WHY ReportController 와 별도 컨트롤러
+       → 권한 정책이 다르기 때문에 클래스 레벨에서 분리하면 가독성 및 유지보수가 좋아진다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/reports")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin - 신고", description = "관리자 신고 목록 조회")
+public class AdminReportController {
+
+    private final ReportQueryUseCase reportQueryUseCase;
+
+    @GetMapping
+    @Operation(
+            summary = "관리자 신고 목록 조회",
+            description = "최근 N개의 신고를 조회한다. status 파라미터로 상태별 필터링 가능."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200", description = "신고 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401", description = "인증 토큰 누락 또는 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403", description = "ADMIN 권한 없음")
+    })
+    public ResponseEntity<ApiResponse<ReportListResponse>> getReports(
+            @Parameter(description = "조회할 최대 개수", example = "10")
+            @RequestParam(defaultValue = "10") int limit,
+            @Parameter(description = "신고 상태 필터 (선택)", example = "PENDING")
+            @RequestParam(required = false) ReportStatus status
+    ) {
+        // 1. status 유무에 따라 UseCase 메서드 선택
+        ReportQueryUseCase.ReportList list = (status == null)
+                ? reportQueryUseCase.getRecent(limit)
+                : reportQueryUseCase.getByStatus(status, limit);
+
+        // 2. UseCase 출력 → 응답 DTO 변환
+        ReportListResponse response = ReportListResponse.from(list);
+
+        // 3. 200 OK + 공통 응답 wrapper 로 반환
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ApiResponseCode.SUCCESS,
+                        "신고 목록 조회 성공",
+                        response
+                )
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/ReportListResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/ReportListResponse.java
@@ -1,0 +1,76 @@
+package com.wanted.momocity.report.presentation.api.response;
+
+import com.wanted.momocity.report.application.usecase.ReportQueryUseCase;
+import com.wanted.momocity.report.domain.model.Report;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/* comment.
+    ReportListResponse 정리
+    1. 역할 : 신고 목록을 HTTP 응답을 보내는 DTO이다. AdminReportController 가 도메인 리스트를 이걸로 변환해서 반환
+    2. 위치 : 표현 계층 - 출력 DTO
+    3. WHY wrapper 패턴 (items 한 필드만)
+       → 향후 totalCount, hasMore 등 데이터 추가 시 시그니처 변경 X
+    4. WHY from(ReportList) 정적 팩토리
+       → UseCase 출력(ReportQueryUseCase.ReportList) → 응답 DTO 변환 책임 응집
+       → Controller 가 ReportListResponse.from(list) 한 줄로 변환
+    5. 응용 ReportList 와 분리하는 이유
+        → ReportList (응용) : 도메인 List<Report> 묶음, UseCase 출력 계약
+        → ReportListResponse (표현) : HTTP 직렬화 형태, FE 가 받는 JSON 구조
+        → 두 계층 다른 책임 → 분리
+    6. WHY 내부 Item record 분리
+       → List<Report> 직접 노출 X → 표현 계층은 도메인 노출 안 함
+ */
+public record ReportListResponse(
+        List<Item> items
+) {
+
+    public static ReportListResponse from(ReportQueryUseCase.ReportList list) {
+        List<Item> items = list.reports().stream()
+                .map(Item::from)
+                .toList();
+        return new ReportListResponse(items);
+    }
+
+    /* comment.
+        Item 정리
+        1. 역할 : 신고 1건의 응답 형태이며 목록 안에 여러 개가 들어가게 된다.
+        2. WHY enum 을 String 으로 변환 (targetType, reason, status)
+           → 표현 계층은 enum 타입이 직접 노출되지 않는다.
+           → JSON 직렬화 시 FE 호환성이 높아진다.
+        3. 필드 8개 의미
+        reportId : 신고 식별자
+        reporterUserId : 신고자 ID
+        targetType : 신고 대상 종류 (POST / COMMENT / USER / LECTURE)
+        targetId : 신고 대상 ID
+        reason : 신고 사유
+        detail : 자유 설명 (nullable)
+        status : 신고 처리 상태
+        reportedAt : 접수 시각
+     */
+    public record Item(
+            Long reportId,
+            Long reporterUserId,
+            String targetType,
+            Long targetId,
+            String reason,
+            String detail,
+            String status,
+            LocalDateTime reportedAt
+    ) {
+
+        public static Item from(Report report) {
+            return new Item(
+                    report.getId(),
+                    report.getReporterUserId(),
+                    report.getTargetType().name(),
+                    report.getTargetId(),
+                    report.getReason().name(),
+                    report.getDetail(),
+                    report.getStatus().name(),
+                    report.getReportedAt()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary

- **report 영역**: 신고 목록 조회 API 추가 → report BC 100% 완료
- **admin 영역**: ErrorLog 인프라 풀세트 + Service/Controller 실구현 → admin BC mnppi 담당 부분 100% 완료
- **BC 정합**: admin ↔ report 사이 Port 패턴(`ReportStatsPort`) 적용으로 BC 격리 일관 완성

---

## 🎯 작업 내용

### 1. 신고 목록 조회 API (`GET /api/v1/admin/reports`)
- `ReportQueryUseCase` + 내부 `ReportList` record (응용 계층 계약)
- `ReportQueryService` 구현 (`@Transactional(readOnly=true)`)
- `ReportListResponse` + 내부 `Item` record (HTTP 응답 DTO)
- `AdminReportController` (`@PreAuthorize("hasRole('ADMIN')")`, status/limit 필터)

### 2. ErrorLog 인프라 구축
- `ErrorLogJpaEntity` (error_log 테이블 매핑, `BaseTimeEntity` 상속)
- `SpringDataErrorLogRepository` (Spring Data JPA)
- `ErrorLogRepositoryAdapter` (도메인 ↔ 엔티티 변환 + 트랜잭션)

### 3. admin 영역 stub 해소
- `ErrorLogQueryService` stub → 실구현 (Repository 주입)
- `ErrorLogController` stub → 실구현 (`ApiResponse` wrapper 적용)
- `AdminDashboardController` 시그니처에 `ApiResponse` 통일 (본문은 외부 어댑터 대기로 stub 유지)

### 4. BC 정합 정정 (admin ↔ report)
- `ReportStatsPort` (admin BC 정의)
- `ReportStatsAdapter` (report BC 가 admin Port 구현 - 데이터 소유자 측 어댑터)
- `ReportRepository.countAll()` 메서드 추가 + Adapter 구현
- `AdminDashboardQueryService` 주석 정정 — "자기 영역 직접 의존" → "외부 BC Port 패턴"

---

## 🏛 아키텍처 패턴 적용

| 패턴 | 적용 |
|---|---|
| **DDD 4계층** | `domain` / `application` / `infrastructure` / `presentation` |
| **DIP** | Controller → UseCase, Service → Repository / Port |
| **헥사고날 (Port/Adapter)** | `ReporterAccountPort`, `ReportStatsPort` 등 |
| **CQRS 경량** | `ReportCommandUseCase` (쓰기) / `ReportQueryUseCase` (조회) |
| **BC 격리** | admin ↔ report / admin ↔ member / admin ↔ lecture 모두 Port 패턴 일관 |

---

## ✅ 검증

- [x] `./gradlew compileJava` 통과
- [x] enrollment / admin / report BC 컨벤션 일관성
- [x] `ApiResponse<T>` wrapper 전 컨트롤러 통일

---

## 🔲 남은 작업 (다음 PR)

- [ ] 전역 예외 처리 (`@RestControllerAdvice`)
- [ ] API 명세 문서화 (수영님 협업)
- [ ] 인수인계서 업데이트 + 트러블슈팅 회고
- [ ] `AdminDashboardController` / `AdminDashboardQueryService` 실구현 (외부 어댑터 입수 후)

---

## 🧪 Test Plan

- [ ] 로컬 빌드 (`./gradlew build`) 통과
- [ ] `GET /api/v1/admin/reports?limit=10&status=PENDING` 호출 테스트
- [ ] `GET /api/v1/admin/error-logs?limit=10` 호출 테스트
- [ ] 신고 데이터 + 에러 로그 데이터 DB 저장 확인
- [ ] Swagger UI 에서 모든 admin API 응답이 `ApiResponse` wrapper 형태인지 확인

---

## 📚 학습 포인트 (발표용)

- **BC 정합성**: admin 이 외부 BC 데이터 가져올 때 항상 Port 정의 → 데이터 소유자가 어댑터 제공 (member/lecture/report 동일)
- **stub vs 실구현 패턴**: 의존성 미준비 시 stub 유지, 준비되면 단계적 해소
- **ApiResponse wrapper 일관성**: 전 API 가 동일 응답 구조 → FE 호출/에러 처리 단순화