### PR TITLE
[PR] 학생 강의 목록 조회 메서드 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetLecturesQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetLecturesQuery.java
@@ -20,6 +20,10 @@ public record GetLecturesQuery(
         // null이면 수강 신청 여부와 상관없이 조회
         Boolean enrolled,
 
+        // 강의명 또는 강사명 검색어입니다.
+        // 값이 없으면 검색 조건 없이 조회합니다.
+        String keyword,
+
         // 조회할 페이지 번호
         // page는 1부터 시작
         int page,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -49,7 +49,7 @@ public class LectureQueryService implements LectureQueryUseCase {
 
     // 강의 목록을 조회
     @Override
-    public LecturePageResponse getLectures(GetLecturesQuery query) {
+    public StudentLecturePageResponse getLectures(GetLecturesQuery query) {
 
         // Authorization 토큰에서 꺼낸 email로 userId를 조회
         Long userId = studentAccountPort.getStudentId(query.userId());
@@ -61,6 +61,7 @@ public class LectureQueryService implements LectureQueryUseCase {
         // category와 enrolled 조건은 repository에서 처리함.
         var lecturePage = lectureRepository.findLectures(
                 query.category(),
+                query.keyword(),
                 query.enrolled(),
                 enrolledLectureIds,
                 query.page(),
@@ -68,7 +69,7 @@ public class LectureQueryService implements LectureQueryUseCase {
         );
 
         // 조회된 강의들을 응답 DTO로 변환합니다.
-        List<LectureListItemResponse> content = lecturePage.content().stream()
+        List<StudentLectureListItemResponse> content = lecturePage.content().stream()
                 .map(lecture -> toResponse(
                         lecture,
                         enrolledLectureIds.contains(lecture.getId()),
@@ -76,7 +77,7 @@ public class LectureQueryService implements LectureQueryUseCase {
                 ))
                 .toList();
 
-        return new LecturePageResponse(
+        return new StudentLecturePageResponse(
                 content,
                 query.page(),
                 query.size(),
@@ -96,10 +97,8 @@ public class LectureQueryService implements LectureQueryUseCase {
          */
         Long teacherId = teacherAccountPort.getTeacherId(query.teacherId());
 
-        /*
-         * teacherId 기준으로 본인이 등록한 강의만 조회합니다.
-         * category, keyword 조건은 repository에서 처리합니다.
-         */
+        // 강의 목록을 조회합니다.
+        // category, keyword, enrolled 조건은 repository에서 처리합니다.
         var lecturePage = lectureRepository.findTeacherLectures(
                 teacherId,
                 query.category(),
@@ -152,44 +151,42 @@ public class LectureQueryService implements LectureQueryUseCase {
     }
 
     /**
-     * Lecture 도메인 객체를 목록 응답 DTO로 변환
+     * Lecture 도메인 객체를 학생 강의 목록 응답 DTO로 변환합니다.
      */
-    private LectureListItemResponse toResponse(
+    private StudentLectureListItemResponse toResponse(
             LectureAggregate lecture,
             boolean enrolled,
             Long userId
     ) {
-        // 수강 신청 ID
-        Long enrollmentId = null;
+        /*
+         * TODO:
+         * 지금은 강사 이름 조회 기능을 아직 연결하지 않았기 때문에 null로 둡니다.
+         * 이후 teacherId로 user.name을 조회하는 포트를 연결하면 됩니다.
+         */
+        String teacherName = null;
 
-        // 기본값은 0
-        int totalProgress = 0;
-        int completedCount = 0;
+        /*
+         * TODO:
+         * 지금은 리뷰 집계 기능을 아직 연결하지 않았기 때문에 기본값으로 둡니다.
+         * 이후 review 테이블에서 평균 평점과 리뷰 개수를 조회하면 됩니다.
+         */
+        double averageRating = 0.0;
+        int reviewCount = 0;
 
-        // 수강 신청한 강의라면 enrollment에서 진도 정보를 조회
-        if (enrolled) {
-            var enrollmentInfo = lectureEnrollmentQueryPort.findByUserIdAndLectureId(
-                    userId,
-                    lecture.getId()
-            );
-
-            if (enrollmentInfo.isPresent()) {
-                enrollmentId = enrollmentInfo.get().enrollmentId();
-                totalProgress = enrollmentInfo.get().totalProgress();
-                completedCount = enrollmentInfo.get().completedCount();
-            }
-        }
-
-        return new LectureListItemResponse(
-                enrollmentId,
-                lecture.getId(),
-                lecture.getTitle(),
-                lecture.getThumbnailUrl(),
-                lecture.getCategory().name(),
-                lecture.getStatus().name(),
-                enrolled,
-                totalProgress,
-                completedCount
+        return new StudentLectureListItemResponse(
+                lecture.getId(),                  // lectureId: 강의 ID
+                lecture.getTeacherId(),           // teacherId: 강사 ID
+                teacherName,                      // teacherName: 강사 이름
+                lecture.getTitle(),               // title: 강의 제목
+                lecture.getDescription(),         // description: 강의 설명
+                lecture.getThumbnailUrl(),        // thumbnailUrl: 썸네일 URL
+                lecture.getCategory().name(),     // category: 강의 카테고리
+                lecture.getStatus().name(),       // lectureStatus: 강의 상태
+                lecture.getCompletedUserCount(),  // completedUserCount: 완료한 사용자 수
+                averageRating,                    // averageRating: 평균 평점
+                reviewCount,                      // reviewCount: 리뷰 개수
+                enrolled,                         // isEnrolled: 수강신청 여부
+                lecture.getCreatedAt()            // createdAt: 강의 등록일
         );
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
@@ -3,29 +3,18 @@ package com.wanted.momocity.lecture.application.usecase;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
-import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.StudentLecturePageResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLecturePageResponse;
 
-/**
- * LectureQueryUseCase는 강의 조회 기능
- *
- * Controller는 이 인터페이스를 통해
- * 강의 조회 기능을 호출
- */
 public interface LectureQueryUseCase {
 
-    /*
-     * 강의 목록을 조회
-     * GetLecturesQuery 안에는
-     * category, enrolled, page, size 같은 조회 조건이 들어 있음
-     */
-    LecturePageResponse getLectures(GetLecturesQuery query);
+    // 학생용 강의 목록 조회
+    StudentLecturePageResponse getLectures(GetLecturesQuery query);
 
     // 강사용 강의 목록 조회
-    // 로그인한 강사가 본인이 등록한 강의만 조회
     TeacherLecturePageResponse getTeacherLectures(GetTeacherLecturesQuery query);
 
-    // 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회
+    // 강사용 강의 상세 조회
     TeacherLectureDetailResponse getTeacherLectureDetail(GetTeacherLectureDetailQuery query);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
@@ -25,6 +25,7 @@ public interface LectureRepository {
     // 학생용 강의 목록을 조회
     LecturePage findLectures(
             LectureCategory category,
+            String keyword,
             Boolean enrolled,
             List<Long> enrolledLectureIds,
             int page,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -71,6 +71,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
     @Transactional(readOnly = true)
     public LecturePage findLectures(
             LectureCategory category,
+            String keyword,
             Boolean enrolled,
             List<Long> enrolledLectureIds,
             int page,
@@ -78,8 +79,11 @@ public class LectureRepositoryAdapter implements LectureRepository {
     ) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
+        String normalizedKeyword = normalizeKeyword(keyword);
+
         Page<LectureJpaEntity> lecturePage = findLecturePage(
                 category,
+                normalizedKeyword,
                 enrolled,
                 enrolledLectureIds,
                 pageable
@@ -143,77 +147,84 @@ public class LectureRepositoryAdapter implements LectureRepository {
     // category, enrolled 조건에 맞춰 ACTIVE 강의만 조회합니다.
     private Page<LectureJpaEntity> findLecturePage(
             LectureCategory category,
+            String keyword,
             Boolean enrolled,
             List<Long> enrolledLectureIds,
             Pageable pageable
     ) {
-        // 학생용 강의 목록은 항상 ACTIVE 강의만 조회합니다.
+        // 학생용 목록에서는 항상 ACTIVE 상태의 강의만 조회합니다.
         LectureStatus status = LectureStatus.ACTIVE;
 
-        // enrolled 조건이 없으면 수강 여부와 상관없이 ACTIVE 강의를 조회합니다.
+        /*
+         * enrolled 조건이 없으면 수강 여부와 상관없이 ACTIVE 강의를 조회합니다.
+         *
+         * 예:
+         * GET /api/v1/lectures
+         * GET /api/v1/lectures?category=STUDY
+         * GET /api/v1/lectures?keyword=Spring
+         */
         if (enrolled == null) {
-            if (category == null) {
-                return repository.findAllByStatus(status, pageable);
-            }
-
-            return repository.findAllByCategoryAndStatus(
-                    category,
+            return repository.findStudentLectures(
                     status,
+                    category,
+                    keyword,
                     pageable
             );
         }
 
-        // enrolled=true인데 신청한 강의가 없다면 결과는 빈 페이지입니다.
+        /*
+         * enrolled=true인데 내가 신청한 강의가 하나도 없다면,
+         * 조회 결과는 빈 페이지가 맞습니다.
+         */
         if (Boolean.TRUE.equals(enrolled) && enrolledLectureIds.isEmpty()) {
             return Page.empty(pageable);
         }
 
-        // enrolled=true이면 신청한 ACTIVE 강의만 조회합니다.
+        /*
+         * enrolled=true이면 내가 신청한 ACTIVE 강의만 조회합니다.
+         *
+         * 예:
+         * GET /api/v1/lectures?enrolled=true
+         * GET /api/v1/lectures?category=STUDY&enrolled=true
+         */
         if (Boolean.TRUE.equals(enrolled)) {
-            if (category == null) {
-                return repository.findAllByStatusAndIdIn(
-                        status,
-                        enrolledLectureIds,
-                        pageable
-                );
-            }
-
-            return repository.findAllByCategoryAndStatusAndIdIn(
-                    category,
+            return repository.findStudentLecturesByEnrolled(
                     status,
                     enrolledLectureIds,
+                    category,
+                    keyword,
                     pageable
             );
         }
 
-        // enrolled=false인데 신청한 강의가 없다면 신청 제외할 강의가 없으므로 ACTIVE 강의 전체를 조회합니다.
+        /*
+         * enrolled=false인데 내가 신청한 강의가 없다면,
+         * 제외할 강의가 없으므로 ACTIVE 강의 전체를 조회합니다.
+         */
         if (enrolledLectureIds.isEmpty()) {
-            if (category == null) {
-                return repository.findAllByStatus(status, pageable);
-            }
-
-            return repository.findAllByCategoryAndStatus(
+            return repository.findStudentLectures(
+                    status,
                     category,
-                    status,
+                    keyword,
                     pageable
             );
         }
 
-        // enrolled=false이면 신청하지 않은 ACTIVE 강의만 조회합니다.
-        if (category == null) {
-            return repository.findAllByStatusAndIdNotIn(
-                    status,
-                    enrolledLectureIds,
-                    pageable
-            );
-        }
-
-        return repository.findAllByCategoryAndStatusAndIdNotIn(
-                category,
+        /*
+         * enrolled=false이면 내가 신청하지 않은 ACTIVE 강의만 조회합니다.
+         *
+         * 예:
+         * GET /api/v1/lectures?enrolled=false
+         * GET /api/v1/lectures?category=STUDY&enrolled=false
+         */
+        return repository.findStudentLecturesByNotEnrolled(
                 status,
                 enrolledLectureIds,
+                category,
+                keyword,
                 pageable
         );
+
     }
 
     // JPA Entity를 도메인 모델로 변환합니다.

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -81,4 +81,75 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
             @Param("keyword") String keyword,
             Pageable pageable
     );
+
+    /*
+     * 학생용 강의 목록을 조회합니다.
+     *
+     * 조건:
+     * - ACTIVE 상태 강의만 조회합니다.
+     * - category가 있으면 해당 카테고리만 조회합니다.
+     * - keyword가 있으면 강의 제목으로 검색합니다.
+     *
+     * teacherName 검색은 user 테이블 조인이 필요하므로 다음 단계에서 확장합니다.
+     */
+    @Query("""
+    select l
+    from LectureJpaEntity l
+    where l.status = :status
+      and (:category is null or l.category = :category)
+      and (:keyword is null or l.title like concat('%', :keyword, '%'))
+    order by l.createdAt desc
+    """)
+    Page<LectureJpaEntity> findStudentLectures(
+            @Param("status") LectureStatus status,
+            @Param("category") LectureCategory category,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /*
+     * 학생용 강의 목록 중,
+     * 로그인한 사용자가 이미 수강신청한 강의만 조회합니다.
+     *
+     * enrolled=true 조건에서 사용합니다.
+     */
+    @Query("""
+    select l
+    from LectureJpaEntity l
+    where l.status = :status
+      and l.id in :lectureIds
+      and (:category is null or l.category = :category)
+      and (:keyword is null or l.title like concat('%', :keyword, '%'))
+    order by l.createdAt desc
+    """)
+    Page<LectureJpaEntity> findStudentLecturesByEnrolled(
+            @Param("status") LectureStatus status,
+            @Param("lectureIds") Collection<Long> lectureIds,
+            @Param("category") LectureCategory category,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /*
+     * 학생용 강의 목록 중,
+     * 로그인한 사용자가 아직 수강신청하지 않은 강의만 조회합니다.
+     *
+     * enrolled=false 조건에서 사용합니다.
+     */
+    @Query("""
+    select l
+    from LectureJpaEntity l
+    where l.status = :status
+      and l.id not in :lectureIds
+      and (:category is null or l.category = :category)
+      and (:keyword is null or l.title like concat('%', :keyword, '%'))
+    order by l.createdAt desc
+    """)
+    Page<LectureJpaEntity> findStudentLecturesByNotEnrolled(
+            @Param("status") LectureStatus status,
+            @Param("lectureIds") Collection<Long> lectureIds,
+            @Param("category") LectureCategory category,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -8,6 +8,7 @@ import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuer
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.StudentLecturePageResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,7 +45,7 @@ public class LectureController {
             description = "학생용 강의 목록을 조회합니다. enrolled=true이면 내가 수강신청한 강의만 조회합니다."
     )
     @GetMapping
-    public ResponseEntity<ApiResponse<LecturePageResponse>> getLectures(
+    public ResponseEntity<ApiResponse<StudentLecturePageResponse>> getLectures(
             Authentication authentication,
 
             // 강의 카테고리 필터
@@ -56,6 +57,8 @@ public class LectureController {
             // false: 신청하지 않은 강의만
             // null: 수강 여부 상관없이 전체 조회
             @RequestParam(required = false) Boolean enrolled,
+
+            @RequestParam(required = false) String keyword,
 
             // 페이지 번호입니다. 기본값은 0
             @RequestParam(defaultValue = "1") int page,
@@ -69,48 +72,16 @@ public class LectureController {
                 userId,
                 parseCategory(category),
                 enrolled,
+                keyword,
                 page,
                 size
         );
 
-        LecturePageResponse response = lectureQueryUseCase.getLectures(query);
+        StudentLecturePageResponse response = lectureQueryUseCase.getLectures(query);
 
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,
                 "강의 목록 조회에 성공했습니다.",
-                response
-        ));
-    }
-
-    // 강사 강의 상세 조회 API입니다.
-// 로그인한 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회합니다.
-    @Operation(
-            summary = "강사 강의 상세 조회",
-            description = "로그인한 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회합니다."
-    )
-    @GetMapping("/{lectureId}")
-    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
-    public ResponseEntity<ApiResponse<TeacherLectureDetailResponse>> getTeacherLectureDetail(
-            Authentication authentication,
-            @PathVariable Long lectureId
-    ) {
-        // Authorization 토큰에서 로그인한 강사 ID를 꺼냅니다.
-        Long teacherId = Long.parseLong(authentication.getName());
-
-        // Controller에서 받은 값을 Application 계층에서 사용할 Query 객체로 묶습니다.
-        GetTeacherLectureDetailQuery query = new GetTeacherLectureDetailQuery(
-                teacherId,
-                lectureId
-        );
-
-        // 강사 강의 상세 조회 UseCase를 실행합니다.
-        TeacherLectureDetailResponse response =
-                lectureQueryUseCase.getTeacherLectureDetail(query);
-
-        // 조회 성공 응답을 반환합니다.
-        return ResponseEntity.ok(ApiResponse.success(
-                ApiResponseCode.SUCCESS,
-                "강사 강의 상세 조회에 성공했습니다.",
                 response
         ));
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -6,6 +6,7 @@ import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.lecture.application.command.ChangeLectureStatusCommand;
 import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
+import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
 import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
@@ -250,6 +251,39 @@ public class TeacherLectureController {
         } catch (IllegalArgumentException exception) {
             throw new DomainRuleViolationException("허용되지 않은 강의 카테고리입니다.");
         }
+    }
+
+    // 강사 강의 상세 조회 API입니다.
+    // 로그인한 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회합니다.
+    @Operation(
+            summary = "강사 강의 상세 조회",
+            description = "로그인한 강사가 본인이 등록한 강의의 상세 정보와 챕터 목록을 조회합니다."
+    )
+    @GetMapping("/{lectureId}")
+    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
+    public ResponseEntity<ApiResponse<TeacherLectureDetailResponse>> getTeacherLectureDetail(
+            Authentication authentication,
+            @PathVariable Long lectureId
+    ) {
+        // Authorization 토큰에서 로그인한 강사 ID를 꺼냅니다.
+        Long teacherId = Long.parseLong(authentication.getName());
+
+        // Controller에서 받은 값을 Application 계층에서 사용할 Query 객체로 묶습니다.
+        GetTeacherLectureDetailQuery query = new GetTeacherLectureDetailQuery(
+                teacherId,
+                lectureId
+        );
+
+        // 강사 강의 상세 조회 UseCase를 실행합니다.
+        TeacherLectureDetailResponse response =
+                lectureQueryUseCase.getTeacherLectureDetail(query);
+
+        // 조회 성공 응답을 반환합니다.
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "강사 강의 상세 조회에 성공했습니다.",
+                response
+        ));
     }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/LectureListItemResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/LectureListItemResponse.java
@@ -11,7 +11,7 @@ public record LectureListItemResponse(
         // 강의 ID
         Long lectureId,
 
-        // 강의 제목입
+        // 강의 제목
         String title,
 
         // 강의 썸네일 이미지 URL

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureListItemResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureListItemResponse.java
@@ -1,0 +1,52 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import java.time.LocalDateTime;
+
+/**
+ * 학생이 보는 강의 목록의 강의 1개 응답 DTO입니다.
+ *
+ * 기존 LectureListItemResponse는 수강 내역 쪽에서 사용할 수 있으므로,
+ * 학생 강의 목록 전용 응답 DTO를 따로 분리합니다.
+ */
+public record StudentLectureListItemResponse(
+
+        // 강의 고유 ID입니다.
+        Long lectureId,
+
+        // 강사를 식별하는 user ID입니다.
+        Long teacherId,
+
+        // 강사 이름입니다.
+        String teacherName,
+
+        // 강의 제목입니다.
+        String title,
+
+        // 강의 설명입니다.
+        String description,
+
+        // 강의 썸네일 이미지 URL입니다.
+        String thumbnailUrl,
+
+        // 강의 카테고리입니다.
+        String category,
+
+        // 강의 상태입니다. 학생 목록에서는 ACTIVE만 내려갑니다.
+        String lectureStatus,
+
+        // 이 강의를 완료한 사용자 수입니다.
+        int completedUserCount,
+
+        // 리뷰 평균 평점입니다.
+        double averageRating,
+
+        // 리뷰 개수입니다.
+        int reviewCount,
+
+        // 로그인한 사용자가 이 강의를 수강신청했는지 여부입니다.
+        boolean isEnrolled,
+
+        // 강의가 등록된 시간입니다.
+        LocalDateTime createdAt
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLecturePageResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLecturePageResponse.java
@@ -1,0 +1,28 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import java.util.List;
+
+/**
+ * 학생 강의 목록 페이지 응답 DTO입니다.
+ *
+ * content에는 학생 강의 목록용 응답 객체들이 들어갑니다.
+ */
+public record StudentLecturePageResponse(
+
+        // 현재 페이지의 강의 목록입니다.
+        List<StudentLectureListItemResponse> content,
+
+        // 현재 페이지 번호입니다.
+        int page,
+
+        // 한 페이지에 보여줄 강의 개수입니다.
+        int size,
+
+        // 전체 강의 개수입니다.
+        long totalElements,
+
+        // 전체 페이지 수입니다.
+        int totalPages
+
+) {
+}


### PR DESCRIPTION
## 작업 내용

- 학생 기준 강의 목록 조회 응답 DTO 분리
  - 기존 수강 내역 응답 DTO와 분리하여 `StudentLectureListItemResponse`, `StudentLecturePageResponse` 추가
  - 학생 강의 목록 응답에 `isEnrolled` 포함
  - 강의 기본 정보, 완료 사용자 수, 리뷰 기본 응답 필드 구조 반영

- 학생 강의 목록 조회 검색 조건 추가
  - `keyword` query parameter 추가
  - 강의 제목 기준 검색 가능하도록 Repository 조회 조건 반영
  - `category`, `enrolled`, `keyword`, `page`, `size` 조건 조합 처리

- 학생 강의 목록 조회 정책 반영
  - 학생 목록에서는 `ACTIVE` 상태 강의만 조회
  - `enrolled=true`이면 수강신청한 강의만 조회
  - `enrolled=false`이면 수강신청하지 않은 강의만 조회

- 강사 강의 상세 조회 위치 정리
  - 강사용 상세 조회 API를 강사 컨트롤러 기준으로 정리
  - 학생용 `LectureController`는 학생 강의 목록 조회 역할만 담당하도록 분리

## 참고 사항

- `teacherName`, `averageRating`, `reviewCount`는 응답 필드 구조만 먼저 반영
- 리뷰 집계 및 강사명 조회는 추후 연동 필요
- 학생 강의 상세 조회의 `isEnrolled`는 다음 작업에서 반영 예정

## 검증

- `./gradlew compileJava` 성공