### PR TITLE
[PR] 관리자 강의 목록 조회 및 상세 조회, 강의 목록 조회 성공 Response 재설정 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetAdminLectureDetailQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetAdminLectureDetailQuery.java
@@ -1,0 +1,28 @@
+package com.wanted.momocity.lecture.application.query;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+
+// 관리자가 강의 상세 정보를 조회할 때 사용하는 Query 객체
+public record GetAdminLectureDetailQuery(
+        Long adminId,
+        Long lectureId
+) {
+    public GetAdminLectureDetailQuery {
+        validateAdminId(adminId);
+        validateLectureId(lectureId);
+    }
+
+    // 로그인한 관리자 id가 있는지 확인한다.
+    private static void validateAdminId(Long adminId) {
+        if (adminId == null) {
+            throw new DomainRuleViolationException("관리자 정보는 필수입니다.");
+        }
+    }
+
+    // 조회할 강의 id가 있는지 확인한다.
+    private static void validateLectureId(Long lectureId) {
+        if (lectureId == null) {
+            throw new DomainRuleViolationException("강의 ID는 필수입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetAdminLecturesQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/GetAdminLecturesQuery.java
@@ -1,0 +1,57 @@
+package com.wanted.momocity.lecture.application.query;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.domain.model.LectureCategory;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+
+// 관리자가 강의 목록을 조회할 때 사용하는 조건을 담는 Query 객체
+public record GetAdminLecturesQuery(
+        Long adminId,
+        LectureStatus status,
+        LectureCategory category,
+        String keyword,
+        int page,
+        int size
+) {
+    public GetAdminLecturesQuery {
+        validateAdminId(adminId);
+        validateStatus(status);
+        validatePage(page);
+        validateSize(size);
+    }
+
+    // 로그인한 관리자 id가 있는지 확인
+    private static void validateAdminId(Long adminId) {
+        if (adminId == null) {
+            throw new DomainRuleViolationException("관리자 정보는 필수입니다.");
+        }
+    }
+
+    // 로그인한 관리자 id가 있는지 확인
+    // 관리자는 WAITING 또는 ACTIVE 상태의 강의만 목록에서 조회
+    // status가 null이면 WAITING + ACTIVE 전체 조회로 처리
+    private static void validateStatus(LectureStatus status) {
+        if (status == null) {
+            return;
+        }
+
+        if (status != LectureStatus.WAITING && status != LectureStatus.ACTIVE) {
+            throw new DomainRuleViolationException("관리자 강의 목록에서는 승인 대기 또는 진행 중 강의만 조회할 수 있습니다.");
+        }
+    }
+
+    // 프론트 페이지 번호는 1부터 시작한다.
+    private static void validatePage(int page) {
+        if (page < 1) {
+            throw new DomainRuleViolationException("페이지 번호는 1 이상이어야 합니다.");
+        }
+    }
+
+    // 한 페이지에 조회할 강의 개수는 1개 이상이어야 한다.
+    private static void validateSize(int size) {
+        if (size < 1) {
+            throw new DomainRuleViolationException("페이지 크기는 1 이상이어야 합니다.");
+        }
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureQueryService.java
@@ -1,0 +1,63 @@
+package com.wanted.momocity.lecture.application.service;
+
+import com.wanted.momocity.lecture.application.query.GetAdminLecturesQuery;
+import com.wanted.momocity.lecture.application.usecase.AdminLectureQueryUseCase;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import com.wanted.momocity.lecture.presentation.api.response.AdminLectureListItemResponse;
+import com.wanted.momocity.lecture.presentation.api.response.AdminLecturePageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// 관리자 강의 조회 로직을 처리하는 Application Service
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminLectureQueryService implements AdminLectureQueryUseCase {
+
+    private final LectureRepository lectureRepository;
+
+    @Override
+    public AdminLecturePageResponse getAdminLectures(GetAdminLecturesQuery query) {
+        // status가 없으면 관리자 전체 목록 기준인 WAITING + ACTIVE를 조회한다.
+        List<LectureStatus> statuses = resolveStatuses(query.status());
+
+        // 관리자 강의 목록을 Repository를 통해 조회한다.
+        var lecturePage = lectureRepository.findAdminLectures(
+                statuses,
+                query.category(),
+                query.keyword(),
+                query.page(),
+                query.size()
+        );
+
+        // 도메인 모델을 관리자 목록 응답 DTO로 변환한다.
+        List<AdminLectureListItemResponse> content = lecturePage.content().stream()
+                .map(AdminLectureListItemResponse::from)
+                .toList();
+
+        // 페이지 정보와 목록을 함께 반환한다.
+        return new AdminLecturePageResponse(
+                content,
+                query.page(),
+                query.size(),
+                lecturePage.totalElements(),
+                lecturePage.totalPages()
+        );
+    }
+
+    // 관리자 목록 조회에서 사용할 강의 상태 목록을 정한다.
+    private List<LectureStatus> resolveStatuses(LectureStatus status) {
+        if (status == null) {
+            return List.of(
+                    LectureStatus.WAITING,
+                    LectureStatus.ACTIVE
+            );
+        }
+
+        return List.of(status);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureQueryService.java
@@ -1,9 +1,16 @@
 package com.wanted.momocity.lecture.application.service;
 
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.query.GetAdminLectureDetailQuery;
 import com.wanted.momocity.lecture.application.query.GetAdminLecturesQuery;
 import com.wanted.momocity.lecture.application.usecase.AdminLectureQueryUseCase;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import com.wanted.momocity.lecture.presentation.api.response.AdminLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.AdminLectureListItemResponse;
 import com.wanted.momocity.lecture.presentation.api.response.AdminLecturePageResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +26,7 @@ import java.util.List;
 public class AdminLectureQueryService implements AdminLectureQueryUseCase {
 
     private final LectureRepository lectureRepository;
+    private final ChapterRepository chapterRepository;
 
     @Override
     public AdminLecturePageResponse getAdminLectures(GetAdminLecturesQuery query) {
@@ -59,5 +67,36 @@ public class AdminLectureQueryService implements AdminLectureQueryUseCase {
         }
 
         return List.of(status);
+    }
+
+    @Override
+    public AdminLectureDetailResponse getAdminLectureDetail(GetAdminLectureDetailQuery query) {
+        /*
+         * 관리자 상세 조회 대상 강의를 조회한다.
+         * 강의가 없으면 404로 변환될 수 있는 예외를 던진다.
+         */
+        LectureAggregate lecture = lectureRepository.findById(query.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        /*
+         * 관리자 화면에서는 승인 대기(WAITING) 또는 진행 중(ACTIVE) 강의만 상세 조회한다.
+         * HOLD, DELETED까지 보여줄 정책이면 이 조건은 나중에 확장하면 된다.
+         */
+        if (lecture.getStatus() != LectureStatus.WAITING
+                && lecture.getStatus() != LectureStatus.ACTIVE) {
+            throw new DomainRuleViolationException("관리자는 승인 대기 또는 진행 중 강의만 조회할 수 있습니다.");
+        }
+
+        /*
+         * 강의에 연결된 챕터 목록을 노출 순서대로 조회한다.
+         * 관리자 상세 화면에서 챕터와 영상 상태를 함께 확인하기 위해 필요하다.
+         */
+        List<LectureChapter> chapters =
+                chapterRepository.findAllByLectureIdOrderByOrderNoAsc(query.lectureId());
+
+        /*
+         * 강의 정보와 챕터 목록을 관리자 상세 응답 DTO로 변환한다.
+         */
+        return AdminLectureDetailResponse.from(lecture, chapters);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -54,18 +54,29 @@ public class LectureQueryService implements LectureQueryUseCase {
     // 강사 이름과 프로필 이미지를 조회하기 위한 auth 포트
     private final LoadUserPort loadUserPort;
 
-    // 강의 목록을 조회
     @Override
+    @Transactional(readOnly = true)
     public StudentLecturePageResponse getLectures(GetLecturesQuery query) {
 
-        // Authorization 토큰에서 꺼낸 email로 userId를 조회
-        Long userId = studentAccountPort.getStudentId(query.userId());
+        /*
+         * Authorization 토큰에서 꺼낸 로그인 사용자 ID로 학생 ID를 조회한다.
+         * 컨트롤러에서는 인증된 사용자 ID만 넘기고,
+         * 실제 학생 식별자는 studentAccountPort를 통해 가져온다.
+         */
+        Long studentId = studentAccountPort.getStudentId(query.userId());
 
-        // userId 기준으로 수강 신청한 강의 ID 목록을 조회
-        List<Long> enrolledLectureIds = lectureEnrollmentQueryPort.findLectureIdsByUserId(userId);
+        /*
+         * 현재 학생이 이미 수강 신청한 강의 ID 목록을 조회한다.
+         * 이 목록은 isEnrolled 값을 만들고,
+         * enrolled=true/false 필터링에도 사용된다.
+         */
+        List<Long> enrolledLectureIds =
+                lectureEnrollmentQueryPort.findLectureIdsByUserId(studentId);
 
-        // 강의 목록을 조회
-        // category와 enrolled 조건은 repository에서 처리함.
+        /*
+         * 학생에게 보여줄 강의 목록을 조회한다.
+         * category, keyword, enrolled 조건과 페이지네이션은 repository에서 처리한다.
+         */
         var lecturePage = lectureRepository.findLectures(
                 query.category(),
                 query.keyword(),
@@ -75,15 +86,22 @@ public class LectureQueryService implements LectureQueryUseCase {
                 query.size()
         );
 
-        // 조회된 강의들을 응답 DTO로 변환합니다.
+        /*
+         * 조회된 강의들을 목록 응답 item으로 변환한다.
+         * 강의가 1개여도 content 배열 안에 들어가야 하므로 List로 변환한다.
+         */
         List<StudentLectureListItemResponse> content = lecturePage.content().stream()
                 .map(lecture -> toResponse(
                         lecture,
                         enrolledLectureIds.contains(lecture.getId()),
-                        userId
+                        studentId
                 ))
                 .toList();
 
+        /*
+         * 최종 data 영역을 만든다.
+         * Controller에서는 이 객체를 ApiResponse.data에 넣어 응답한다.
+         */
         return new StudentLecturePageResponse(
                 content,
                 query.page(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/AdminLectureQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/AdminLectureQueryUseCase.java
@@ -1,0 +1,16 @@
+package com.wanted.momocity.lecture.application.usecase;
+
+import com.wanted.momocity.lecture.application.query.GetAdminLectureDetailQuery;
+import com.wanted.momocity.lecture.application.query.GetAdminLecturesQuery;
+import com.wanted.momocity.lecture.presentation.api.response.AdminLectureDetailResponse;
+import com.wanted.momocity.lecture.presentation.api.response.AdminLecturePageResponse;
+
+// 관리자 강의 조회 기능을 정의하는 UseCase 인터페이스
+public interface AdminLectureQueryUseCase {
+
+    // 관리자가 강의 목록을 조회
+    AdminLecturePageResponse getAdminLectures(GetAdminLecturesQuery query);
+
+    // 관리자가 강의 상세 정보를 조회한다.
+    AdminLectureDetailResponse getAdminLectureDetail(GetAdminLectureDetailQuery query);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
@@ -3,6 +3,7 @@ package com.wanted.momocity.lecture.domain.repository;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LecturePage;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,9 +31,19 @@ public interface LectureRepository {
             int size
     );
 
-    // 강사가 등록한 강의 목록을 조회한다.
+    // 강사가 등록한 강의 목록을 조회
     LecturePage findTeacherLectures(
             Long teacherId,
+            LectureCategory category,
+            String keyword,
+            int page,
+            int size
+    );
+
+    // 관리자가 강의 목록을 조회
+    // status 목록을 받아 WAITING, ACTIVE 같은 여러 상태를 한 번에 조회
+    LecturePage findAdminLectures(
+            List<LectureStatus> statuses,
             LectureCategory category,
             String keyword,
             int page,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -65,6 +65,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
                 .map(this::toDomain);
     }
 
+
     // 학생용 강의 목록을 조회
     // 학생용 목록은 기본적으로 ACTIVE 상태의 강의 보여준다.
     @Override
@@ -128,6 +129,44 @@ public class LectureRepositoryAdapter implements LectureRepository {
                 .map(this::toDomain)
                 .toList();
 
+        return new LecturePage(
+                content,
+                lecturePage.getTotalElements(),
+                lecturePage.getTotalPages()
+        );
+    }
+
+    // 관리자가 강의 목록을 조회
+    // statuses에는 기본적으로 WAITING, ACTIVE가 들어온다.
+    @Override
+    @Transactional(readOnly = true)
+    public LecturePage findAdminLectures(
+            List<LectureStatus> statuses,
+            LectureCategory category,
+            String keyword,
+            int page,
+            int size
+    ) {
+        // 프론트는 page를 1부터 보내고, Spring Data JPA는 page를 0부터 시작
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        // keyword가 null이거나 공백이면 검색 조건을 적용하지 않기 위해 null로 정리
+        String normalizedKeyword = normalizeKeyword(keyword);
+
+        // 관리자 강의 목록 조회 쿼리를 실행
+        Page<LectureJpaEntity> lecturePage = repository.findAdminLectures(
+                statuses,
+                category,
+                normalizedKeyword,
+                pageable
+        );
+
+        // JPA Entity를 도메인 모델로 변환
+        List<LectureAggregate> content = lecturePage.getContent().stream()
+                .map(this::toDomain)
+                .toList();
+
+        // 도메인 페이지 객체로 감싸서 반환
         return new LecturePage(
                 content,
                 lecturePage.getTotalElements(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
+import java.util.List;
 
 // SpringDataLectureRepository는 실제 lecture 테이블 조회를 담당하는 JPA Repository
 public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEntity, Long> {
@@ -75,6 +76,31 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
         """)
     Page<LectureJpaEntity> findTeacherLectures(
             @Param("teacherId") Long teacherId,
+            @Param("category") LectureCategory category,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /* comment
+     * 관리자가 강의 목록을 조회
+     *
+     * 조건:
+     * - statuses 안에 포함된 강의 상태만 조회한다.
+     *   예: WAITING, ACTIVE
+     * - category가 있으면 해당 카테고리만 조회한다.
+     * - keyword가 있으면 강의 제목에 keyword가 포함된 강의만 조회한다.
+     * - 최신 등록순으로 정렬한다.
+     */
+    @Query("""
+    select l
+    from LectureJpaEntity l
+    where l.status in :statuses
+      and (:category is null or l.category = :category)
+      and (:keyword is null or l.title like concat('%', :keyword, '%'))
+    order by l.createdAt desc
+    """)
+    Page<LectureJpaEntity> findAdminLectures(
+            @Param("statuses") List<LectureStatus> statuses,
             @Param("category") LectureCategory category,
             @Param("keyword") String keyword,
             Pageable pageable

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -97,6 +97,11 @@ public class LectureController {
             ));
         }
 
+        /*
+         * 학생 강의 목록 조회
+         * 학생은 ACTIVE 상태의 강의만 조회하고,
+         * 응답에는 수강 여부(isEnrolled)가 포함된다.
+         */
         GetLecturesQuery query = new GetLecturesQuery(
                 userId,
                 parseCategory(category),
@@ -106,8 +111,8 @@ public class LectureController {
                 size
         );
 
-        // 학생 강의 목록 조회
-        StudentLecturePageResponse response = lectureQueryUseCase.getLectures(query);
+        StudentLecturePageResponse response =
+                lectureQueryUseCase.getLectures(query);
 
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -3,18 +3,12 @@ package com.wanted.momocity.lecture.presentation.api;
 import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
-import com.wanted.momocity.lecture.application.query.GetAdminLecturesQuery;
-import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
-import com.wanted.momocity.lecture.application.query.GetStudentLectureDetailQuery;
-import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
+import com.wanted.momocity.lecture.application.query.*;
 import com.wanted.momocity.lecture.application.usecase.AdminLectureQueryUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
-import com.wanted.momocity.lecture.presentation.api.response.AdminLecturePageResponse;
-import com.wanted.momocity.lecture.presentation.api.response.StudentLectureDetailResponse;
-import com.wanted.momocity.lecture.presentation.api.response.StudentLecturePageResponse;
-import com.wanted.momocity.lecture.presentation.api.response.TeacherLecturePageResponse;
+import com.wanted.momocity.lecture.presentation.api.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -135,50 +129,60 @@ public class LectureController {
     // 학생은 ACTIVE 상태의 강의만 상세 조회
     @Operation(
             summary = "강의 상세 조회",
-            description = "학생 또는 회원이 ACTIVE 상태의 강의 상세 정보를 조회합니다."
+            description = "권한에 따라 강의 상세 정보를 조회합니다. 관리자는 승인 대기/진행 중 강의를 조회하고, 학생은 ACTIVE 강의만 조회합니다."
     )
     @GetMapping("/{lectureId}")
-    public ResponseEntity<ApiResponse<StudentLectureDetailResponse>> getLectureDetail(
+    public ResponseEntity<ApiResponse<?>> getLectureDetail(
             Authentication authentication,
 
             // 상세 조회할 강의 ID
             @PathVariable Long lectureId
     ) {
-        // Authorization 토큰에서 로그인한 사용자 ID를 꺼낸다
+        /*
+         * Authorization 토큰에서 로그인 사용자 ID와 권한을 꺼낸다.
+         * 같은 URL이라도 권한에 따라 조회 정책과 응답 DTO가 달라진다.
+         */
         Long userId = Long.parseLong(authentication.getName());
+        String role = getRole(authentication);
 
-        // Controller에서 받은 값을 Application 계층에서 사용할 Query 객체로 묶는다.
+        /*
+         * 관리자 강의 상세 조회
+         * 관리자는 승인 대기(WAITING) 또는 진행 중(ACTIVE) 강의를 상세 조회한다.
+         */
+        if ("ROLE_ADMIN".equals(role)) {
+            GetAdminLectureDetailQuery query = new GetAdminLectureDetailQuery(
+                    userId,
+                    lectureId
+            );
+
+            AdminLectureDetailResponse response =
+                    adminLectureQueryUseCase.getAdminLectureDetail(query);
+
+            return ResponseEntity.ok(ApiResponse.success(
+                    ApiResponseCode.SUCCESS,
+                    "관리자 강의 상세 조회에 성공했습니다.",
+                    response
+            ));
+        }
+
+        /*
+         * 학생 강의 상세 조회
+         * 학생은 ACTIVE 상태의 강의만 상세 조회한다.
+         * 응답에는 isEnrolled가 포함된다.
+         */
         GetStudentLectureDetailQuery query = new GetStudentLectureDetailQuery(
                 userId,
                 lectureId
         );
 
-        // 학생 강의 상세 조회 UseCase를 실행
         StudentLectureDetailResponse response =
                 lectureQueryUseCase.getStudentLectureDetail(query);
 
-        // 조회 성공 응답을 반환
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,
                 "강의 상세 조회에 성공했습니다.",
                 response
         ));
-    }
-
-    /* comment
-     * 문자열 category를 LectureCategory enum으로 변환
-     * category가 없으면 null을 반환해서 전체 카테고리를 조회
-     */
-    private LectureCategory parseCategory(String category) {
-        if (category == null || category.isBlank()) {
-            return null;
-        }
-
-        try {
-            return LectureCategory.valueOf(category.toUpperCase());
-        } catch (IllegalArgumentException exception) {
-            throw new DomainRuleViolationException("허용되지 않는 강의 카테고리입니다.");
-        }
     }
 
     // 문자열 status를 LectureStatus enum으로 변환한다.
@@ -192,6 +196,22 @@ public class LectureController {
             return LectureStatus.valueOf(status.toUpperCase());
         } catch (IllegalArgumentException exception) {
             throw new DomainRuleViolationException("허용되지 않은 강의 상태입니다.");
+        }
+    }
+
+    /*
+     * 문자열 category를 LectureCategory enum으로 변환한다.
+     * category가 없으면 null을 반환해서 전체 카테고리 조회로 처리한다.
+     */
+    private LectureCategory parseCategory(String category) {
+        if (category == null || category.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LectureCategory.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new DomainRuleViolationException("허용되지 않은 강의 카테고리입니다.");
         }
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -3,21 +3,24 @@ package com.wanted.momocity.lecture.presentation.api;
 import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.lecture.application.query.GetAdminLecturesQuery;
 import com.wanted.momocity.lecture.application.query.GetLecturesQuery;
 import com.wanted.momocity.lecture.application.query.GetStudentLectureDetailQuery;
-import com.wanted.momocity.lecture.application.query.GetTeacherLectureDetailQuery;
+import com.wanted.momocity.lecture.application.query.GetTeacherLecturesQuery;
+import com.wanted.momocity.lecture.application.usecase.AdminLectureQueryUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
-import com.wanted.momocity.lecture.presentation.api.response.LecturePageResponse;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.presentation.api.response.AdminLecturePageResponse;
 import com.wanted.momocity.lecture.presentation.api.response.StudentLectureDetailResponse;
 import com.wanted.momocity.lecture.presentation.api.response.StudentLecturePageResponse;
-import com.wanted.momocity.lecture.presentation.api.response.TeacherLectureDetailResponse;
+import com.wanted.momocity.lecture.presentation.api.response.TeacherLecturePageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.*;
 
 /* comment
@@ -34,6 +37,8 @@ public class LectureController {
 
     // 강의 조회 UseCase
     private final LectureQueryUseCase lectureQueryUseCase;
+    // 관리자 강의 조회 UseCase
+    private final AdminLectureQueryUseCase adminLectureQueryUseCase;
 
     // 강의 목록 조회 API
     @Operation(
@@ -41,28 +46,56 @@ public class LectureController {
             description = "학생용 강의 목록을 조회합니다. enrolled=true이면 내가 수강신청한 강의만 조회합니다."
     )
     @GetMapping
-    public ResponseEntity<ApiResponse<StudentLecturePageResponse>> getLectures(
+    public ResponseEntity<ApiResponse<?>> getLectures(
             Authentication authentication,
-
-            // 강의 카테고리 필터
-            // 없으면 전체 카테고리 조회
             @RequestParam(required = false) String category,
-
-            // 수강 신청 여부 필터
-            // true: 신청한 강의만
-            // false: 신청하지 않은 강의만
-            // null: 수강 여부 상관없이 전체 조회
             @RequestParam(required = false) Boolean enrolled,
-
             @RequestParam(required = false) String keyword,
-
-            // 페이지 번호입니다. 기본값은 0
+            @RequestParam(required = false) String status,
             @RequestParam(defaultValue = "1") int page,
-
-            // 페이지 크기입니다. 기본값은 10
             @RequestParam(defaultValue = "10") int size
     ) {
+        String role = getRole(authentication);
         Long userId = Long.parseLong(authentication.getName());
+
+        // 관리자 강의 목록 조회
+        if ("ROLE_ADMIN".equals(role)) {
+            GetAdminLecturesQuery query = new GetAdminLecturesQuery(
+                    userId,
+                    parseStatus(status),
+                    parseCategory(category),
+                    keyword,
+                    page,
+                    size
+            );
+
+            AdminLecturePageResponse response = adminLectureQueryUseCase.getAdminLectures(query);
+
+            return ResponseEntity.ok(ApiResponse.success(
+                    ApiResponseCode.SUCCESS,
+                    "관리자 강의 목록 조회에 성공했습니다.",
+                    response
+            ));
+        }
+
+        // 강사 강의 목록 조회
+        if ("ROLE_TEACHER".equals(role)) {
+            GetTeacherLecturesQuery query = new GetTeacherLecturesQuery(
+                    userId,
+                    page,
+                    size,
+                    parseCategory(category),
+                    keyword
+            );
+
+            TeacherLecturePageResponse response = lectureQueryUseCase.getTeacherLectures(query);
+
+            return ResponseEntity.ok(ApiResponse.success(
+                    ApiResponseCode.SUCCESS,
+                    "강사 강의 목록 조회에 성공했습니다.",
+                    response
+            ));
+        }
 
         GetLecturesQuery query = new GetLecturesQuery(
                 userId,
@@ -73,6 +106,7 @@ public class LectureController {
                 size
         );
 
+        // 학생 강의 목록 조회
         StudentLecturePageResponse response = lectureQueryUseCase.getLectures(query);
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -80,6 +114,16 @@ public class LectureController {
                 "강의 목록 조회에 성공했습니다.",
                 response
         ));
+    }
+
+    // Authentication에 들어있는 ROLE 정보를 꺼낸다.
+    // 예: ROLE_STUDENT, ROLE_TEACHER, ROLE_ADMIN
+    private String getRole(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(authority -> authority.startsWith("ROLE_"))
+                .findFirst()
+                .orElseThrow(() -> new DomainRuleViolationException("사용자 권한 정보가 없습니다."));
     }
 
     // 학생 강의 상세 조회 API
@@ -129,6 +173,20 @@ public class LectureController {
             return LectureCategory.valueOf(category.toUpperCase());
         } catch (IllegalArgumentException exception) {
             throw new DomainRuleViolationException("허용되지 않는 강의 카테고리입니다.");
+        }
+    }
+
+    // 문자열 status를 LectureStatus enum으로 변환한다.
+    // status가 없으면 null을 반환해서 관리자 전체 조회로 처리한다.
+    private LectureStatus parseStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LectureStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new DomainRuleViolationException("허용되지 않은 강의 상태입니다.");
         }
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureChapterResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureChapterResponse.java
@@ -1,0 +1,36 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+// 관리자 강의 상세 조회에서 챕터 1개의 정보를 내려주는 응답 DTO
+/*  comment
+*   영상 정보까지 넣은 이유는 관리자는 챕터, 영상, 영상 상태, 원본 파일명을 봐야 되기 때문에
+*   학생 응답보다 더 많은 정보를 넣음
+* */
+public record AdminLectureChapterResponse(
+        Long chapterId,
+        Long lectureId,
+        String title,
+        int orderNo,
+        String videoUrl,
+        Long videoSizeBytes,
+        Integer durationSec,
+        String videoStatus,
+        String originalFilename
+) {
+
+    // 도메인 모델 LectureChapter를 관리자 챕터 응답 DTO로 변환
+    public static AdminLectureChapterResponse from(LectureChapter chapter) {
+        return new AdminLectureChapterResponse(
+                chapter.getId(),
+                chapter.getLectureId(),
+                chapter.getTitle(),
+                chapter.getOrderNo(),
+                chapter.getVideoUrl(),
+                chapter.getVideoSizeBytes(),
+                chapter.getDurationSec(),
+                chapter.getVideoStatus().name(),
+                chapter.getOriginalFilename()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureDetailResponse.java
@@ -1,0 +1,45 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureChapter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 관리자 강의 상세 조회 응답 DTO
+public record AdminLectureDetailResponse(
+        Long lectureId,
+        Long teacherId,
+        String title,
+        String description,
+        String thumbnailUrl,
+        String category,
+        String lectureStatus,
+        int completedUserCount,
+        List<AdminLectureChapterResponse> chapters,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    // 강의 도메인 모델과 챕터 목록을 관리자 상세 응답 DTO로 변환한다.
+    public static AdminLectureDetailResponse from(
+            LectureAggregate lecture,
+            List<LectureChapter> chapters
+    ) {
+        return new AdminLectureDetailResponse(
+                lecture.getId(),
+                lecture.getTeacherId(),
+                lecture.getTitle(),
+                lecture.getDescription(),
+                lecture.getThumbnailUrl(),
+                lecture.getCategory().name(),
+                lecture.getStatus().name(),
+                lecture.getCompletedUserCount(),
+                chapters.stream()
+                        .map(AdminLectureChapterResponse::from)
+                        .toList(),
+                lecture.getCreatedAt(),
+                lecture.getUpdatedAt()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureListItemResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureListItemResponse.java
@@ -1,0 +1,36 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+
+import java.time.LocalDateTime;
+
+// 관리자 강의 목록에서 강의 1개를 표현하는 응답 DTO
+public record AdminLectureListItemResponse(
+        Long lectureId,
+        Long teacherId,
+        String title,
+        String description,
+        String thumbnailUrl,
+        String category,
+        String lectureStatus,
+        int completedUserCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    // 도메인 모델 LectureAggregate를 관리자 목록 응답 DTO로 변환
+    public static AdminLectureListItemResponse from(LectureAggregate lecture) {
+        return new AdminLectureListItemResponse(
+                lecture.getId(),
+                lecture.getTeacherId(),
+                lecture.getTitle(),
+                lecture.getDescription(),
+                lecture.getThumbnailUrl(),
+                lecture.getCategory().name(),
+                lecture.getStatus().name(),
+                lecture.getCompletedUserCount(),
+                lecture.getCreatedAt(),
+                lecture.getUpdatedAt()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLecturePageResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLecturePageResponse.java
@@ -1,0 +1,13 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import java.util.List;
+
+// 관리자 강의 목록 페이지 응답 DTO
+public record AdminLecturePageResponse(
+        List<AdminLectureListItemResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureListItemResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureListItemResponse.java
@@ -1,47 +1,53 @@
 package com.wanted.momocity.lecture.presentation.api.response;
 
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+
 import java.time.LocalDateTime;
 
-// 학생이 보는 강의 목록의 강의 1개 응답 DTO
+/* comment
+ * 학생 강의 목록에서 강의 1개를 표현하는 응답 DTO
+ * 최종 응답의 data.content 배열 안에 들어간다.
+ */
 public record StudentLectureListItemResponse(
-
-        // 강의 고유 ID
-        Long lectureId,
-
-        // 강사를 식별하는 user ID
-        Long teacherId,
-
-        // 강사 이름
-        String teacherName,
-
-        // 강의 제목
-        String title,
-
-        // 강의 설명
-        String description,
-
-        // 강의 썸네일 이미지 URL
-        String thumbnailUrl,
-
-        // 강의 카테고리
-        String category,
-
-        // 강의 상태
-        String lectureStatus,
-
-        // 이 강의를 완료한 사용자 수
-        int completedUserCount,
-
-        // 리뷰 평균 평점
-        double averageRating,
-
-        // 리뷰 개수
-        int reviewCount,
-
-        // 로그인한 사용자가 이 강의를 수강신청했는지 여부 확인
-        boolean isEnrolled,
-
-        // 강의가 등록된 시간
-        LocalDateTime createdAt
+        Long lectureId,              // 강의 ID
+        Long teacherId,              // 강사 ID
+        String teacherName,          // 강사 이름
+        String title,                // 강의 제목
+        String description,          // 강의 설명
+        String thumbnailUrl,         // 썸네일 URL
+        String category,             // 강의 카테고리
+        String lectureStatus,        // 강의 상태
+        int completedUserCount,      // 수강 완료 인원
+        double averageRating,        // 평균 평점
+        int reviewCount,             // 수강평 개수
+        boolean isEnrolled,          // 현재 로그인한 학생의 수강 여부
+        LocalDateTime createdAt      // 강의 생성일
 ) {
+    /* comment
+     * 도메인 모델을 화면 응답 DTO로 변환
+     * 목록 조회에서는 이 객체 여러 개가 content 배열에 담긴다.
+     */
+    public static StudentLectureListItemResponse from(
+            LectureAggregate lecture,
+            String teacherName,
+            double averageRating,
+            int reviewCount,
+            boolean isEnrolled
+    ) {
+        return new StudentLectureListItemResponse(
+                lecture.getId(),
+                lecture.getTeacherId(),
+                teacherName,
+                lecture.getTitle(),
+                lecture.getDescription(),
+                lecture.getThumbnailUrl(),
+                lecture.getCategory().name(),
+                lecture.getStatus().name(),
+                lecture.getCompletedUserCount(),
+                averageRating,
+                reviewCount,
+                isEnrolled,
+                lecture.getCreatedAt()
+        );
+    }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLecturePageResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLecturePageResponse.java
@@ -2,23 +2,15 @@ package com.wanted.momocity.lecture.presentation.api.response;
 
 import java.util.List;
 
-// 학생 강의 목록 페이지 응답 DTO
+/*
+ * 학생 강의 목록 조회의 data 영역을 담당하는 응답 DTO
+ * content 배열과 페이지 정보를 함께 내려준다.
+ */
 public record StudentLecturePageResponse(
-
-        // 현재 페이지의 강의 목록
-        List<StudentLectureListItemResponse> content,
-
-        // 현재 페이지 번호
-        int page,
-
-        // 한 페이지에 보여줄 강의 개수
-        int size,
-
-        // 전체 강의 개수
-        long totalElements,
-
-        // 전체 페이지 수
-        int totalPages
-
+        List<StudentLectureListItemResponse> content, // 강의 목록 배열
+        int page,                                     // 현재 페이지 번호
+        int size,                                     // 한 페이지에 보여줄 강의 개수
+        long totalElements,                          // 전체 강의 개수
+        int totalPages                               // 전체 페이지 수
 ) {
 }


### PR DESCRIPTION
## 작업 내용

- 강의 목록 조회 응답 형식을 `content` 배열 + 페이지 정보 구조로 정리했습니다.
 
- 학생/강사/관리자 목록 조회가 공통적으로 `ApiResponse` 안의 `data.content` 배열로 내려가도록 맞췄습니다.
 
- `/api/v1/lectures` 목록 조회에서 로그인 사용자 권한에 따라 조회 정책을 분기했습니다.
  - 학생: `ACTIVE` 상태 강의 조회 및 `isEnrolled` 포함
  - 강사: 본인이 등록한 강의 조회
  - 관리자: `WAITING`, `ACTIVE` 상태 강의 조회
- 관리자 강의 목록 조회 기능을 추가했습니다.
- 관리자 강의 상세 조회 기능을 추가했습니다.
- 관리자 상세 조회 응답에 강의 정보와 챕터/영상 정보를 함께 포함했습니다.

## 조회 흐름

```text
GET /api/v1/lectures
Authorization: Bearer {access_token}

LectureController
 -> ROLE 확인
 -> ROLE_STUDENT: LectureQueryUseCase#getLectures
 -> ROLE_TEACHER: LectureQueryUseCase#getTeacherLectures
 -> ROLE_ADMIN: AdminLectureQueryUseCase#getAdminLectures
 -> ApiResponse.success(...)

## 참고사항
- URL에서 role을 제거하고, Authorization 토큰의 권한 정보를 기준으로 학생/강사/관리자 조회를 분기했습니다.
- 목록 조회는 강의가 1개여도 항상 content 배열로 내려갑니다.
- 페이지 번호는 프론트 기준으로 1부터 사용합니다.- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 