### PR TITLE
[PR] 학생 강의 목록 상세 조회 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetStudentLectureDetailQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetStudentLectureDetailQuery.java
@@ -1,0 +1,26 @@
+package com.wanted.momocity.lecture.application.query;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+
+// 학생 강의 상세 조회 조건을 담는 Query 객체입니다.
+public record GetStudentLectureDetailQuery(
+
+        // Authorization 토큰에서 꺼낸 로그인 사용자 ID입니다.
+        Long userId,
+
+        // 상세 조회할 강의 ID입니다.
+        Long lectureId
+
+) {
+
+    // record가 생성될 때 값이 정상인지 검사합니다.
+    public GetStudentLectureDetailQuery {
+        if (userId == null || userId <= 0) {
+            throw new DomainRuleViolationException("유효하지 않은 사용자입니다.");
+        }
+
+        if (lectureId == null || lectureId <= 0) {
+            throw new DomainRuleViolationException("유효하지 않은 강의 식별자입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -4,12 +4,14 @@ import com.wanted.momocity.enrollment.application.port.StudentAccountPort;
 import com.wanted.momocity.lecture.application.port.LectureEnrollmentQueryPort;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.query.GetStudentLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
 import com.wanted.momocity.lecture.presentation.api.response.*;
@@ -83,6 +85,53 @@ public class LectureQueryService implements LectureQueryUseCase {
                 query.size(),
                 lecturePage.totalElements(),
                 lecturePage.totalPages()
+        );
+    }
+
+    // 학생 강의 상세 조회
+    @Override
+    public StudentLectureDetailResponse getStudentLectureDetail(GetStudentLectureDetailQuery query) {
+
+        // Authorization 토큰에서 가져온 userId가 실제 학생 계정인지 확인합니다.
+        Long userId = studentAccountPort.getStudentId(query.userId());
+
+        // lectureId로 강의를 조회합니다.
+        LectureAggregate lecture = lectureRepository.findById(query.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 학생은 ACTIVE 상태의 강의만 상세 조회할 수 있습니다.
+        if (lecture.getStatus() != LectureStatus.ACTIVE) {
+            throw new AccessDeniedException("진행 중인 강의만 조회할 수 있습니다.");
+        }
+
+        // 해당 강의의 챕터 목록을 orderNo 오름차순으로 조회합니다.
+        List<LectureChapter> chapters =
+                chapterRepository.findAllByLectureIdOrderByOrderNoAsc(query.lectureId());
+
+        // 로그인한 학생이 이 강의를 수강신청했는지 확인합니다.
+        boolean isEnrolled = lectureEnrollmentQueryPort
+                .findByUserIdAndLectureId(userId, query.lectureId())
+                .isPresent();
+
+        /*
+         * TODO:
+         * 강사명, 강사 프로필, 리뷰 집계는 아직 연결하지 않았으므로 기본값으로 둡니다.
+         * 이후 user 조회 포트와 review 집계 포트를 연결하면 됩니다.
+         */
+        String teacherName = null;
+        String teacherProfileImageUrl = null;
+        double averageRating = 0.0;
+        int reviewCount = 0;
+
+        // 조회한 강의/챕터/부가정보를 학생 상세 응답 DTO로 변환합니다.
+        return StudentLectureDetailResponse.from(
+                lecture,
+                chapters,
+                teacherName,
+                teacherProfileImageUrl,
+                averageRating,
+                reviewCount,
+                isEnrolled
         );
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/LectureQueryUseCase.java
@@ -1,8 +1,10 @@
 package com.wanted.momocity.lecture.application.usecase;
 
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.query.GetStudentLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
+import com.wanted.momocity.lecture.presentation.api.response.StudentLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.StudentLecturePageResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLecturePageResponse;
@@ -17,4 +19,7 @@ public interface LectureQueryUseCase {
 
     // 강사용 강의 상세 조회
     TeacherLectureDetailResponse getTeacherLectureDetail(GetTeacherLectureDetailQuery query);
+
+    // 학생 강의 상세 조회
+    StudentLectureDetailResponse getStudentLectureDetail(GetStudentLectureDetailQuery query);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -4,10 +4,12 @@ import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationExc
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
+import com.wanted.momocity.lecture.application.query.GetStudentLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.StudentLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.StudentLecturePageResponse;
 import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,6 +84,40 @@ public class LectureController {
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,
                 "강의 목록 조회에 성공했습니다.",
+                response
+        ));
+    }
+
+    // 학생 강의 상세 조회 API입니다.
+// 학생은 ACTIVE 상태의 강의만 상세 조회할 수 있습니다.
+    @Operation(
+            summary = "강의 상세 조회",
+            description = "학생 또는 회원이 ACTIVE 상태의 강의 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{lectureId}")
+    public ResponseEntity<ApiResponse<StudentLectureDetailResponse>> getLectureDetail(
+            Authentication authentication,
+
+            // 상세 조회할 강의 ID입니다.
+            @PathVariable Long lectureId
+    ) {
+        // Authorization 토큰에서 로그인한 사용자 ID를 꺼냅니다.
+        Long userId = Long.parseLong(authentication.getName());
+
+        // Controller에서 받은 값을 Application 계층에서 사용할 Query 객체로 묶습니다.
+        GetStudentLectureDetailQuery query = new GetStudentLectureDetailQuery(
+                userId,
+                lectureId
+        );
+
+        // 학생 강의 상세 조회 UseCase를 실행합니다.
+        StudentLectureDetailResponse response =
+                lectureQueryUseCase.getStudentLectureDetail(query);
+
+        // 조회 성공 응답을 반환합니다.
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "강의 상세 조회에 성공했습니다.",
                 response
         ));
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureChapterResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureChapterResponse.java
@@ -1,0 +1,35 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+// 학생 강의 상세 조회에서 챕터 1개의 정보를 내려주는 응답 DTO입니다.
+public record StudentLectureChapterResponse(
+
+        // 챕터 ID입니다.
+        Long chapterId,
+
+        // 챕터 제목입니다.
+        String title,
+
+        // 강의 안에서 챕터가 보여질 순서입니다.
+        int orderNo,
+
+        // 동영상 재생 시간입니다. 단위는 초입니다.
+        Integer durationSec,
+
+        // 동영상 처리 상태입니다. 예: UPLOADING, ENCODING, READY, FAILED
+        String videoStatus
+
+) {
+
+    // LectureChapter 도메인 객체를 학생용 챕터 응답 DTO로 변환합니다.
+    public static StudentLectureChapterResponse from(LectureChapter chapter) {
+        return new StudentLectureChapterResponse(
+                chapter.getId(),
+                chapter.getTitle(),
+                chapter.getOrderNo(),
+                chapter.getDurationSec(),
+                chapter.getVideoStatus().name()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureDetailResponse.java
@@ -1,0 +1,93 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 학생 강의 상세 조회 응답 DTO입니다.
+public record StudentLectureDetailResponse(
+
+        // 강의 ID입니다.
+        Long lectureId,
+
+        // 강사 ID입니다.
+        Long teacherId,
+
+        // 강사 이름입니다.
+        String teacherName,
+
+        // 강사 프로필 이미지 URL입니다.
+        String teacherProfileImageUrl,
+
+        // 강의 제목입니다.
+        String title,
+
+        // 강의 설명입니다.
+        String description,
+
+        // 강의 썸네일 이미지 URL입니다.
+        String thumbnailUrl,
+
+        // 강의 카테고리입니다.
+        String category,
+
+        // 강의 상태입니다. 학생 상세 조회에서는 ACTIVE만 조회 가능합니다.
+        String lectureStatus,
+
+        // 강의를 완료한 사용자 수입니다.
+        int completedUserCount,
+
+        // 리뷰 평균 평점입니다.
+        double averageRating,
+
+        // 리뷰 개수입니다.
+        int reviewCount,
+
+        // 로그인한 학생이 이 강의를 수강신청했는지 여부입니다.
+        boolean isEnrolled,
+
+        // 강의에 포함된 챕터 목록입니다.
+        List<StudentLectureChapterResponse> chapters,
+
+        // 강의 생성 시간입니다.
+        LocalDateTime createdAt,
+
+        // 강의 수정 시간입니다.
+        LocalDateTime updatedAt
+
+) {
+
+    // 강의, 챕터 목록, 부가 정보를 학생 상세 응답 DTO로 변환합니다.
+    public static StudentLectureDetailResponse from(
+            LectureAggregate lecture,
+            List<LectureChapter> chapters,
+            String teacherName,
+            String teacherProfileImageUrl,
+            double averageRating,
+            int reviewCount,
+            boolean isEnrolled
+    ) {
+        return new StudentLectureDetailResponse(
+                lecture.getId(),
+                lecture.getTeacherId(),
+                teacherName,
+                teacherProfileImageUrl,
+                lecture.getTitle(),
+                lecture.getDescription(),
+                lecture.getThumbnailUrl(),
+                lecture.getCategory().name(),
+                lecture.getStatus().name(),
+                lecture.getCompletedUserCount(),
+                averageRating,
+                reviewCount,
+                isEnrolled,
+                chapters.stream()
+                        .map(StudentLectureChapterResponse::from)
+                        .toList(),
+                lecture.getCreatedAt(),
+                lecture.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 학생 강의 상세 조회 API 추가
  - `GET /api/v1/lectures/{lectureId}`
  - 로그인한 학생/회원이 강의 상세 정보를 조회할 수 있도록 구현
  - 학생 상세 조회는 `ACTIVE` 상태 강의만 조회 가능하도록 처리

- 학생 강의 상세 조회 응답 DTO 추가
  - `StudentLectureDetailResponse` 추가
  - `StudentLectureChapterResponse` 추가
  - 강의 기본 정보와 챕터 목록을 학생용 응답으로 분리
  - 상세 응답에 `isEnrolled` 포함

- 챕터 목록 조회 연동
  - 강의 상세 조회 시 해당 강의의 챕터 목록을 함께 조회
  - 챕터 목록은 `orderNo` 오름차순 기준으로 응답
  - 학생 상세 조회에서는 영상 URL 없이 챕터 기본 정보만 응답

- 수강 여부 확인 연동
  - 로그인한 사용자 ID와 강의 ID 기준으로 수강신청 여부 조회
  - 조회 결과에 따라 `isEnrolled` 값을 `true/false`로 응답

## 참고 사항

- `teacherName`, `teacherProfileImageUrl`, `averageRating`, `reviewCount`는 현재 기본값으로 응답
- 강사 정보 조회 및 리뷰 집계는 후속 작업에서 연동 예정

## 검증

- `./gradlew compileJava` 성공