### PR TITLE
[PR] 강의 동영상 상태 READY 변경 로직 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/ChangeChapterVideoStatusCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/ChangeChapterVideoStatusCommand.java
@@ -1,0 +1,12 @@
+package com.wanted.momocity.lecture.application.command;
+
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
+
+// 챕터 동영상 상태 변경에 필요한 값을 담는 Command
+public record ChangeChapterVideoStatusCommand(
+        Long teacherId,
+        Long lectureId,
+        Long chapterId,
+        VideoStatus videoStatus
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
@@ -2,6 +2,7 @@ package com.wanted.momocity.lecture.application.service;
 
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.command.ChangeChapterVideoStatusCommand;
 import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
 import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.application.port.TeacherAccountPort;
@@ -140,5 +141,40 @@ public class ChapterCommandService implements ChapterCommandUseCase {
         return chapterRepository.save(updatedChapter);
     }
 
+
+    @Override
+    public LectureChapter changeChapterVideoStatus(ChangeChapterVideoStatusCommand command) {
+        // Authorization 토큰에서 가져온 값으로 강사 ID를 조회
+        Long teacherId = teacherAccountPort.getTeacherId(command.teacherId());
+
+        // 상태를 변경할 강의를 조회
+        LectureAggregate lecture = lectureRepository.findById(command.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 본인이 등록한 강의의 챕터만 동영상 상태를 변경
+        if (!lecture.isOwnedBy(teacherId)) {
+            throw new AccessDeniedException("본인이 등록한 강의의 챕터만 동영상 상태를 변경할 수 있습니다.");
+        }
+
+        // 상태를 변경할 챕터를 조회
+        LectureChapter chapter = chapterRepository.findById(command.chapterId())
+                .orElseThrow(() -> new ChapterNotFoundException("챕터를 찾을 수 없습니다."));
+
+        // 요청한 챕터가 요청한 강의에 속한 챕터인지 확인
+        if (!chapter.belongsTo(command.lectureId())) {
+            throw new ChapterNotFoundException("유효하지 않은 챕터 식별자입니다.");
+        }
+
+        // 동영상이 등록되지 않은 챕터는 READY 같은 상태로 바꿈
+        if (!chapter.hasVideo()) {
+            throw new DomainRuleViolationException("동영상이 등록된 챕터만 상태를 변경할 수 있습니다.");
+        }
+
+        // 도메인 모델에서 videoStatus를 변경
+        LectureChapter changedChapter = chapter.changeVideoStatus(command.videoStatus());
+
+        // 변경된 챕터를 저장
+        return chapterRepository.save(changedChapter);
+    }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/ChapterCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/ChapterCommandUseCase.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.lecture.application.usecase;
 
+import com.wanted.momocity.lecture.application.command.ChangeChapterVideoStatusCommand;
 import com.wanted.momocity.lecture.application.command.CreateChapterCommand;
 import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
@@ -12,4 +13,7 @@ public interface ChapterCommandUseCase {
 
     // 동영상 등록
     LectureChapter registerChapterVideo(RegisterChapterVideoCommand command);
+
+    // 챕터 동영상 처리 상태를 변경
+    LectureChapter changeChapterVideoStatus(ChangeChapterVideoStatusCommand command);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureChapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/model/LectureChapter.java
@@ -133,6 +133,26 @@ public class LectureChapter {
         );
     }
 
+    // 챕터 동영상 처리 상태를 변경
+    // 예: UPLOADING -> ENCODING -> READY -> FAILED
+    public LectureChapter changeVideoStatus(VideoStatus videoStatus) {
+        validateVideoStatus(videoStatus);
+
+        return new LectureChapter(
+                id,
+                lectureId,
+                title,
+                orderNo,
+                videoUrl,
+                videoSizeBytes,
+                durationSec,
+                videoStatus,
+                originalFilename,
+                createdAt,
+                updatedAt
+        );
+    }
+
     /* comment
      * 이미 동영상이 등록된 챕터인지 확인
      * 서비스에서 중복 등록을 막을 때 사용

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -4,6 +4,7 @@ import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.application.command.ChangeChapterVideoStatusCommand;
 import com.wanted.momocity.lecture.application.command.ChangeLectureStatusCommand;
 import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
 import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
@@ -14,10 +15,7 @@ import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
-import com.wanted.momocity.lecture.presentation.api.request.ChangeLectureStatusRequest;
-import com.wanted.momocity.lecture.presentation.api.request.CreateChapterRequest;
-import com.wanted.momocity.lecture.presentation.api.request.CreateLectureRequest;
-import com.wanted.momocity.lecture.presentation.api.request.RegisterChapterVideoRequest;
+import com.wanted.momocity.lecture.presentation.api.request.*;
 import com.wanted.momocity.lecture.presentation.api.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -285,6 +283,36 @@ public class TeacherLectureController {
                 "강사 강의 상세 조회에 성공했습니다.",
                 response
         ));
+    }
+
+    @PatchMapping("/{lectureId}/chapters/{chapterId}/video/status")
+    @PreAuthorize("hasAuthority('ROLE_TEACHER')")
+    public ResponseEntity<ApiResponse<RegisterChapterVideoResponse>> changeChapterVideoStatus(
+            Authentication authentication,
+            @PathVariable Long lectureId,
+            @PathVariable Long chapterId,
+            @Valid @RequestBody ChangeChapterVideoStatusRequest request
+    ) {
+        // Authorization 토큰에서 로그인한 강사 식별 값을 가져온다.
+        String teacherId = authentication.getName();
+
+        // Request DTO를 Application 계층에서 사용할 Command로 변환한다.
+        ChangeChapterVideoStatusCommand command = request.toCommand(
+                teacherId,
+                lectureId,
+                chapterId
+        );
+
+        // 챕터 동영상 상태 변경 유스케이스를 실행한다.
+        LectureChapter chapter = chapterCommandUseCase.changeChapterVideoStatus(command);
+
+        // 변경된 챕터 정보를 응답한다.
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(
+                        ApiResponseCode.SUCCESS,
+                        "챕터 동영상 상태가 변경되었습니다.",
+                        RegisterChapterVideoResponse.from(chapter)
+                ));
     }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/ChangeChapterVideoStatusRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/ChangeChapterVideoStatusRequest.java
@@ -1,0 +1,35 @@
+package com.wanted.momocity.lecture.presentation.api.request;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.command.ChangeChapterVideoStatusCommand;
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
+
+// 챕터 동영상 상태 변경 요청 DTO
+public record ChangeChapterVideoStatusRequest(
+        String videoStatus
+) {
+    public ChangeChapterVideoStatusCommand toCommand(
+            Long teacherId,
+            Long lectureId,
+            Long chapterId
+    ) {
+        return new ChangeChapterVideoStatusCommand(
+                teacherId,
+                lectureId,
+                chapterId,
+                parseVideoStatus(videoStatus)
+        );
+    }
+
+    private VideoStatus parseVideoStatus(String videoStatus) {
+        if (videoStatus == null || videoStatus.isBlank()) {
+            throw new DomainRuleViolationException("동영상 상태는 필수입니다.");
+        }
+
+        try {
+            return VideoStatus.valueOf(videoStatus.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new DomainRuleViolationException("허용되지 않은 동영상 상태입니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

챕터에 등록된 동영상의 처리 상태를 변경할 수 있는 기능을 추가했습니다.

기존 동영상 등록 API에서는 영상 업로드 후 `videoStatus`가 `UPLOADING`으로 저장됩니다.  
이번 작업에서는 등록된 동영상의 상태를 `READY` 등으로 변경할 수 있도록 별도 API와 서비스 로직을 추가했습니다.

## 작업 흐름

```text
TeacherLectureController
 -> ChangeChapterVideoStatusRequest
 -> ChangeChapterVideoStatusCommand
 -> ChapterCommandUseCase
 -> ChapterCommandService
 -> LectureChapter.changeVideoStatus()
 -> ChapterRepository
 -> ChapterRepositoryAdapter
 -> ChapterJpaEntity
```

## 주요 검증
- 로그인한 사용자가 강사 권한인지 확인
- 본인이 등록한 강의의 챕터인지 확인
- 요청한 챕터가 해당 강의에 속하는지 확인
- 동영상이 등록된 챕터인지 확인
- videoStatus 값이 허용된 enum 값인지 확인


## 참고 사항
- 이번 작업은 chapter.video_status 변경만 담당합니다.
- 동영상 등록 API와 동영상 상태 변경 API는 역할이 달라 분리했습니다.
- 동영상 등록: PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}/video
- 동영상 상태 변경: PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}/video/status
- 학생에게 영상이 최종 노출되려면 아래 조건이 모두 필요합니다.
- lecture.status = ACTIVE
- chapter.video_status = READY
- lecture.status = ACTIVE 처리는 관리자 승인 로직에서 담당합니다.