### PR TITLE
[PR] 학생 강의 상세 조회 시 강사명/프로필 조회 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -1,5 +1,7 @@
 package com.wanted.momocity.lecture.application.service;
 
+import com.wanted.momocity.auth.application.port.LoadUserPort;
+import com.wanted.momocity.auth.domain.model.User;
 import com.wanted.momocity.enrollment.application.port.StudentAccountPort;
 import com.wanted.momocity.lecture.application.port.LectureEnrollmentQueryPort;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
@@ -48,6 +50,9 @@ public class LectureQueryService implements LectureQueryUseCase {
 
     // 챕터 목록 조회
     private final ChapterRepository chapterRepository;
+
+    // 강사 이름과 프로필 이미지를 조회하기 위한 auth 포트
+    private final LoadUserPort loadUserPort;
 
     // 강의 목록을 조회
     @Override
@@ -113,13 +118,17 @@ public class LectureQueryService implements LectureQueryUseCase {
                 .findByUserIdAndLectureId(userId, query.lectureId())
                 .isPresent();
 
-        /*
-         * TODO:
-         * 강사명, 강사 프로필, 리뷰 집계는 아직 연결하지 않았으므로 기본값으로 둡니다.
-         * 이후 user 조회 포트와 review 집계 포트를 연결하면 됩니다.
-         */
-        String teacherName = null;
-        String teacherProfileImageUrl = null;
+        // lecture.teacherId로 강사 정보를 조회합니다.
+        User teacher = loadUserPort.findById(lecture.getTeacherId())
+                .orElseThrow(() -> new LectureNotFoundException("강사 정보를 찾을 수 없습니다."));
+
+        // 강사 이름입니다.
+        String teacherName = teacher.getName();
+
+        // 강사 프로필 이미지 URL입니다.
+        String teacherProfileImageUrl = teacher.getProfileImageUrl();
+
+        // 리뷰 집계는 다음 단계에서 review 테이블 조회로 연결합니다.
         double averageRating = 0.0;
         int reviewCount = 0;
 


### PR DESCRIPTION
## 작업 내용

- 학생 강의 상세 조회 응답에 강사 정보 연동
  - `lecture.teacherId` 기준으로 강사 사용자 정보 조회
  - `teacherName` 실제 강사 이름 응답
  - `teacherProfileImageUrl` 실제 강사 프로필 이미지 URL 응답

- 학생 강의 상세 조회 응답 보완
  - 기존 임시값으로 두었던 강사명/프로필 값을 실제 데이터로 변경
  - 리뷰 관련 필드는 다음 모듈 구현 전까지 기본값 유지

## 참고 사항

- 리뷰 기능은 다음 모듈에서 구현 예정
- 현재 `averageRating`은 `0.0`, `reviewCount`는 `0`으로 응답
- 리뷰 모듈 구현 후 review 테이블 기준 집계값으로 교체 예정