### PR TITLE
[PR] 강의 조회 응답에 평점 및 리뷰 수 필드 추가, ENCODRING인 동영상의 강의가 조회 시 공개되는 문제 해결

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureQueryService.java
@@ -96,9 +96,12 @@ public class AdminLectureQueryService implements AdminLectureQueryUseCase {
         List<LectureChapter> chapters =
                 chapterRepository.findAllByLectureIdOrderByOrderNoAsc(query.lectureId());
 
-        /*
-         * 강의 정보와 챕터 목록을 관리자 상세 응답 DTO로 변환한다.
-         */
-        return AdminLectureDetailResponse.from(lecture, chapters);
+        // 강의 정보와 챕터 목록을 관리자 상세 응답 DTO로 변환
+        return AdminLectureDetailResponse.from(
+                lecture,
+                chapters,
+                0.0,
+                0
+        );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -181,7 +181,11 @@ public class LectureQueryService implements LectureQueryUseCase {
 
         // 도메인 모델을 강사용 목록 응답 DTO로 변환
         List<TeacherLectureListItemResponse> content = lecturePage.content().stream()
-                .map(TeacherLectureListItemResponse::from)
+                .map(lecture -> TeacherLectureListItemResponse.from(
+                        lecture,
+                        0.0,
+                        0
+                ))
                 .toList();
 
         // 페이지 정보와 목록 응답을 함께 반환
@@ -215,7 +219,12 @@ public class LectureQueryService implements LectureQueryUseCase {
                 chapterRepository.findAllByLectureIdOrderByOrderNoAsc(query.lectureId());
 
         // 강의 정보와 챕터 목록을 응답 DTO로 변환
-        return TeacherLectureDetailResponse.from(lecture, chapters);
+        return TeacherLectureDetailResponse.from(
+                lecture,
+                chapters,
+                0.0,
+                0
+        );
     }
 
     // Lecture 도메인 객체를 학생 강의 목록 응답 DTO로 변환

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/AdminLectureDetailResponse.java
@@ -16,6 +16,8 @@ public record AdminLectureDetailResponse(
         String category,
         String lectureStatus,
         int completedUserCount,
+        double averageRating,
+        int reviewCount,
         List<AdminLectureChapterResponse> chapters,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
@@ -24,7 +26,9 @@ public record AdminLectureDetailResponse(
     // 강의 도메인 모델과 챕터 목록을 관리자 상세 응답 DTO로 변환한다.
     public static AdminLectureDetailResponse from(
             LectureAggregate lecture,
-            List<LectureChapter> chapters
+            List<LectureChapter> chapters,
+            double averageRating,
+            int reviewCount
     ) {
         return new AdminLectureDetailResponse(
                 lecture.getId(),
@@ -35,6 +39,8 @@ public record AdminLectureDetailResponse(
                 lecture.getCategory().name(),
                 lecture.getStatus().name(),
                 lecture.getCompletedUserCount(),
+                averageRating,
+                reviewCount,
                 chapters.stream()
                         .map(AdminLectureChapterResponse::from)
                         .toList(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureDetailResponse.java
@@ -2,6 +2,7 @@ package com.wanted.momocity.lecture.presentation.api.response;
 
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
+import com.wanted.momocity.lecture.domain.model.VideoStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -84,6 +85,7 @@ public record StudentLectureDetailResponse(
                 reviewCount,
                 isEnrolled,
                 chapters.stream()
+                        .filter(chapter -> chapter.getVideoStatus() == VideoStatus.READY)
                         .map(StudentLectureChapterResponse::from)
                         .toList(),
                 lecture.getCreatedAt(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureDetailResponse.java
@@ -33,6 +33,12 @@ public record TeacherLectureDetailResponse(
         // 수강 완료 사용자 수
         int completedUserCount,
 
+        // 강의 평점 평균
+        double averageRating,
+
+        // 리뷰 개수
+        int reviewCount,
+
         // 강의에 포함된 챕터 목
         List<TeacherLectureChapterResponse> chapters,
 
@@ -47,7 +53,9 @@ public record TeacherLectureDetailResponse(
     // LectureAggregate와 챕터 목록을 강의 상세 응답 DTO로 변환
     public static TeacherLectureDetailResponse from(
             LectureAggregate lecture,
-            List<LectureChapter> chapters
+            List<LectureChapter> chapters,
+            double averageRating,
+            int reviewCount
     ) {
         return new TeacherLectureDetailResponse(
                 lecture.getId(),
@@ -58,7 +66,8 @@ public record TeacherLectureDetailResponse(
                 lecture.getCategory().name(),
                 lecture.getStatus().name(),
                 lecture.getCompletedUserCount(),
-                chapters.stream()
+                averageRating,
+                reviewCount,                chapters.stream()
                         .map(TeacherLectureChapterResponse::from)
                         .toList(),
                 lecture.getCreatedAt(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureListItemResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/TeacherLectureListItemResponse.java
@@ -20,12 +20,18 @@ public record TeacherLectureListItemResponse(
         String category,
         String lectureStatus,
         int completedUserCount,
+        double averageRating,
+        int reviewCount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
 
     // 도메인 모델 LectureAggregate를 강사용 목록 응답 DTO
-    public static TeacherLectureListItemResponse from(LectureAggregate lecture) {
+    public static TeacherLectureListItemResponse from(
+            LectureAggregate lecture,
+            double averageRating,
+            int reviewCount
+    ) {
         return new TeacherLectureListItemResponse(
                 lecture.getId(),
                 lecture.getTeacherId(),
@@ -35,6 +41,8 @@ public record TeacherLectureListItemResponse(
                 lecture.getCategory().name(),
                 lecture.getStatus().name(),
                 lecture.getCompletedUserCount(),
+                averageRating,
+                reviewCount,
                 lecture.getCreatedAt(),
                 lecture.getUpdatedAt()
         );


### PR DESCRIPTION
close #231 , close #233 

## 작업 내용

- 강의 조회 응답에 `averageRating`, `reviewCount` 필드를 추가했습니다.
- 관리자 강의 상세 조회 응답에 평점/리뷰 수 필드를 추가했습니다.
- 강사 강의 목록 조회 응답에 평점/리뷰 수 필드를 추가했습니다.
- 강사 강의 상세 조회 응답에 평점/리뷰 수 필드를 추가했습니다.
- 응답 DTO 변환 로직에서 기본값을 전달하도록 수정했습니다.

- ENCORDING 상태인 동영상의 강의가 공개 되었었는데 무조건 READY 상태인 강의만 공개되도록 변경

## 변경 대상

- `AdminLectureDetailResponse`
- `TeacherLectureListItemResponse`
- `TeacherLectureDetailResponse`
- `AdminLectureQueryService`
- `LectureQueryService`

-  'StudentLectureDetailResponse'

## 응답 예시

```json
{
  "lectureId": 10,
  "teacherId": 3,
  "title": "Spring Boot 입문",
  "description": "Spring Boot 기초부터 REST API 개발까지 배우는 강의입니다.",
  "thumbnailUrl": "https://example.com/images/spring-boot.png",
  "category": "STUDY",
  "lectureStatus": "ACTIVE",
  "completedUserCount": 12,
  "averageRating": 0.0,
  "reviewCount": 0,
  "createdAt": "2026-05-19T10:30:00",
  "updatedAt": "2026-05-19T10:30:00"
}