### PR TITLE
[PR] 임시 비밀번호 버그 해결 및 이메일 전송 비동기처리 / LocalDateTime 변경 

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/port/TokenProviderPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/port/TokenProviderPort.java
@@ -15,6 +15,9 @@ public interface TokenProviderPort {
     long getRefreshTokenValidityMilliseconds();
     long getAccessTokenValidityMilliseconds();
 
+    // 임시비밀번호 발급용 3분짜리 액세스 토큰 생성
+    String createTempAccessToken(Authentication authentication);
+
     // 소셜 로그인 용 -> 이메일이랑 role만 가지고 access 토큰 발급하기
     String createAccessToken(String userId, String role);
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/service/LoginService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/service/LoginService.java
@@ -61,7 +61,9 @@ public class LoginService implements LoginUsecase {
         }
 
         // 인증 성공 후 액세스 토큰 발급
-        String accessToken = tokenProviderPort.createAccessToken(authentication);
+        String accessToken = user.getIsTempPwd()
+                ? tokenProviderPort.createTempAccessToken(authentication)
+                : tokenProviderPort.createAccessToken(authentication);
 
         // 리프레시 토큰 발급
         String refreshToken = tokenProviderPort.createRefreshToken(String.valueOf(user.getId()));
@@ -74,6 +76,10 @@ public class LoginService implements LoginUsecase {
         );
 
         // 컨트롤러로 보내서 프론트에게 전달할 수 있도록 리턴
-        return new LoginResponse(accessToken, refreshToken,user.getStatus(),tokenProviderPort.getAccessTokenValidityMilliseconds() / 1000 );
+        long accessTokenExpiry = user.getIsTempPwd()
+                ? 3 * 60  // 3분
+                : tokenProviderPort.getAccessTokenValidityMilliseconds() / 1000;
+
+        return new LoginResponse(accessToken, refreshToken, user.getStatus(), accessTokenExpiry);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/service/RefreshService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/service/RefreshService.java
@@ -47,6 +47,11 @@ public class RefreshService implements NewTokenUsecase {
             throw new InvalidRefreshTokenException("아직 승인되지 않은 계정입니다.");
         }
 
+        // 임시비번 로그인 유저는 토큰 연장 불가
+        if (user.getIsTempPwd()) {
+            throw new InvalidRefreshTokenException("임시 비밀번호를 변경 후 이용해주세요.");
+        }
+
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 String.valueOf(user.getId()),
                 null,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/model/User.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/model/User.java
@@ -1,7 +1,5 @@
 package com.wanted.momocity.auth.domain.model;
 
-
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -21,12 +19,12 @@ public class User {
     private final Long point;
     private final Boolean isPaid;  // 결제를 했는지 안 했는지
     private final Boolean doNotDisturb; // 설정 끄기를 했는지 안 했는지
-    private final Instant createdAt;
+    private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final LocalDateTime deletedAt;
     private final Boolean isTempPwd;  // 이 사용자의 비밀번호가 임시비밀번호인지 아닌지
 
-    private User(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, Boolean isPaid, Boolean doNotDisturb, Instant createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, Boolean isTempPwd) {
+    private User(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, Boolean isPaid, Boolean doNotDisturb, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, Boolean isTempPwd) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -48,7 +46,7 @@ public class User {
     }
 
     // DB에서 꺼내 쓸 메서드
-    public static User restore(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, long point, boolean isPaid, boolean doNotDisturb, Instant createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isTempPwd) {
+    public static User restore(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, long point, boolean isPaid, boolean doNotDisturb, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isTempPwd) {
         return new User(id, email, password, name, nickname, birth, profileImageUrl,
                 role, status, category, proof, point,
                 isPaid, doNotDisturb, createdAt, updatedAt, deletedAt, isTempPwd);
@@ -79,7 +77,7 @@ public class User {
                 0L,              // point
                 false,          // isPaid
                 false,          // doNotDisturb
-                Instant.now(),    // createdAt
+                LocalDateTime.now(),    // createdAt
                 LocalDateTime.now(),    // updatedAt
                 null,           // deletedAt
                 false           // isTempPwd
@@ -102,7 +100,7 @@ public class User {
                 0L,              // point
                 false,          // isPaid
                 false,          // doNotDisturb
-                Instant.now(),    // createdAt
+                LocalDateTime.now(),    // createdAt
                 LocalDateTime.now(),    // updatedAt
                 null,           // deletedAt
                 false           // isTempPwd
@@ -129,7 +127,7 @@ public class User {
         return point;
     }
 
-    public Instant getCreatedAt(){
+    public LocalDateTime getCreatedAt(){
         return createdAt;
     }
 
@@ -164,7 +162,7 @@ public class User {
                 0L,             // point
                 false,          // isPaid
                 false,          // doNotDisturb
-                Instant.now(),  // createdAt
+                LocalDateTime.now(),  // createdAt
                 LocalDateTime.now(), // updatedAt
                 null,           // deletedAt
                 false           // isTempPwd

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/model/UserOauth.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/model/UserOauth.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.auth.domain.model;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 public class UserOauth {
 
@@ -8,9 +8,9 @@ public class UserOauth {
     private final User user;
     private final String provider;
     private final String providerId;
-    private final Instant createdAt;
+    private final LocalDateTime createdAt;
 
-    private UserOauth(Long id, User user, String provider, String providerId, Instant createdAt) {
+    private UserOauth(Long id, User user, String provider, String providerId, LocalDateTime createdAt) {
         this.id = id;
         this.user = user;
         this.provider = provider;
@@ -20,11 +20,11 @@ public class UserOauth {
 
     // 신규 생성
     public static UserOauth create(User user, String provider, String providerId) {
-        return new UserOauth(null, user, provider, providerId, Instant.now());
+        return new UserOauth(null, user, provider, providerId, LocalDateTime.now());
     }
 
     // DB에서 꺼내 쓸 때
-    public static UserOauth restore(Long id, User user, String provider, String providerId, Instant createdAt) {
+    public static UserOauth restore(Long id, User user, String provider, String providerId, LocalDateTime createdAt) {
         return new UserOauth(id, user, provider, providerId, createdAt);
     }
 
@@ -33,6 +33,6 @@ public class UserOauth {
     public User getUser() { return user; }
     public String getProvider() { return provider; }
     public String getProviderId() { return providerId; }
-    public Instant getCreatedAt() { return createdAt; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/email/EmailSendAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/email/EmailSendAdapter.java
@@ -6,6 +6,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,11 +15,13 @@ public class EmailSendAdapter implements EmailSendPort {
 
     private final JavaMailSender mailSender;
 
+    @Async
     @Override
     public void send(String toEmail, String code) {
         sendEmail(toEmail, code, "인증 코드");
     }
 
+    @Async
     @Override
     public void sendTempPassword(String toEmail, String tempPassword) {
         sendEmail(toEmail, tempPassword, "임시 비밀번호");

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -166,6 +166,23 @@ public class JwtTokenProvider implements TokenProviderPort {
         return ACCESS_TOKEN_EXPIRE_TIME;
     }
 
+    // 임시비밀번호 발급용 3분짜리 액세스 토큰 생성
+    @Override
+    public String createTempAccessToken(Authentication authentication) {
+        String username = authentication.getName();
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("roles", authorities)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3 * 60 * 1000L)) // 3분
+                .signWith(SignatureAlgorithm.HS512, key)
+                .compact();
+    }
+
     // 소셜 로그인에서는 authentication이 없으니까 서비스에서 소셜로그인 하고 얻은
     @Override
     public String createAccessToken(String userId, String role) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/persistence/UserJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/persistence/UserJpaEntity.java
@@ -5,7 +5,6 @@ import com.wanted.momocity.auth.domain.model.Role;
 import com.wanted.momocity.auth.domain.model.Status;
 import jakarta.persistence.*;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -60,7 +59,7 @@ public class UserJpaEntity {
     private boolean doNotDisturb;
 
     @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
@@ -74,7 +73,7 @@ public class UserJpaEntity {
 
     protected UserJpaEntity() {}
 
-    public UserJpaEntity(String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, boolean isPaid, boolean doNotDisturb, Instant createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isTempPwd) {
+    public UserJpaEntity(String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, boolean isPaid, boolean doNotDisturb, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isTempPwd) {
         this.email = email;
         this.password = password;
         this.name = name;
@@ -151,7 +150,7 @@ public class UserJpaEntity {
         return doNotDisturb;
     }
 
-    public Instant getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/persistence/UserOauthJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/persistence/UserOauthJpaEntity.java
@@ -2,7 +2,7 @@ package com.wanted.momocity.auth.infrastructure.persistence;
 
 import jakarta.persistence.*;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_oauth")
@@ -23,11 +23,11 @@ public class UserOauthJpaEntity {
     private String providerId;
 
     @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
+    private LocalDateTime createdAt;
 
     protected UserOauthJpaEntity() {}
 
-    public UserOauthJpaEntity(UserJpaEntity user, String provider, String providerId, Instant createdAt) {
+    public UserOauthJpaEntity(UserJpaEntity user, String provider, String providerId, LocalDateTime createdAt) {
         this.user = user;
         this.provider = provider;
         this.providerId = providerId;
@@ -38,5 +38,5 @@ public class UserOauthJpaEntity {
     public UserJpaEntity getUser() { return user; }
     public String getProvider() { return provider; }
     public String getProviderId() { return providerId; }
-    public Instant getCreatedAt() { return createdAt; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/presentation/api/common/ApiErrorResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/presentation/api/common/ApiErrorResponse.java
@@ -1,19 +1,24 @@
 package com.wanted.momocity.global.presentation.api.common;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 
 /*
  * ApiErrorResponse는 예외 상황을 외부 클라이언트에 일관된 형태로 전달하기 위한 표준 모델이다.
  * domain / application 예외가 그대로 노출되지 않고, presentation 규약에 맞게 번역된다.
  */
+/*comment
+ *  Instant는 절대 시간점으로 글로벌 서비스에서 활용 - 우리나라랑 시간대 안 맞음
+ *  -> LocalDateTime으로 변경 : 얘는 말 그대로 로컬 시간 - 우리나라 시간대
+ * */
 public record ApiErrorResponse(
-        Instant timestamp,
+        LocalDateTime timestamp,
         int status,
         String code,
         String message
 ) {
 
     public static ApiErrorResponse of(int status, String code, String message) {
-        return new ApiErrorResponse(Instant.now(), status, code, message);
+        return new ApiErrorResponse(LocalDateTime.now(), status, code, message);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/presentation/api/common/ApiResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/presentation/api/common/ApiResponse.java
@@ -1,14 +1,18 @@
 package com.wanted.momocity.global.presentation.api.common;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 /*
  * ApiResponse는 성공 응답의 공통 표현 형식이다.
  * presentation 계층이 외부 계약을 표준화하고, 안쪽 계층은 HTTP 응답 구조를 몰라도 되게 만든다.
  * status는 HTTP 의미를, code와 message는 비즈니스 의미를 전달한다.
  */
+/*comment
+*  Instant는 절대 시간점으로 글로벌 서비스에서 활용 - 우리나라랑 시간대 안 맞음
+*  -> LocalDateTime으로 변경 : 얘는 말 그대로 로컬 시간 - 우리나라 시간대
+* */
 public record ApiResponse<T>(
-        Instant timestamp,
+        LocalDateTime timestamp,
         int status,
         String code,
         String message,
@@ -16,15 +20,15 @@ public record ApiResponse<T>(
 ) {
 
     public static <T> ApiResponse<T> success(String code, String message, T data) {
-        return new ApiResponse<>(Instant.now(), 200, code, message, data);
+        return new ApiResponse<>(LocalDateTime.now(), 200, code, message, data);
     }
 
     // 생성과 일반 성공을 분리해두면 controller가 REST 의도를 더 명확히 표현할 수 있다.
     public static <T> ApiResponse<T> created(String code, String message, T data) {
-        return new ApiResponse<>(Instant.now(), 201, code, message, data);
+        return new ApiResponse<>(LocalDateTime.now(), 201, code, message, data);
     }
 
     public static ApiResponse<Void> success(String code, String message) {
-        return new ApiResponse<>(Instant.now(), 200, code, message, null);
+        return new ApiResponse<>(LocalDateTime.now(), 200, code, message, null);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
@@ -9,6 +9,7 @@ import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
 import com.wanted.momocity.user.application.policy.UserPolicy;
 import com.wanted.momocity.user.application.port.UserEmailSendPort;
 import com.wanted.momocity.user.application.usecase.UserCommandUsecase;
+import com.wanted.momocity.user.domain.exception.InvalidReasonException;
 import com.wanted.momocity.user.domain.model.Role;
 import com.wanted.momocity.user.domain.model.Status;
 import com.wanted.momocity.user.domain.repository.UserRepository;
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -68,7 +69,7 @@ public class UserCommandService implements UserCommandUsecase {
 
         userRepository.updateRoleAndStatus(command.userId(), Role.TEACHER, Status.ACTIVE);
         userEmailSendPort.sendTeacherResult(email, "ACTIVE", null);
-        return new TeacherActionResult(command.userId(), "ACTIVE", null, Instant.now());
+        return new TeacherActionResult(command.userId(), "ACTIVE", null, LocalDateTime.now());
     }
 
     // 강사거절
@@ -85,6 +86,6 @@ public class UserCommandService implements UserCommandUsecase {
 
         userRepository.updateRoleAndStatus(command.userId(), Role.TEACHER, Status.REJECTED);
         userEmailSendPort.sendTeacherResult(email, "REJECTED", command.reason());
-        return new TeacherActionResult(command.userId(), "REJECTED", command.reason(), Instant.now());
+        return new TeacherActionResult(command.userId(), "REJECTED", command.reason(), LocalDateTime.now());
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
@@ -48,6 +48,7 @@ public class UserCommandService implements UserCommandUsecase {
             String storedPassword = userRepository.findPasswordById(command.userId());
             userPolicy.passwordPolicy(command.currentPassword(), command.password(), storedPassword);
             encodedPassword = passwordEncodePort.encode(command.password());  // 검증 통과 후 암호화
+            userRepository.clearTempPwd(command.userId());
         }
 
         userRepository.updateUserInfo(new UpdateUserInfoCommand(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
@@ -36,7 +36,9 @@ public class UserQueryService implements UserQueryUsecase {
                 user.getEmail(),
                 user.getName(),
                 user.getNickname(),
-                user.getBirth()
+                user.getBirth(),
+                user.getTempPwd(),
+                user.getCreatedAt()
         );
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserCommandUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserCommandUsecase.java
@@ -5,7 +5,7 @@ import com.wanted.momocity.user.application.command.RejectTeacherCommand;
 import com.wanted.momocity.user.application.command.NicknameRegisterCommand;
 import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 public interface UserCommandUsecase {
 
@@ -28,7 +28,7 @@ public interface UserCommandUsecase {
             Long userId,
             String status,
             String reason,
-            Instant processedAt
+            LocalDateTime processedAt
     ) {
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
@@ -4,6 +4,7 @@ import com.wanted.momocity.user.domain.model.TeacherApplication;
 import com.wanted.momocity.user.domain.model.Category;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UserQueryUsecase {
@@ -19,7 +20,10 @@ public interface UserQueryUsecase {
             String email,
             String name,
             String nickname,
-            LocalDate birth
+            LocalDate birth,
+            Boolean isTempPwd,
+            LocalDateTime createdAt
+
     ){}
 
     record RenderingBuildingsView(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/User.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/User.java
@@ -2,7 +2,6 @@ package com.wanted.momocity.user.domain.model;
 
 import lombok.Builder;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -23,12 +22,12 @@ public class User {
     private final Long point;
     private final Boolean isPaid;  // 결제를 했는지 안 했는지
     private final Boolean doNotDisturb; // 설정 끄기를 했는지 안 했는지
-    private final Instant createdAt;
+    private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final LocalDateTime deletedAt;
     private final Boolean isTempPwd;  // 이 사용자의 비밀번호가 임시비밀번호인지 아닌지
 
-    public User(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, Boolean isPaid, Boolean doNotDisturb, Instant createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, Boolean isTempPwd) {
+    public User(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, Boolean isPaid, Boolean doNotDisturb, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, Boolean isTempPwd) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -52,13 +51,15 @@ public class User {
     // 마이페이지에서 사용자에게 제시할 사용자 정보가 몇 개 없어서 user칼럼 전체 다 가져오면 널이 너무 만ㅎ음
     // -> 빌더 사용
     public static User restore(String profileImageUrl, String email,
-                               String name, String nickname, LocalDate birth) {
+                               String name, String nickname, LocalDate birth, Boolean isTempPwd, LocalDateTime createdAt) {
         return User.builder()
                 .profileImageUrl(profileImageUrl)
                 .email(email)
                 .name(name)
                 .nickname(nickname)
                 .birth(birth)
+                .isTempPwd(isTempPwd)
+                .createdAt(createdAt)
                 .build();
     }
 
@@ -119,7 +120,7 @@ public class User {
         return doNotDisturb;
     }
 
-    public Instant getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
@@ -23,6 +23,9 @@ public interface UserRepository {
     // 사용자 정보 수정
     void updateUserInfo(UpdateUserInfoCommand command);
 
+    // 임시비밀번호 죽이기 - 임시비번으로 로그인 해서 비번 바꾸면 is_tempPwd false로 변경
+    void clearTempPwd(Long userId);
+
     // id로 기존 비밀번호 찾기
     String findPasswordById(Long aLong);
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -50,4 +50,8 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
                              @Param("status") Status status,
                              @Param("updatedAt") LocalDateTime updatedAt);
 
-}
+    // 임시비번을 사용자가 변경했을 때
+    @Modifying
+    @Transactional
+    @Query("UPDATE UserUser u SET u.isTempPwd = false WHERE u.id = :userId")
+    void clearTempPwd(@Param("userId") Long userId);}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserJpaEntity.java
@@ -6,7 +6,6 @@ import com.wanted.momocity.user.domain.model.Status;
 import com.wanted.momocity.user.domain.model.User;
 import jakarta.persistence.*;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -61,7 +60,7 @@ public class UserJpaEntity {
     private boolean doNotDisturb;
 
     @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
@@ -76,7 +75,7 @@ public class UserJpaEntity {
     protected UserJpaEntity() {}
 
     // id 포함 생성자 추가
-    public UserJpaEntity(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, boolean isPaid, boolean doNotDisturb, Instant createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isTempPwd) {
+    public UserJpaEntity(Long id, String email, String password, String name, String nickname, LocalDate birth, String profileImageUrl, Role role, Status status, Category category, String proof, Long point, boolean isPaid, boolean doNotDisturb, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isTempPwd) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -177,7 +176,7 @@ public class UserJpaEntity {
         return doNotDisturb;
     }
 
-    public Instant getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -49,6 +49,12 @@ public class UserRepositoryAdapter implements UserRepository {
         );
     }
 
+    // 임시비번에서 새로운 비번 변경하면 is_tempPwd false 로 변경
+    @Override
+    public void clearTempPwd(Long userId) {
+        springDataUserRepository.clearTempPwd(userId);
+    }
+
     @Override
     public String findPasswordById(Long userId) {
         return springDataUserRepository.findById(userId)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -95,7 +95,9 @@ public class UserRepositoryAdapter implements UserRepository {
                 entity.getEmail(),
                 entity.getName(),
                 entity.getNickname(),
-                entity.getBirth()
+                entity.getBirth(),
+                entity.isTempPwd(),
+                entity.getCreatedAt()
         );
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserBuildingController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserBuildingController.java
@@ -1,0 +1,38 @@
+package com.wanted.momocity.user.presentation.api;
+
+import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.user.application.usecase.UserQueryUsecase;
+import com.wanted.momocity.user.presentation.api.response.UserResponseCode;
+import com.wanted.momocity.user.presentation.api.response.UserResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@Tag(name="user building controller", description = "사용자 개인의 건물 정보를 다루기 위한 User api 관련 컨트롤러 - 추후 모듈에서는 마이페이지 속 빌딩 정보 조회 추가 예정")
+public class UserBuildingController {
+
+    private final UserQueryUsecase userQueryUsecase;
+
+    @GetMapping("/user/buildings")
+    @Operation(
+            summary = "로그인 후 학생의 메인페이지 렌더링을 위한 정보 전달",
+            description = "액세스 토큰을 받아 카테고리, 포지션, 레벨 세 값을 응답에 전달한다")
+    public ResponseEntity<ApiResponse<UserQueryUsecase.RenderingBuildingsView>> renderingBuildings(
+            @AuthenticationPrincipal CustomUserDetails userDetails ){
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.SUCCESS,
+                UserResponseMessage.VIEW_BUILDING_INFO,
+                userQueryUsecase.userBuildingInfo(userDetails.getUserId())
+        ));
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
@@ -122,19 +122,4 @@ public class UserController {
     }
 
 
-    @GetMapping("/user/buildings")
-    @Operation(
-            summary = "로그인 후 학생의 메인페이지 렌더링을 위한 정보 전달",
-            description = "액세스 토큰을 받아 카테고리, 포지션, 레벨 세 값을 응답에 전달한다")
-    public ResponseEntity<ApiResponse<UserQueryUsecase.RenderingBuildingsView>>renderingBuildings(
-            @AuthenticationPrincipal CustomUserDetails userDetails ){
-
-        return ResponseEntity.ok(ApiResponse.success(
-                UserResponseCode.SUCCESS,
-                UserResponseMessage.VIEW_BUILDING_INFO,
-                userQueryUsecase.userBuildingInfo(userDetails.getUserId())
-        ));
-    }
-
-
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
@@ -1,5 +1,8 @@
 package com.wanted.momocity.user.presentation.api;
 
+import com.wanted.momocity.auth.application.port.BlacklistPort;
+import com.wanted.momocity.auth.application.port.RedisRefreshTokenPort;
+import com.wanted.momocity.auth.application.port.TokenProviderPort;
 import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.user.application.command.NicknameRegisterCommand;
@@ -9,6 +12,7 @@ import com.wanted.momocity.user.application.usecase.UserQueryUsecase;
 import com.wanted.momocity.user.presentation.api.request.NicknameRequest;
 import com.wanted.momocity.user.presentation.api.request.UpdateUserInfoRequest;
 import com.wanted.momocity.user.presentation.api.response.NicknameRegisterResponse;
+import com.wanted.momocity.user.presentation.api.response.UserInfoUpdateResponse;
 import com.wanted.momocity.user.presentation.api.response.UserResponseCode;
 import com.wanted.momocity.user.presentation.api.response.UserResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +33,10 @@ public class UserController {
 
     private final UserCommandUsecase userCommandUsecase;
     private final UserQueryUsecase userQueryUsecase;
+
+    private final BlacklistPort blacklistPort;
+    private final TokenProviderPort tokenProviderPort;
+    private final RedisRefreshTokenPort redisRefreshTokenPort;
 
 
     @GetMapping("/user/detail")
@@ -67,19 +75,34 @@ public class UserController {
     @PatchMapping("/user/update")
     @Operation(summary = "사용자 정보 수정",
                 description = "프로필 이미지(모듈4부터), 닉네임, 비밀번호 변경 가능")
-    public ResponseEntity<ApiResponse<Void>> updateUserInfo(
+    public ResponseEntity<ApiResponse<UserInfoUpdateResponse>> updateUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestHeader("Authorization") String bearerToken,
             @RequestBody @Valid UpdateUserInfoRequest request){
 
         userCommandUsecase.updateUserInfo(new UpdateUserInfoCommand(
                 userDetails.getUserId(),request.profileImageUrl(),request.nickname(),request.currentPassword(),request.password()
         ));
 
+        boolean isPwdChanged = request.password() != null;
+
+        // 비밀번호 변경되면 있는 토큰 다 만료시키고 액세스 블랙리스트 처리 - 로그아웃이랑 동일
+        if (isPwdChanged) {
+            String accessToken = bearerToken.substring(7);
+            long remaining = tokenProviderPort.getRemainingMillis(accessToken);
+            if (remaining > 0) {
+                // 액세스 토큰 블랙리스트에 추가
+                blacklistPort.addBlacklist(accessToken, remaining);
+            }
+            // 리프레시 토큰 삭제
+            redisRefreshTokenPort.deleteByUserId(String.valueOf(userDetails.getUserId()));
+        }
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(
                         UserResponseCode.SUCCESS,
                         UserResponseMessage.USER_INFO_UPDATE_SUCCESS,
-                    null
+                        new UserInfoUpdateResponse(isPwdChanged)
                 ));
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/TeacherActionResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/TeacherActionResponse.java
@@ -1,6 +1,7 @@
 package com.wanted.momocity.user.presentation.api.response;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 
 /* comment.
     TeacherActionResponse 정리
@@ -23,6 +24,6 @@ public record TeacherActionResponse(
         Long userId,
         String status,
         String reason,
-        Instant processedAt
+        LocalDateTime processedAt
 ) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/UserInfoUpdateResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/UserInfoUpdateResponse.java
@@ -1,0 +1,6 @@
+package com.wanted.momocity.user.presentation.api.response;
+
+public record UserInfoUpdateResponse(
+        Boolean isPwdChanged
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/ViewingController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/ViewingController.java
@@ -62,7 +62,7 @@ public class ViewingController {
     }
 
     // 강의 메타데이터 조회
-    // GET /api/v1/lectures/{lectureId}
+    // GET /api/v1/lectures/{lectureId}/meta
     @Operation(summary = "강의 메타데이터 조회",
             description = "플레이어 UI 상단에 강의 제목, 강사명, 현재 차시 표시용.")
     @ApiResponses(value = {
@@ -70,7 +70,7 @@ public class ViewingController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 토큰 만료"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "수강 권한 없음")
     })
-    @GetMapping("/lectures/{lectureId}")
+    @GetMapping("/lectures/{lectureId}/meta")
     public ResponseEntity<ApiResponse<LectureMetaResponse>> getLectureMeta(
             @Parameter(description = "강의 ID", required = true) @PathVariable Long lectureId,
             @AuthenticationPrincipal CustomUserDetails userDetails


### PR DESCRIPTION
## 이메일 전송 비동기 처리
- 이메일 인증 / 임시비밀번호 발급 이메일 전송을 비동기로 처리
- #210 

---

## 임시 비밀번호 버그 해결 
1. 임시비밀번호 토큰 처리
- 임시비밀번호로 로그인 시 일반 액세스 토큰 대신 만료시간 3분짜리 단기 토큰 발급
- 프론트에 실제 토큰 만료시간을 응답에 포함해 전달
- 리프레시 토큰으로 액세스 토큰 재발급 시 임시비밀번호 유저 차단

2. 비밀번호 변경 시 토큰 처리
- 비밀번호 변경 시 isTempPwd 컬럼 false로 업데이트
- 비밀번호 변경 시 기존 액세스 토큰 블랙리스트 등록 + 리프레시 토큰 Redis에서 삭제
- 비밀번호 변경 여부를 응답에 포함해 프론트에서 재로그인 유도

- #215 

---

## LocalDateTime 변경 
- Instant타입 설정으로 인해 timestamp 및 user,auth 도메인 createdAt 시간대 불일치 문제 해결

---

## 내정보 조회 시 추가 정보 전달
- 마이페이지 화면 랜더링 시 is_TempPwd , createdAt 칼럼 정보 전달
- #211 