### PR TITLE
[PR] 관리자 신청된 강의 승인/거절에 따른 상태 변경 구현(모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/AdminChangeLectureStatusCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/command/AdminChangeLectureStatusCommand.java
@@ -1,0 +1,47 @@
+package com.wanted.momocity.lecture.application.command;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+
+// 관리자가 강의 상태를 변경할 때 사용하는 Command 객체
+public record AdminChangeLectureStatusCommand(
+        Long adminId,                   // 상태 변경을 요청한 관리자 ID
+        Long lectureId,                 // 상태를 변경할 강의 ID
+        LectureStatus lectureStatus     // 변경할 강의 상태
+) {
+    public AdminChangeLectureStatusCommand {
+        validateAdminId(adminId);
+        validateLectureId(lectureId);
+        validateLectureStatus(lectureStatus);
+    }
+
+    // 관리자 ID는 인증된 사용자 정보에서 가져와야 하므로 필수
+    private static void validateAdminId(Long adminId) {
+        if (adminId == null) {
+            throw new DomainRuleViolationException("관리자 정보는 필수입니다.");
+        }
+    }
+
+    // 어떤 강의를 변경할지 알아야 하므로 강의 ID는 필수
+    private static void validateLectureId(Long lectureId) {
+        if (lectureId == null) {
+            throw new DomainRuleViolationException("강의 ID는 필수입니다.");
+        }
+    }
+
+    /*
+     * 관리자 승인/거절 버튼에서는 ACTIVE, HOLD만 허용한다.
+     * ACTIVE = 승인
+     * HOLD = 거절
+     */
+    private static void validateLectureStatus(LectureStatus lectureStatus) {
+        if (lectureStatus == null) {
+            throw new DomainRuleViolationException("강의 상태는 필수입니다.");
+        }
+
+        if (lectureStatus != LectureStatus.ACTIVE
+                && lectureStatus != LectureStatus.HOLD) {
+            throw new DomainRuleViolationException("관리자는 강의를 승인 또는 거절 상태로만 변경할 수 있습니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureCommandService.java
@@ -1,0 +1,75 @@
+package com.wanted.momocity.lecture.application.service;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.command.AdminChangeLectureStatusCommand;
+import com.wanted.momocity.lecture.application.usecase.AdminLectureCommandUseCase;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
+import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
+import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import com.wanted.momocity.lecture.presentation.api.response.AdminChangeLectureStatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 강의 명령을 처리하는 Application Service 강의 승인/거절 상태 변경을 담당
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminLectureCommandService implements AdminLectureCommandUseCase {
+
+    private final LectureRepository lectureRepository;
+    private final ChapterRepository chapterRepository;
+
+    @Override
+    public AdminChangeLectureStatusResponse changeLectureStatus(AdminChangeLectureStatusCommand command) {
+
+        /* comment
+         * 상태를 변경할 강의를 조회한다.
+         * 존재하지 않으면 강의 없음 예외를 던진다.
+         */
+        LectureAggregate lecture = lectureRepository.findById(command.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+        // 승인(ACTIVE)으로 변경할 때만 강의 공개 조건을 검증
+        if (command.lectureStatus() == LectureStatus.ACTIVE) {
+            validateLectureReadyForApproval(command.lectureId());
+        }
+
+        // 도메인 모델에서 강의 상태를 변경
+        LectureAggregate changedLecture =
+                lecture.changeStatus(command.lectureStatus());
+
+        // 변경된 강의 상태를 저장
+        LectureAggregate savedLecture =
+                lectureRepository.save(changedLecture);
+
+        // 변경 결과를 응답 DTO로 변환
+        return AdminChangeLectureStatusResponse.from(savedLecture);
+    }
+
+    /* comment
+     * 강의를 ACTIVE로 승인하기 전에 공개 가능한 상태인지 검증한다.
+     * 조건:
+     * 1. 챕터가 최소 1개 이상 있어야 한다.
+     * 2. 모든 챕터에 동영상 URL이 있어야 한다.
+     * 3. 모든 챕터의 동영상 상태가 READY여야 한다.
+     */
+    private void validateLectureReadyForApproval(Long lectureId) {
+        int chapterCount = chapterRepository.countByLectureId(lectureId);
+
+        if (chapterCount < 1) {
+            throw new DomainRuleViolationException("강의를 승인하려면 최소 1개 이상의 챕터가 필요합니다.");
+        }
+
+        if (chapterRepository.existsByLectureIdAndVideoUrlIsNull(lectureId)) {
+            throw new DomainRuleViolationException("강의를 승인하려면 모든 챕터에 동영상이 등록되어야 합니다.");
+        }
+
+        if (chapterRepository.existsByLectureIdAndVideoStatusNot(lectureId, VideoStatus.READY)) {
+            throw new DomainRuleViolationException("강의를 승인하려면 모든 동영상이 READY 상태여야 합니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/AdminLectureCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/usecase/AdminLectureCommandUseCase.java
@@ -1,0 +1,11 @@
+package com.wanted.momocity.lecture.application.usecase;
+
+import com.wanted.momocity.lecture.application.command.AdminChangeLectureStatusCommand;
+import com.wanted.momocity.lecture.presentation.api.response.AdminChangeLectureStatusResponse;
+
+// 관리자 강의 명령 기능을 정의하는 UseCase
+public interface AdminLectureCommandUseCase {
+
+    // 관리자가 강의 상태를 변경
+    AdminChangeLectureStatusResponse changeLectureStatus(AdminChangeLectureStatusCommand command);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/ChapterRepository.java
@@ -2,6 +2,7 @@ package com.wanted.momocity.lecture.domain.repository;
 
 
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,4 +30,7 @@ public interface ChapterRepository {
 
     // 특정 강의에 등록된 챕터 목록을 orderNo 오름차순으로 조회
     List<LectureChapter> findAllByLectureIdOrderByOrderNoAsc(Long lectureId);
+
+    // 특정 강의 안에 지정한 영상 상태가 아닌 챕터가 있는지 확인한
+    boolean existsByLectureIdAndVideoStatusNot(Long lectureId, VideoStatus videoStatus);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/ChapterRepositoryAdapter.java
@@ -2,10 +2,12 @@ package com.wanted.momocity.lecture.infrastructure.adapter;
 
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
 import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.infrastructure.persistence.ChapterJpaEntity;
 import com.wanted.momocity.lecture.infrastructure.persistence.SpringDataChapterRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -57,6 +59,19 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
                 .stream()
                 .map(ChapterJpaEntity::toDomain)
                 .toList();
+    }
+
+    // 특정 강의의 챕터 중 지정한 영상 상태가 아닌 챕터가 있는지 확인
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByLectureIdAndVideoStatusNot(
+            Long lectureId,
+            VideoStatus videoStatus
+    ) {
+        return repository.existsByLectureIdAndVideoStatusNot(
+                lectureId,
+                videoStatus
+        );
     }
     
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/LectureStatsAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/adapter/LectureStatsAdapter.java
@@ -1,0 +1,41 @@
+package com.wanted.momocity.lecture.infrastructure.adapter;
+
+import com.wanted.momocity.admin.application.port.LectureStatsPort;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.infrastructure.persistence.SpringDataLectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+// 관리자 대시보드에서 필요한 강의 통계 값을 제공하는 Adapter
+@Component
+@RequiredArgsConstructor
+public class LectureStatsAdapter implements LectureStatsPort {
+
+    private final SpringDataLectureRepository repository;
+
+    /* comment
+     * 현재 활성화된 강의 수를 조회한다.
+     * ACTIVE 상태의 강의만 사용자에게 공개되는 강의로 본다.
+     */
+    @Override
+    public long countActive() {
+        return repository.countByStatus(LectureStatus.ACTIVE);
+    }
+
+    /*
+     * 특정 날짜 이전에 생성된 활성화 강의 수를 조회한다.
+     * 관리자 대시보드에서 전월 대비 증감률 계산에 사용한다.
+     */
+    @Override
+    public long countActiveBefore(LocalDate date) {
+        LocalDateTime dateTime = date.atStartOfDay();
+
+        return repository.countByStatusAndCreatedAtBefore(
+                LectureStatus.ACTIVE,
+                dateTime
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataChapterRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.lecture.infrastructure.persistence;
 
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -18,4 +19,7 @@ public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEnt
 
     // 특정 강의에 속한 챕터 목록을 orderNo 오름차순으로 조회
     List<ChapterJpaEntity> findAllByLectureIdOrderByOrderNoAsc(Long lectureId);
+
+    // 특정 강의의 챕터 중 지정한 영상 상태가 아닌 챕터가 있는지 확인
+    boolean existsByLectureIdAndVideoStatusNot(Long lectureId, VideoStatus videoStatus);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -57,6 +58,21 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
             LectureStatus status,
             Collection<Long> lectureIds,
             Pageable pageable
+    );
+
+    /* comment
+     * 특정 상태의 강의 개수를 조회한다.
+     * 관리자 대시보드에서 현재 진행 중인 강의 수를 계산할 때 사용한다.
+     */
+    long countByStatus(LectureStatus status);
+
+    /* comment
+     * 특정 날짜 이전에 생성된 특정 상태의 강의 개수를 조회한다.
+     * 관리자 대시보드에서 이전 기간 대비 증감률을 계산할 때 사용한다.
+     */
+    long countByStatusAndCreatedAtBefore(
+            LectureStatus status,
+            LocalDateTime createdAt
     );
 
     /* comment

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -4,15 +4,18 @@ import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationExc
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.lecture.application.query.*;
+import com.wanted.momocity.lecture.application.usecase.AdminLectureCommandUseCase;
 import com.wanted.momocity.lecture.application.usecase.AdminLectureQueryUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
+import com.wanted.momocity.lecture.presentation.api.request.AdminChangeLectureStatusRequest;
 import com.wanted.momocity.lecture.presentation.api.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.*;
@@ -33,6 +36,8 @@ public class LectureController {
     private final LectureQueryUseCase lectureQueryUseCase;
     // 관리자 강의 조회 UseCase
     private final AdminLectureQueryUseCase adminLectureQueryUseCase;
+    // 관리자 강의 상태 UseCase
+    private final AdminLectureCommandUseCase adminLectureCommandUseCase;
 
     // 강의 목록 조회 API
     @Operation(
@@ -181,6 +186,58 @@ public class LectureController {
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,
                 "강의 상세 조회에 성공했습니다.",
+                response
+        ));
+    }
+
+    /* comment
+     * 관리자 강의 상태 변경 API
+     * ACTIVE = 승인
+     * HOLD = 거절
+     */
+    @Operation(
+            summary = "관리자 강의 상태 변경",
+            description = """
+                관리자가 강의를 승인 또는 거절합니다.
+                lectureStatus가 ACTIVE이면 승인 처리되고,
+                lectureStatus가 HOLD이면 거절 처리됩니다.
+                
+                ACTIVE 승인 시에는 아래 조건을 검증합니다.
+                - 챕터가 최소 1개 이상 있어야 합니다.
+                - 모든 챕터에 동영상이 등록되어 있어야 합니다.
+                - 모든 챕터의 동영상 상태가 READY여야 합니다.
+                """
+    )
+    @PatchMapping("/{lectureId}/status")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<ApiResponse<AdminChangeLectureStatusResponse>> changeLectureStatus(
+            Authentication authentication,
+
+            // 상태를 변경할 강의 ID
+            @PathVariable Long lectureId,
+
+            // 변경할 상태값(ACTIVE 또는 HOLD)
+            @RequestBody AdminChangeLectureStatusRequest request
+    ) {
+        // Authorization 토큰에서 관리자 ID를 꺼냄
+        Long adminId = Long.parseLong(authentication.getName());
+
+        // Request 값을 Application Service가 사용할 Command로 변환
+        var command = request.toCommand(
+                adminId,
+                lectureId
+        );
+
+        // 관리자 강의 상태 변경 UseCase를 실행
+        AdminChangeLectureStatusResponse response =
+                adminLectureCommandUseCase.changeLectureStatus(command);
+
+        /*
+         * 상태 변경 성공 응답을 반환한다.
+         */
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "강의 상태가 변경되었습니다.",
                 response
         ));
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/AdminChangeLectureStatusRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/AdminChangeLectureStatusRequest.java
@@ -1,0 +1,40 @@
+package com.wanted.momocity.lecture.presentation.api.request;
+
+import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
+import com.wanted.momocity.lecture.application.command.AdminChangeLectureStatusCommand;
+import com.wanted.momocity.lecture.domain.model.LectureStatus;
+
+// 관리자 강의 상태 변경 요청 DTO
+public record AdminChangeLectureStatusRequest(
+        String lectureStatus // ACTIVE 또는 HOLD
+) {
+
+    /*
+     * Controller에서 adminId, lectureId를 함께 받아 Command로 변환
+     * adminId는 Authorization 토큰에서 가져온 사용자 ID
+     * lectureId는 URL PathVariable애서 가져온다.
+     */
+    public AdminChangeLectureStatusCommand toCommand(
+            Long adminId,
+            Long lectureId
+    ) {
+        return new AdminChangeLectureStatusCommand(
+                adminId,
+                lectureId,
+                parseLectureStatus(lectureStatus)
+        );
+    }
+
+    // 문자열로 들어온 lectureStatus를 enum으로 변환
+    private LectureStatus parseLectureStatus(String lectureStatus) {
+        if (lectureStatus == null || lectureStatus.isBlank()) {
+            throw new DomainRuleViolationException("강의 상태는 필수입니다.");
+        }
+
+        try {
+            return LectureStatus.valueOf(lectureStatus.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new DomainRuleViolationException("허용되지 않은 강의 상태입니다.");
+        }
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminChangeLectureStatusResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminChangeLectureStatusResponse.java
@@ -1,0 +1,22 @@
+package com.wanted.momocity.lecture.presentation.api.response;
+
+import com.wanted.momocity.lecture.domain.model.LectureAggregate;
+
+import java.time.LocalDateTime;
+
+// 관리자 강의 상태 변경 성공 응답 DTO
+public record AdminChangeLectureStatusResponse(
+        Long lectureId,             // 상태가 변경된 강의 ID
+        String lectureStatus,       // 변경된 강의 상태
+        LocalDateTime updatedAt     // 상태 변경 시각
+) {
+
+    // 도메인 모델에서 필요한 값만 응답 DTO로 변환
+    public static AdminChangeLectureStatusResponse from(LectureAggregate lecture) {
+        return new AdminChangeLectureStatusResponse(
+                lecture.getId(),
+                lecture.getStatus().name(),
+                lecture.getUpdatedAt()
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
@@ -9,6 +9,7 @@ import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
 import com.wanted.momocity.user.application.policy.UserPolicy;
 import com.wanted.momocity.user.application.port.UserEmailSendPort;
 import com.wanted.momocity.user.application.usecase.UserCommandUsecase;
+import com.wanted.momocity.user.domain.exception.InvalidReasonException;
 import com.wanted.momocity.user.domain.model.Role;
 import com.wanted.momocity.user.domain.model.Status;
 import com.wanted.momocity.user.domain.repository.UserRepository;


### PR DESCRIPTION
## 작업 내용

- 관리자가 신청된 강의를 승인/거절할 수 있도록 강의 상태 변경 기능을 구현했습니다.
- 관리자 승인 시 강의 상태를 `WAITING -> ACTIVE`로 변경합니다.
- 관리자 거절 시 강의 상태를 `WAITING -> HOLD`로 변경합니다.
- 상태 변경 요청/응답 DTO를 추가했습니다.
- 관리자 상태 변경 UseCase와 Service를 추가했습니다.
- 승인 처리 시 강의 공개 조건을 검증하도록 구현했습니다.
  - 챕터가 최소 1개 이상 존재해야 합니다.
  - 모든 챕터에 동영상이 등록되어 있어야 합니다.
  - 모든 챕터의 동영상 상태가 `READY`여야 합니다.
- 챕터 영상 상태 검증을 위해 `ChapterRepository` 계층에 조회 메서드를 추가했습니다.
- `LectureController`에 관리자 강의 상태 변경 API를 추가했습니다.
- Swagger 문서를 추가했습니다.

## API 명세

- Method: `PATCH`
- Path: `/api/v1/lectures/{lectureId}/status`
- 인증 필요 여부: Yes
- 권한: `ROLE_ADMIN`

### Request

```json
{
  "lectureStatus": "ACTIVE"
}
```

## 처리 흐름
LectureController
 -> AdminChangeLectureStatusRequest
 -> AdminChangeLectureStatusCommand
 -> AdminLectureCommandUseCase
 -> AdminLectureCommandService
 -> LectureRepository
 -> ChapterRepository
 -> LectureAggregate.changeStatus()
 -> LectureRepository.save()
 -> AdminChangeLectureStatusResponse