### PR TITLE
[PR] admin/report BC URL admin prefix 제거

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/AdminDashboardController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/AdminDashboardController.java
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
     AdminDashboardController 정리
     1. 이 클래스의 역할 : 관리자 대시보드 통계 HTTP API 진입점. FE 대시보드 페이지 열 때 호출
     2. 다루는 API :
-        - GET /api/v1/admin/dashboard/summary
+        - GET /api/v1/dashboard/summary
     3. 클래스 레벨 어노테이션 :
         - @RestController              : REST API 컨트롤러, 반환값 자동 JSON 변환
-        - @RequestMapping("/api/v1/admin") : 클래스 안 모든 핸들러 URL 앞에 공통 prefix
+        - @RequestMapping("/api/v1") : 클래스 안 모든 핸들러 URL 앞에 공통 prefix
         - @PreAuthorize("hasRole('ADMIN')") : 모든 핸들러 호출 전 권한 검사. ADMIN 아니면 403
         - @Tag                         : Swagger UI 에서 "Admin - 대시보드" 그룹으로 표시
     4. 의존성 :
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
         - HTTP 메서드 : GET 방식과 PATCH 방식
  */
 @RestController
-@RequestMapping("/api/v1/admin")
+@RequestMapping("/api/v1")
 @PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Admin - 대시보드", description = "관리자 대시보드 통계 (회원/신고/강의 수)")
 public class AdminDashboardController {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/ErrorLogController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/presentation/api/ErrorLogController.java
@@ -22,10 +22,10 @@ import java.util.List;
     ErrorLogController 정리
     1. 이 클래스의 역할 : 에러 로그 조회 HTTP API 진입점. FE 대시보드 에러 로그 위젯이 호출
     2. 다루는 API :
-        - GET /api/v1/admin/error-logs?limit=N
+        - GET /api/v1/error-logs?limit=N
     3. 클래스 레벨 어노테이션 :
         - @RestController              : REST API 컨트롤러 표시. 반환값 자동 JSON 직렬화
-        - @RequestMapping("/api/v1/admin") : 클래스 내 모든 핸들러의 공통 URL prefix
+        - @RequestMapping("/api/v1") : 클래스 내 모든 핸들러의 공통 URL prefix
         - @PreAuthorize("hasRole('ADMIN')") : 모든 핸들러 호출 전 ADMIN 권한 검사. 미충족 시 403
         - @Tag                         : Swagger UI 에서 "Admin - 에러 로그" 그룹으로 묶어 표시
     4. 의존성 :
@@ -38,7 +38,7 @@ import java.util.List;
         e) ApiResponse wrapper 로 감싸 ResponseEntity 반환 (전 컨트롤러 일관성)
  */
 @RestController
