### PR TITLE
[PR] 강사 강의 상세 조회 및 teacherEmail -> teacherId로 변경

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/ChangeLectureStatusCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/ChangeLectureStatusCommand.java
@@ -4,7 +4,7 @@ import com.wanted.momocity.lecture.domain.model.LectureStatus;
 
 // 강의 상태 변경에 필요한 값을 담는 Command
 public record ChangeLectureStatusCommand(
-        String teacherEmail,
+        Long teacherId,
         Long lectureId,
         LectureStatus lectureStatus
 ) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/CreateChapterCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/CreateChapterCommand.java
@@ -4,7 +4,7 @@ package com.wanted.momocity.lecture.application.command;
 public record CreateChapterCommand(
         // 로그인한 강사의 email
         // Authorization 토큰에서 꺼낸 값
-        String teacherEmail,
+        Long teacherId,
 
         // 챕터를 등록할 강의 ID
         Long lectureId,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/CreateLectureCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/CreateLectureCommand.java
@@ -6,7 +6,7 @@ import com.wanted.momocity.lecture.domain.model.LectureCategory;
  * CreateLectureCommand는 강의 등록 유스케이스에 필요한 입력값 레코드
  */
 public record CreateLectureCommand(
-        String teacherEmail,
+        Long teacherId,
         String title,
         String description,
         String thumbnailUrl,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/RegisterChapterVideoCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/RegisterChapterVideoCommand.java
@@ -8,7 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 * */
 public record RegisterChapterVideoCommand(
         // Authorization 토큰에서 꺼낸 로그인 강사 Email
-        String teacherEmail,
+        Long teacherId,
         // 강의 Id
         Long lectureId,
         // 챕터 Id

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/TeacherAccountPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/TeacherAccountPort.java
@@ -7,5 +7,5 @@ package com.wanted.momocity.lecture.application.port;
 public interface TeacherAccountPort {
 
     // email로 강사 조회
-    Long getTeacherId(String email);
+    Long getTeacherId(Long userId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetTeacherLectureDetailQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetTeacherLectureDetailQuery.java
@@ -1,0 +1,22 @@
+package com.wanted.momocity.lecture.application.query;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+
+public record GetTeacherLectureDetailQuery(
+
+        // 토큰에서 꺼낸 로그인 사용자 PK
+        Long teacherId,
+        Long lectureId
+) {
+
+    // Query 객체가 생성될 때 필요한 값이 비어있는지 검증합니다.
+    public GetTeacherLectureDetailQuery {
+        if (teacherId == null) {
+            throw new DomainRuleViolationException("강사 정보는 필수입니다.");
+        }
+
+        if (lectureId == null) {
+            throw new DomainRuleViolationException("강의 ID는 필수입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetTeacherLecturesQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetTeacherLecturesQuery.java
@@ -5,7 +5,7 @@ import com.wanted.momocity.lecture.domain.model.LectureCategory;
 
 // 강사 강의 목록 조회의 조건을 담은 record
 public record GetTeacherLecturesQuery(
-        String teacherEmail,
+        Long teacherId,
         int page,
         int size,
         LectureCategory category,
@@ -13,13 +13,13 @@ public record GetTeacherLecturesQuery(
 ) {
     // Query 객체가 만들어질 때 기본 조회 조건을 검증
     public GetTeacherLecturesQuery {
-        validateTeacherEmail(teacherEmail);
+        validateTeacherId(teacherId);
         validatePage(page);
         validateSize(size);
     }
     // 로그인한 강사 email
-    private static void validateTeacherEmail(String teacherEmail) {
-        if (teacherEmail == null || teacherEmail.isBlank()) {
+    private static void validateTeacherId(Long teacherId) {
+        if (teacherId == null) {
             throw new DomainRuleViolationException("강사 정보는 필수입니다.");
         }
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
@@ -46,7 +46,7 @@ public class ChapterCommandService implements ChapterCommandUseCase {
     @Override
     public LectureChapter createChapter(CreateChapterCommand command) {
         // Authorization 토큰에서 가져온 email로 강사 ID를 조회합니다.
-        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherId());
 
         // 챕터를 등록할 강의를 조회
         LectureAggregate lecture = lectureRepository.findById(command.lectureId())
@@ -90,7 +90,7 @@ public class ChapterCommandService implements ChapterCommandUseCase {
     @Override
     public LectureChapter registerChapterVideo(RegisterChapterVideoCommand command) {
         // Authrization 토큰에서 가져온 email로 강사 Id 조회
-        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherId());
 
         // 동영상을 등록할 강의를 조회
         LectureAggregate lecture = lectureRepository.findById(command.lectureId())

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
@@ -47,7 +47,7 @@ public class LectureCommandService implements LectureCommandUseCase {
         /*
          * Authorization 토큰에서 얻은 email로 강사 id를 조회한다.
          */
-        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherId());
 
         // command.thumbnailUrl()은 S3 업로드 후 생성된 이미지 URL이다.
         LectureAggregate lecture = LectureAggregate.create(
@@ -75,7 +75,7 @@ public class LectureCommandService implements LectureCommandUseCase {
         /*
          * Authorization 토큰에서 얻은 email로 강사 id를 조회합니다.
          */
-        Long teacherId = teacherAccountPort.getTeacherId(command.teacherEmail());
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherId());
 
         // 상태를 변경할 강의를 조회합니다.
         LectureAggregate lecture = lectureRepository.findById(command.lectureId())

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -4,17 +4,19 @@ import com.wanted.momocity.enrollment.application.port.StudentAccountPort;
 import com.wanted.momocity.lecture.application.port.LectureEnrollmentQueryPort;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
-import com.wanted.momocity.lecture.presentation.api.response.LectureListItemResponse;
-import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.*;
 
-import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureListItemResponse;
-import com.wanted.momocity.lecture.presentation.api.response.TeacherLecturePageResponse;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,9 @@ public class LectureQueryService implements LectureQueryUseCase {
     private final LectureEnrollmentQueryPort lectureEnrollmentQueryPort;
 
     private final TeacherAccountPort teacherAccountPort;
+
+    // 챕터 목록 조회
+    private final ChapterRepository chapterRepository;
 
     // 강의 목록을 조회
     @Override
@@ -89,7 +94,7 @@ public class LectureQueryService implements LectureQueryUseCase {
          * Authorization 토큰에서 가져온 email로 강사 ID를 조회합니다.
          * 강사 권한이 아니거나 사용자를 찾을 수 없으면 TeacherAccountPort 쪽에서 예외가 발생합니다.
          */
-        Long teacherId = teacherAccountPort.getTeacherId(query.teacherEmail());
+        Long teacherId = teacherAccountPort.getTeacherId(query.teacherId());
 
         /*
          * teacherId 기준으로 본인이 등록한 강의만 조회합니다.
@@ -120,6 +125,30 @@ public class LectureQueryService implements LectureQueryUseCase {
                 lecturePage.totalElements(),
                 lecturePage.totalPages()
         );
+    }
+
+    // 강사가 본인이 등록한 강의 상세 정보와 챕터 목록을 조회합니다.
+    @Override
+    public TeacherLectureDetailResponse getTeacherLectureDetail(GetTeacherLectureDetailQuery query) {
+
+        // 토큰에서 꺼낸 teacherId가 실제 강사 계정인지 확인합니다.
+        Long teacherId = teacherAccountPort.getTeacherId(query.teacherId());
+
+        // lectureId로 강의를 조회합니다.
+        LectureAggregate lecture = lectureRepository.findById(query.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 본인이 등록한 강의가 아니면 조회할 수 없습니다.
+        if (!lecture.isOwnedBy(teacherId)) {
+            throw new AccessDeniedException("본인이 등록한 강의만 조회할 수 있습니다.");
+        }
+
+        // 해당 강의의 챕터 목록을 orderNo 오름차순으로 조회합니다.
+        List<LectureChapter> chapters =
+                chapterRepository.findAllByLectureIdOrderByOrderNoAsc(query.lectureId());
+
+        // 강의 정보와 챕터 목록을 응답 DTO로 변환합니다.
+        return TeacherLectureDetailResponse.from(lecture, chapters);
     }
 
     /**

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
@@ -1,8 +1,10 @@
 package com.wanted.momocity.lecture.application.usecase;
 
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
 import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLecturePageResponse;
 
 /**
@@ -23,4 +25,7 @@ public interface LectureQueryUseCase {
     // 강사용 강의 목록 조회
     // 로그인한 강사가 본인이 등록한 강의만 조회
     TeacherLecturePageResponse getTeacherLectures(GetTeacherLecturesQuery query);
+
+    // 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회
+    TeacherLectureDetailResponse getTeacherLectureDetail(GetTeacherLectureDetailQuery query);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
@@ -3,6 +3,7 @@ package com.wanted.momocity.lecture.domain.repository;
 
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -25,4 +26,7 @@ public interface ChapterRepository {
 
     // 특정 강의에 동영상이 등록되지 않은 챕터가 있는지 확인
     boolean existsByLectureIdAndVideoUrlIsNull(Long lectureId);
+
+    // 특정 강의에 등록된 챕터 목록을 orderNo 오름차순으로 조회
+    List<LectureChapter> findAllByLectureIdOrderByOrderNoAsc(Long lectureId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/AuthTeacherAccountAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/AuthTeacherAccountAdapter.java
@@ -26,8 +26,8 @@ public class AuthTeacherAccountAdapter implements TeacherAccountPort {
      * 해당 사용자가 강사인지 확인한 뒤 user id를 teacherId로 반환
      */
     @Override
-    public Long getTeacherId(String email) {
-        User user = loadUserPort.findByEmail(email)
+    public Long getTeacherId(Long userId) {
+        User user = loadUserPort.findById(userId)
                 .orElseThrow(() -> new AuthenticationCredentialsNotFoundException("인증된 사용자 정보를 찾을 수 없습니다."));
 
         if (user.getRole() != Role.TEACHER) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
@@ -7,6 +7,7 @@ import com.wanted.momocity.lecture.infrastructure.persistence.ChapterJpaEntity;
 import com.wanted.momocity.lecture.infrastructure.persistence.SpringDataChapterRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 // ChapterRepositoryAdapter는 도메인 Repository를 JPA Repository와 연결합니다.
@@ -47,6 +48,15 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
     @Override
     public boolean existsByLectureIdAndVideoUrlIsNull(Long lectureId) {
         return repository.existsByLectureIdAndVideoUrlIsNull(lectureId);
+    }
+
+    // 특정 강의에 속한 챕터 목록을 orderNo 오름차순으로 조회
+    @Override
+    public List<LectureChapter> findAllByLectureIdOrderByOrderNoAsc(Long lectureId) {
+        return repository.findAllByLectureIdOrderByOrderNoAsc(lectureId)
+                .stream()
+                .map(ChapterJpaEntity::toDomain)
+                .toList();
     }
     
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
@@ -2,6 +2,8 @@ package com.wanted.momocity.lecture.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 // SpringDataChapterRepository는 Spring Data JPA 전용 Repository
 public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEntity, Long> {
 
@@ -13,4 +15,7 @@ public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEnt
 
     // 강의에 videoUrl이 비어있는 챕터가  있는지 확인
     boolean existsByLectureIdAndVideoUrlIsNull(Long lectureId);
+
+    // 특정 강의에 속한 챕터 목록을 orderNo 오름차순으로 조회
+    List<ChapterJpaEntity> findAllByLectureIdOrderByOrderNoAsc(Long lectureId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -62,11 +62,10 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
 
     /*
      * 강사가 본인이 등록한 강의 목록을 조회합니다.
-     *
-     * 조건:
-     * - teacherId는 필수입니다.
-     * - category가 있으면 해당 카테고리만 조회합니다.
-     * - keyword가 있으면 강의 제목에 keyword가 포함된 강의만 조회합니다.
+     *  Query문 쓴 이유 :  선택 필터가 있는 목록 조회를 메서드 여러 개로 나누지 않고, 하나의 조회 메서드에서 처리하기 위해서
+     * 조회 결과로 LectureJpaEntity 객체 전체를 가져와서 LectureJpaEntity에서 데이터를 조회하고,
+     * 그 Entity를 앞으로 l이라는 별명으로 부른다.
+     * 로그인한 강사의 ID와 강의의 teacherId가 같은 것만 조회한다.
      */
     @Query("""
         select l

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -4,13 +4,16 @@ import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationExc
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -79,6 +82,39 @@ public class LectureController {
         ));
     }
 
+    // 강사 강의 상세 조회 API입니다.
+// 로그인한 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회합니다.
+    @Operation(
+            summary = "강사 강의 상세 조회",
+            description = "로그인한 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회합니다."
+    )
+    @GetMapping("/{lectureId}")
+    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
+    public ResponseEntity<ApiResponse<TeacherLectureDetailResponse>> getTeacherLectureDetail(
+            Authentication authentication,
+            @PathVariable Long lectureId
+    ) {
+        // Authorization 토큰에서 로그인한 강사 ID를 꺼냅니다.
+        Long teacherId = Long.parseLong(authentication.getName());
+
+        // Controller에서 받은 값을 Application 계층에서 사용할 Query 객체로 묶습니다.
+        GetTeacherLectureDetailQuery query = new GetTeacherLectureDetailQuery(
+                teacherId,
+                lectureId
+        );
+
+        // 강사 강의 상세 조회 UseCase를 실행합니다.
+        TeacherLectureDetailResponse response =
+                lectureQueryUseCase.getTeacherLectureDetail(query);
+
+        // 조회 성공 응답을 반환합니다.
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "강사 강의 상세 조회에 성공했습니다.",
+                response
+        ));
+    }
+
     /*
      * 문자열 category를 LectureCategory enum으로 변환
      * category가 없으면 null을 반환해서 전체 카테고리를 조회
@@ -94,4 +130,6 @@ public class LectureController {
             throw new DomainRuleViolationException("허용되지 않는 강의 카테고리입니다.");
         }
     }
+
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -61,8 +61,7 @@ public class TeacherLectureController {
             Authentication authentication,
             @Valid @ModelAttribute CreateLectureRequest request
     ) {
-        String teacherEmail = authentication.getName();
-
+        Long teacherId = Long.parseLong(authentication.getName());
         /*
          * S3 업로드 전에 category를 먼저 검증
          * 잘못된 카테고리 요청이면 여기서 400 응답으로 끝나고, 썸네일 파일은 업로드 X
@@ -72,7 +71,7 @@ public class TeacherLectureController {
         String thumbnailUrl = s3UploadPort.upload(request.thumbnail());
 
         LectureAggregate lecture = lectureCommandUseCase.createLecture(
-                request.toCommand(teacherEmail, thumbnailUrl)
+                request.toCommand(teacherId, thumbnailUrl)
         );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(
@@ -96,10 +95,10 @@ public class TeacherLectureController {
             @Valid @RequestBody CreateChapterRequest request
     ) {
         // Authorization 토큰에서 로그인한 강사의 email을 가져옴
-        String teacherEmail = authentication.getName();
+        Long teacherId = Long.parseLong(authentication.getName());
 
         // Request DTO를 application 계층의 Command로 변환
-        var command = request.toCommand(teacherEmail, lectureId);
+        var command = request.toCommand(teacherId, lectureId);
 
         // 챕터 등록 유스케이스를 실행
         LectureChapter chapter = chapterCommandUseCase.createChapter(command);
@@ -134,11 +133,11 @@ public class TeacherLectureController {
             @Valid @ModelAttribute RegisterChapterVideoRequest request
     ) {
         // Authorization 토큰에서 로그인한 강사의 email을 가져옵니다.
-        String teacherEmail = authentication.getName();
+        Long teacherId = Long.parseLong(authentication.getName());
 
         // 요청 DTO를 Application 계층에서 사용할 Command로 변환합니다.
         RegisterChapterVideoCommand command = request.toCommand(
-                teacherEmail,
+                teacherId,
                 lectureId,
                 chapterId
         );
@@ -172,11 +171,11 @@ public class TeacherLectureController {
             @Valid @RequestBody ChangeLectureStatusRequest request
     ) {
         // Authorization 토큰에서 로그인한 강사의 email을 가져옴
-        String teacherEmail = authentication.getName();
+        Long teacherId = Long.parseLong(authentication.getName());
 
         // Request DTO를 Application 계층에서 사용할 Command로 변환
         ChangeLectureStatusCommand command = request.toCommand(
-                teacherEmail,
+                teacherId,
                 lectureId
         );
 
@@ -214,11 +213,11 @@ public class TeacherLectureController {
             @RequestParam(required = false) String keyword
     ) {
         // Authorization 토큰에서 로그인한 강사의 email을 가져옵니다.
-        String teacherEmail = authentication.getName();
+        Long teacherId = Long.parseLong(authentication.getName());
 
         // 요청 파라미터를 Application 계층의 Query 객체로 변환합니다.
         GetTeacherLecturesQuery query = new GetTeacherLecturesQuery(
-                teacherEmail,
+                teacherId,
                 page,
                 size,
                 parseCategory(category),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/ChangeLectureStatusRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/ChangeLectureStatusRequest.java
@@ -15,11 +15,11 @@ public record ChangeLectureStatusRequest(
 
     // 문자열로 받은 상태값을 LectureStatus enum으로 변환한 뒤 Command로 만든다.
     public ChangeLectureStatusCommand toCommand(
-            String teacherEmail,
+            Long teacherId,
             Long lectureId
     ) {
         return new ChangeLectureStatusCommand(
-                teacherEmail,
+                teacherId,
                 lectureId,
                 parseLectureStatus()
         );

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateChapterRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateChapterRequest.java
@@ -16,9 +16,9 @@ public record CreateChapterRequest(
 ) {
 
     // Controller에서 받은 요청값을 application 계층의 Command로 변환
-    public CreateChapterCommand toCommand(String teacherEmail, Long lectureId) {
+    public CreateChapterCommand toCommand(Long teacherId, Long lectureId) {
         return new CreateChapterCommand(
-                teacherEmail,
+                teacherId,
                 lectureId,
                 title,
                 orderNo

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateLectureRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateLectureRequest.java
@@ -25,11 +25,11 @@ public record CreateLectureRequest(
 ) {
 
     // 중복 검증 추가
-    public CreateLectureCommand toCommand(String teacherEmail, String thumbnailUrl) {
+    public CreateLectureCommand toCommand(Long teacherId, String thumbnailUrl) {
         LectureCategory lectureCategory = parseCategory(category);
 
         return new CreateLectureCommand(
-                teacherEmail,
+                teacherId,
                 title,
                 description,
                 thumbnailUrl,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/RegisterChapterVideoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/RegisterChapterVideoRequest.java
@@ -29,12 +29,12 @@ public record RegisterChapterVideoRequest(
      * Controller는 HTTP 요청만 알고, Service는 Command만 보고 처리하게 분리합니다.
      */
     public RegisterChapterVideoCommand toCommand(
-            String teacherEmail,
+            Long teacherId,
             Long lectureId,
             Long chapterId
     ) {
         return new RegisterChapterVideoCommand(
-                teacherEmail,
+                teacherId,
                 lectureId,
                 chapterId,
                 video,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureChapterResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureChapterResponse.java
@@ -1,0 +1,57 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+import java.time.LocalDateTime;
+
+// 강사 강의 상세 조회에서 챕터 1개의 정보를 내려주는 응답 DTO
+public record TeacherLectureChapterResponse(
+
+        // 챕터 ID
+        Long chapterId,
+
+        // 챕터 제목
+        String title,
+
+        // 강의 안에서 챕터가 보여질 순서
+        int orderNo,
+
+        // 등록된 동영상 URL
+        String videoUrl,
+
+        // 등록된 동영상 파일 크기
+        Long videoSizeBytes,
+
+        // 동영상 재생 시간입니다. 단위는 초
+        Integer durationSec,
+
+        // 동영상 처리 상태
+        String videoStatus,
+
+        // 업로드한 원본 파일명
+        String originalFilename,
+
+        // 챕터 생성 일시
+        LocalDateTime createdAt,
+
+        // 챕터 수정 일시
+        LocalDateTime updatedAt
+
+) {
+
+    // 도메인 모델 LectureChapter를 응답 DTO로 변환
+    public static TeacherLectureChapterResponse from(LectureChapter chapter) {
+        return new TeacherLectureChapterResponse(
+                chapter.getId(),
+                chapter.getTitle(),
+                chapter.getOrderNo(),
+                chapter.getVideoUrl(),
+                chapter.getVideoSizeBytes(),
+                chapter.getDurationSec(),
+                chapter.getVideoStatus().name(),
+                chapter.getOriginalFilename(),
+                chapter.getCreatedAt(),
+                chapter.getUpdatedAt()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureDetailResponse.java
@@ -1,0 +1,68 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 강사 강의 상세 조회에서 강의 1개의 상세 정보를 내려주는 응답 DTO
+public record TeacherLectureDetailResponse(
+
+        // 강의 ID
+        Long lectureId,
+
+        // 강사 ID
+        Long teacherId,
+
+        // 강의 제목
+        String title,
+
+        // 강의 설명
+        String description,
+
+        // 강의 썸네일 이미지 URL
+        String thumbnailUrl,
+
+        // 강의 카테고리
+        String category,
+
+        // 강의 상태
+        String lectureStatus,
+
+        // 수강 완료 사용자 수
+        int completedUserCount,
+
+        // 강의에 포함된 챕터 목
+        List<TeacherLectureChapterResponse> chapters,
+
+        // 강의 생성 일시
+        LocalDateTime createdAt,
+
+        // 강의 수정 일시
+        LocalDateTime updatedAt
+
+) {
+
+    // LectureAggregate와 챕터 목록을 강의 상세 응답 DTO로 변환
+    public static TeacherLectureDetailResponse from(
+            LectureAggregate lecture,
+            List<LectureChapter> chapters
+    ) {
+        return new TeacherLectureDetailResponse(
+                lecture.getId(),
+                lecture.getTeacherId(),
+                lecture.getTitle(),
+                lecture.getDescription(),
+                lecture.getThumbnailUrl(),
+                lecture.getCategory().name(),
+                lecture.getStatus().name(),
+                lecture.getCompletedUserCount(),
+                chapters.stream()
+                        .map(TeacherLectureChapterResponse::from)
+                        .toList(),
+                lecture.getCreatedAt(),
+                lecture.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 인증 사용자 식별 기준을 `email`에서 `userId`로 변경
  - JWT 토큰에서 `authentication.getName()`으로 꺼낸 값을 로그인 사용자 PK로 사용하도록 수정
  - 강의 등록, 챕터 등록, 강의 상태 변경, 강사 강의 조회 로직에서 `teacherId` 기준으로 처리되도록 변경

- 강사 강의 상세 조회 API 구현
  - `GET /api/v1/teacher/lectures/{lectureId}`
  - 로그인한 강사 본인이 등록한 강의만 조회 가능하도록 처리
  - 강의 기본 정보와 챕터 목록을 함께 응답하도록 구성

- 챕터 목록 조회 연동
  - 강의 상세 조회 시 해당 강의의 챕터 목록을 함께 조회
  - 챕터는 `orderNo` 기준 오름차순으로 정렬

- 응답 DTO 추가
  - 강사 강의 상세 응답 DTO 추가
  - 상세 응답 내 챕터 응답 DTO 추가

## 검증

- `./gradlew compileJava` 성공