### PR TITLE
[PR] 기존에 필요없는 파라미터 값 drop

### DIFF
--- a/legend-momo-city/db/00-ddl-fix.sql
+++ b/legend-momo-city/db/00-ddl-fix.sql
@@ -7,6 +7,8 @@
 --   이게 적용 안 된 DB에 시드(seed-dummy.sql 등)를 넣으면 오류가 난다.
 --     수정 ① 카테고리 ENUM : 'HEALTH' -> 'FITNESS'  (user / lecture / building)
 --     수정 ② user.email   : NOT NULL -> NULL (널 허용)
+--     수정 ③ report 잔재 컬럼 DROP : reporter_id / target_nickname / reason_detail
+--            (ddl-auto:update 가 안 지운 옛 컬럼. 현재 엔티티는 reporter_user_id / detail 사용)
 --   => 이 파일을 실행하면 어떤 시작 상태든 시드가 기대하는 스키마로 맞춰진다.
 -- ---------------------------------------------------------------------
 --  [실행 순서]  ※ 이 순서를 반드시 지킬 것
@@ -29,6 +31,41 @@ ALTER TABLE `building` MODIFY `category` ENUM('FITNESS','STUDY','COOK','BEAUTY',
 
 -- 수정 ② user.email : NOT NULL -> NULL (널 허용, UNIQUE 는 유지됨)
 ALTER TABLE `user` MODIFY `email` VARCHAR(255) NULL;
+
+-- ---------------------------------------------------------------------
+-- 수정 ③ report 잔재(orphan) 컬럼 정리
+--   배경 : ddl-auto:update 는 컬럼 "추가"만 하고 "삭제"는 안 한다.
+--          report 엔티티가 reporter_id->reporter_user_id, reason_detail->detail 로
+--          리팩토링되면서 옛 컬럼이 NOT NULL 인 채 테이블에 남았다.
+--          현재 엔티티(ReportJpaEntity)가 매핑하지 않는 3개를 제거한다.
+--   확인 : 코드 전체 검색 결과 reporter_id/target_nickname/reason_detail 사용처 없음(미사용 검증 완료).
+--   주의 : Hibernate 로 새로 만든 DB 는 애초에 이 컬럼이 없을 수 있으므로,
+--          information_schema 로 "존재할 때만" DROP 한다(멱등·안전).
+-- ---------------------------------------------------------------------
+SET @db := DATABASE();
+
+-- (reporter_id 에는 옛 FK(fk_report_reporter)가 걸려있으므로 "FK 먼저" 제거해야 컬럼 DROP 가능.
+--  FK 이름이 DB마다 다를 수 있어 information_schema 로 동적 조회 후 제거.)
+SET @fk := (SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA=@db AND TABLE_NAME='report' AND COLUMN_NAME='reporter_id'
+              AND REFERENCED_TABLE_NAME IS NOT NULL LIMIT 1);
+SET @sql := IF(@fk IS NOT NULL, CONCAT('ALTER TABLE `report` DROP FOREIGN KEY `',@fk,'`'), 'DO 0');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @sql := IF(EXISTS(SELECT 1 FROM information_schema.COLUMNS
+                      WHERE TABLE_SCHEMA=@db AND TABLE_NAME='report' AND COLUMN_NAME='reporter_id'),
+               'ALTER TABLE `report` DROP COLUMN `reporter_id`', 'DO 0');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @sql := IF(EXISTS(SELECT 1 FROM information_schema.COLUMNS
+                      WHERE TABLE_SCHEMA=@db AND TABLE_NAME='report' AND COLUMN_NAME='target_nickname'),
+               'ALTER TABLE `report` DROP COLUMN `target_nickname`', 'DO 0');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+
+SET @sql := IF(EXISTS(SELECT 1 FROM information_schema.COLUMNS
+                      WHERE TABLE_SCHEMA=@db AND TABLE_NAME='report' AND COLUMN_NAME='reason_detail'),
+               'ALTER TABLE `report` DROP COLUMN `reason_detail`', 'DO 0');
+PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
 
 -- =====================================================================
 --  END  (적용 후 seed-dummy.sql 실행)

--- a/legend-momo-city/db/seed-dummy.sql
+++ b/legend-momo-city/db/seed-dummy.sql
@@ -363,24 +363,25 @@ VALUES
 --   ★ 신규일수록 PENDING(분 단위 전), 오래될수록 처리완료(수일 전) = 운영 흐름 재현
 --   (GET /api/v1/reports?status=PENDING 필터 시 6건, 최근순 정렬 시 r1 이 최상단)
 -- =====================================================================
--- ※ 실제 스키마 반영: reporter_user_id(NOT NULL, reporter_id 와 동일인) / reported_at(NOT NULL, 접수시각)
---   / updated_at(NOT NULL) 추가. 처리완료(REVIEWED/RESOLVED/REJECTED) 건만 handled_at + handler_admin_id(관리자=1) 채움.
---   created_at = reported_at 로 맞춰 최근순 정렬 일관성 확보. PENDING 은 handled_at/handler NULL.
+-- ※ 실제 엔티티 스키마 반영 (잔재 컬럼 reporter_id/target_nickname/reason_detail 은 00-ddl-fix.sql 에서 DROP).
+--   현재 엔티티 사용 컬럼만: reporter_user_id(신고자) / detail(사유 상세) / reported_at(접수시각) / updated_at.
+--   처리완료(REVIEWED/RESOLVED/REJECTED) 건만 handled_at + handler_admin_id(관리자=1). created_at=reported_at 로 정렬 일관성.
+--   ※ target 은 (target_type + target_id) 로 식별. (대상 닉네임은 엔티티가 저장 안 함)
 INSERT INTO `report`
-  (`id`,`reporter_id`,`reporter_user_id`,`target_type`,`target_id`,`target_nickname`,`reason`,`reason_detail`,`status`,`created_at`,`reported_at`,`updated_at`,`handled_at`,`handler_admin_id`)
+  (`id`,`reporter_user_id`,`target_type`,`target_id`,`reason`,`detail`,`status`,`created_at`,`reported_at`,`updated_at`,`handled_at`,`handler_admin_id`)
 VALUES
-  (1 ,2,2,'USER'   ,10,'banned_user','SPAM'         ,'DM으로 광고를 계속 보냅니다.'      ,'PENDING' ,NOW() - INTERVAL 4 MINUTE ,NOW() - INTERVAL 4 MINUTE ,NOW() - INTERVAL 4 MINUTE ,NULL                  ,NULL),
-  (2 ,3,3,'COMMENT',11,'banned_user','ABUSE'        ,'댓글에 욕설과 비방이 있습니다.'     ,'PENDING' ,NOW() - INTERVAL 51 MINUTE,NOW() - INTERVAL 51 MINUTE,NOW() - INTERVAL 51 MINUTE,NULL                  ,NULL),
-  (3 ,4,4,'COMMENT',12,'black_user' ,'SPAM'         ,'스팸 광고 댓글을 도배합니다.'      ,'PENDING' ,NOW() - INTERVAL 19 HOUR  ,NOW() - INTERVAL 19 HOUR  ,NOW() - INTERVAL 19 HOUR  ,NULL                  ,NULL),
-  (4 ,5,5,'POST'   ,8 ,'jiyoung'    ,'INAPPROPRIATE','게시글에 부적절한 이미지가 있어요.','REVIEWED',NOW() - INTERVAL 2 DAY    ,NOW() - INTERVAL 2 DAY    ,NOW() - INTERVAL 44 HOUR  ,NOW() - INTERVAL 44 HOUR,1),
-  (5 ,2,2,'USER'   ,11,'black_user' ,'ABUSE'        ,'지속적으로 비방 메시지를 보냅니다.','RESOLVED',NOW() - INTERVAL 3 DAY    ,NOW() - INTERVAL 3 DAY    ,NOW() - INTERVAL 2 DAY    ,NOW() - INTERVAL 2 DAY  ,1),
-  (6 ,3,3,'LECTURE',10,'chef_park'  ,'ETC'          ,'강의 내용이 설명과 다릅니다.'      ,'PENDING' ,NOW() - INTERVAL 5 HOUR   ,NOW() - INTERVAL 5 HOUR   ,NOW() - INTERVAL 5 HOUR   ,NULL                  ,NULL),
-  (7 ,4,4,'POST'   ,2 ,'minsu'      ,'SPAM'         ,'홍보성 글로 의심됩니다.'          ,'REJECTED',NOW() - INTERVAL 4 DAY - INTERVAL 3 HOUR,NOW() - INTERVAL 4 DAY - INTERVAL 3 HOUR,NOW() - INTERVAL 4 DAY,NOW() - INTERVAL 4 DAY,1),
-  (8 ,5,5,'USER'   ,10,'banned_user','ABUSE'        ,'욕설이 담긴 DM을 받았습니다.'      ,'REVIEWED',NOW() - INTERVAL 26 HOUR  ,NOW() - INTERVAL 26 HOUR  ,NOW() - INTERVAL 20 HOUR  ,NOW() - INTERVAL 20 HOUR,1),
-  (9 ,6,6,'COMMENT',11,'banned_user','INAPPROPRIATE','외부 광고 링크를 첨부했습니다.'   ,'PENDING' ,NOW() - INTERVAL 23 MINUTE,NOW() - INTERVAL 23 MINUTE,NOW() - INTERVAL 23 MINUTE,NULL                  ,NULL),
-  (10,2,2,'POST'   ,9 ,'hyunwoo'    ,'ETC'          ,'동일 내용을 중복 게시했습니다.'    ,'RESOLVED',NOW() - INTERVAL 4 DAY    ,NOW() - INTERVAL 4 DAY    ,NOW() - INTERVAL 3 DAY    ,NOW() - INTERVAL 3 DAY  ,1),
-  (11,7,7,'USER'   ,11,'black_user' ,'SPAM'         ,'대량으로 친구신청 스팸을 보냅니다.','PENDING' ,NOW() - INTERVAL 2 HOUR   ,NOW() - INTERVAL 2 HOUR   ,NOW() - INTERVAL 2 HOUR   ,NULL                  ,NULL),
-  (12,3,3,'LECTURE',5 ,'coach_kim'  ,'ETC'          ,'강의 일정을 지키지 않았습니다.'    ,'REJECTED',NOW() - INTERVAL 6 DAY    ,NOW() - INTERVAL 6 DAY    ,NOW() - INTERVAL 5 DAY    ,NOW() - INTERVAL 5 DAY  ,1);
+  (1 ,2,'USER'   ,10,'SPAM'         ,'DM으로 광고를 계속 보냅니다.'      ,'PENDING' ,NOW() - INTERVAL 4 MINUTE ,NOW() - INTERVAL 4 MINUTE ,NOW() - INTERVAL 4 MINUTE ,NULL                  ,NULL),
+  (2 ,3,'COMMENT',11,'ABUSE'        ,'댓글에 욕설과 비방이 있습니다.'     ,'PENDING' ,NOW() - INTERVAL 51 MINUTE,NOW() - INTERVAL 51 MINUTE,NOW() - INTERVAL 51 MINUTE,NULL                  ,NULL),
+  (3 ,4,'COMMENT',12,'SPAM'         ,'스팸 광고 댓글을 도배합니다.'      ,'PENDING' ,NOW() - INTERVAL 19 HOUR  ,NOW() - INTERVAL 19 HOUR  ,NOW() - INTERVAL 19 HOUR  ,NULL                  ,NULL),
+  (4 ,5,'POST'   ,8 ,'INAPPROPRIATE','게시글에 부적절한 이미지가 있어요.','REVIEWED',NOW() - INTERVAL 2 DAY    ,NOW() - INTERVAL 2 DAY    ,NOW() - INTERVAL 44 HOUR  ,NOW() - INTERVAL 44 HOUR,1),
+  (5 ,2,'USER'   ,11,'ABUSE'        ,'지속적으로 비방 메시지를 보냅니다.','RESOLVED',NOW() - INTERVAL 3 DAY    ,NOW() - INTERVAL 3 DAY    ,NOW() - INTERVAL 2 DAY    ,NOW() - INTERVAL 2 DAY  ,1),
+  (6 ,3,'LECTURE',10,'ETC'          ,'강의 내용이 설명과 다릅니다.'      ,'PENDING' ,NOW() - INTERVAL 5 HOUR   ,NOW() - INTERVAL 5 HOUR   ,NOW() - INTERVAL 5 HOUR   ,NULL                  ,NULL),
+  (7 ,4,'POST'   ,2 ,'SPAM'         ,'홍보성 글로 의심됩니다.'          ,'REJECTED',NOW() - INTERVAL 4 DAY - INTERVAL 3 HOUR,NOW() - INTERVAL 4 DAY - INTERVAL 3 HOUR,NOW() - INTERVAL 4 DAY,NOW() - INTERVAL 4 DAY,1),
+  (8 ,5,'USER'   ,10,'ABUSE'        ,'욕설이 담긴 DM을 받았습니다.'      ,'REVIEWED',NOW() - INTERVAL 26 HOUR  ,NOW() - INTERVAL 26 HOUR  ,NOW() - INTERVAL 20 HOUR  ,NOW() - INTERVAL 20 HOUR,1),
+  (9 ,6,'COMMENT',11,'INAPPROPRIATE','외부 광고 링크를 첨부했습니다.'   ,'PENDING' ,NOW() - INTERVAL 23 MINUTE,NOW() - INTERVAL 23 MINUTE,NOW() - INTERVAL 23 MINUTE,NULL                  ,NULL),
+  (10,2,'POST'   ,9 ,'ETC'          ,'동일 내용을 중복 게시했습니다.'    ,'RESOLVED',NOW() - INTERVAL 4 DAY    ,NOW() - INTERVAL 4 DAY    ,NOW() - INTERVAL 3 DAY    ,NOW() - INTERVAL 3 DAY  ,1),
+  (11,7,'USER'   ,11,'SPAM'         ,'대량으로 친구신청 스팸을 보냅니다.','PENDING' ,NOW() - INTERVAL 2 HOUR   ,NOW() - INTERVAL 2 HOUR   ,NOW() - INTERVAL 2 HOUR   ,NULL                  ,NULL),
+  (12,3,'LECTURE',5 ,'ETC'          ,'강의 일정을 지키지 않았습니다.'    ,'REJECTED',NOW() - INTERVAL 6 DAY    ,NOW() - INTERVAL 6 DAY    ,NOW() - INTERVAL 5 DAY    ,NOW() - INTERVAL 5 DAY  ,1);
 
 -- =====================================================================
 --  23. payment  (8개 - 결제는 가입 직후~최근 구독 갱신까지)


### PR DESCRIPTION
## 작업 개요
팀 공통 DB 셋업을 위한 스크립트를 `db/`에 추가하고, report 테이블의 미사용(잔재) 컬럼을 정리했습니다.
기존에 테이블 생성 DDL만 공유되고 "수정사항"이 빠져 시드 적재 시 오류가 나던 문제를 해결합니다.

## 추가 파일 (`db/`)
| 파일 | 역할 |
|---|---|
| `00-ddl-fix.sql` | 스키마 수정사항 + report 잔재 컬럼 정리 (시드 전 실행) |
| `seed-dummy.sql` | 기본 더미데이터 26테이블 236행 (시간값 NOW 기준 LIVE) |
| `seed-friend-test.sql` | friend BC 기능 테스트용 픽스처 (시나리오 주석 포함) |

## 실행 순서 (필수)
1. 테이블 생성 (앱 1회 bootRun 또는 제공 DDL)
2. `00-ddl-fix.sql`
3. `seed-dummy.sql`
4. (선택) `seed-friend-test.sql`

## 스키마 수정사항 (00-ddl-fix.sql)
- **① category ENUM**: `HEALTH` → `FITNESS` (user / lecture / building)
- **② user.email**: `NOT NULL` → `NULL` (널 허용)
- **③ report 잔재 컬럼 정리**: `ddl-auto:update`가 삭제하지 않고 남긴 옛 컬럼 제거
  - `reporter_id` (현재 엔티티는 `reporter_user_id` 사용) — FK(`fk_report_reporter`) 먼저 제거 후 DROP
  - `target_nickname`, `reason_detail` (현재 엔티티는 `detail` 사용)
  - ※ 코드 전체 검색으로 미사용 검증 완료. information_schema 가드로 멱등 처리(없으면 건너뜀)

## 검증
- [x] 전체 체인(00-ddl-fix → seed-dummy → seed-friend-test) 로컬 MySQL 클린 적재 (에러 0건)
- [x] report 잔재 컬럼 3개 제거 확인, `detail`로 사유 상세 정상 적재
- [x] report 12행(PENDING 6), error_log 12행, friend 10 / message 45

## ⚠️ 후속 (타 BC)
- `user`/`building` 엔티티의 category enum(Java)도 `FITNESS`로 변경 필요 (현재는 DB 스키마만 정렬)
- report 잔재 컬럼은 DB에서 제거됨 → 엔티티 기준과 일치

## 라벨(제안)
chore, database, refactor