-@RequestMapping("/api/v1/admin")
+@RequestMapping("/api/v1")
 @PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Admin - 에러 로그", description = "관리자 대시보드 에러 로그 조회")
 public class ErrorLogController {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
@@ -20,11 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 /* comment.
     AdminReportController 정리
     1. 역할 : 관리자 신고 목록 조회 HTTP API 진입점 (ADMIN 권한 가진 사용자만 접근 가능)
-    2. 다루는 API : GET /api/v1/admin/reports?limit=N&status=PENDING
+    2. 다루는 API : GET /api/v1/reports?limit=N&status=PENDING
     3. 클래스 레벨 어노테이션
        - @RestController : REST API 컨트롤러. 반환값 자동 JSON 직렬화.
        - @RequiredArgsConstructor : final 필드 생성자 자동 생성 (Lombok).
-       - @RequestMapping("/api/v1/admin/reports") : 공통 URL prefix.
+       - @RequestMapping("/api/v1/reports") : 공통 URL prefix.
        - @PreAuthorize("hasRole('ADMIN')") : 모든 핸들러 호출 전 ADMIN 권한 검사. 미충족 시 403.
        - @Tag : Swagger UI 에서 "Admin - 신고" 그룹.
     4. 의존성
@@ -39,12 +39,15 @@ import org.springframework.web.bind.annotation.RestController;
             1. status 없음 : 전체 최근 N개
             2. status 있음 : 특정 상태의 최근 N개
        → 한 엔드포인트를 통해서 두 케이스를 처리한다.
-    7. WHY ReportController 와 별도 컨트롤러
+    7. WHY ReportController 와 별도 컨트롤러 (같은 base path 공유)
        → 권한 정책이 다르기 때문에 클래스 레벨에서 분리하면 가독성 및 유지보수가 좋아진다.
+       → POST /api/v1/reports(ReportController, 회원) 와 base path 는 같지만,
+         스프링은 (경로 + HTTP 메서드) 조합으로 매핑하므로 GET/POST 가 충돌하지 않는다.
+       → 결과 : 하나의 리소스 경로(reports)를 권한/CQRS(Command·Query)로 안전하게 분리.
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/admin/reports")
+@RequestMapping("/api/v1/reports")
 @PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Admin - 신고", description = "관리자 신고 목록 조회")
 public class AdminReportController {


### PR DESCRIPTION
## 작업 개요
admin / report BC 본인 영역 엔드포인트에서 `/admin` URL prefix 를 제거했습니다.
권한 검사는 기존대로 클래스 레벨 `@PreAuthorize("hasRole('ADMIN')")` 로 유지합니다.

## 변경된 엔드포인트
| 구분 | 변경 전 | 변경 후 |
|---|---|---|
| 신고 목록(관리자) | `GET /api/v1/admin/reports` | `GET /api/v1/reports` |
| 에러 로그(관리자) | `GET /api/v1/admin/error-logs` | `GET /api/v1/error-logs` |
| 대시보드 요약(관리자) | `GET /api/v1/admin/dashboard/summary` | `GET /api/v1/dashboard/summary` |

## 변경 파일
- `report/presentation/api/AdminReportController.java`
- `admin/presentation/api/ErrorLogController.java`
- `admin/presentation/api/AdminDashboardController.java`

## 설계 결정 — 컨트롤러 분리 유지
- `GET /api/v1/reports`(관리자 조회)와 `POST /api/v1/reports`(회원 신고 접수)는
  **base path 를 공유하지만** 스프링은 `(경로 + HTTP 메서드)` 조합으로 매핑하므로
  두 컨트롤러가 같은 경로를 써도 충돌하지 않습니다.
- 따라서 `ReportController`(POST, 회원)와 `AdminReportController`(GET, 관리자)는
  **합치지 않고 분리 유지**했습니다.
  - 권한 정책 분리(클래스 레벨 `@PreAuthorize`)
  - CQRS(Command / Query) 분리
  - 컨트롤러당 UseCase 1:1 의존(SRP)

## 보안 영향 (중요 — 리뷰 포인트)
prefix 제거로 이 3개 엔드포인트가 `SecurityConfig` 의
`requestMatchers("/api/v1/admin/**").hasAnyAuthority("ROLE_ADMIN")` 규칙 밖으로 나갔습니다.
다만 보안 공백은 **없습니다**:
- `@EnableMethodSecurity(prePostEnabled = true)` 활성화됨 → `@PreAuthorize` 정상 작동
- `SecurityConfig` 의 `anyRequest().authenticated()` 가 받아내어 미인증 접근 차단
- 결과: 3개 엔드포인트 모두 **인증 + ADMIN 권한** 필요 (기존과 동일하게 ADMIN 전용)

`SecurityConfig` 의 `/api/v1/admin/**` 규칙은 member / teacher BC 가 아직 사용하므로
**수정하지 않았습니다.**

## 테스트
- [x] `./gradlew compileJava` BUILD SUCCESSFUL
- [ ] `./gradlew bootRun` 동작 검증 (Swagger / 권한 / 전역예외) — 후속 작업
- [ ] 더미 데이터(data.sql + Postman) 후속 작업

## FE 안내 필요
위 3개 엔드포인트 URL 이 변경되었습니다. FE 호출부 수정 필요.

## 후속 작업
- [ ] 노션 API 명세 동기화
- [ ] 더미 데이터 생성
- [ ] bootRun 통합 동작 검증