### PR TITLE
[PR] 수강 진척도 Port 연동 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/port/ProgressPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/port/ProgressPort.java
@@ -1,0 +1,8 @@
+package com.wanted.momocity.enrollment.application.port;
+
+// Enrollment가 Viewing의 진척도 정보를 조회하기 위해 사용하는 Port.
+public interface ProgressPort {
+
+    // 특정 사용자가 특정 강의를 얼마나 시청했는지 전체 진척도를 조회
+    int getTotalProgress(Long userId, Long lectureId);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/adapter/ProgressAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/adapter/ProgressAdapter.java
@@ -1,7 +1,7 @@
 package com.wanted.momocity.viewing.infrastructure.adapter;
 
+import com.wanted.momocity.enrollment.application.port.ProgressPort;
 import com.wanted.momocity.viewing.application.port.ChapterPort;
-//import com.wanted.momocity.application.application.port.ProgressPort;
 import com.wanted.momocity.viewing.domain.model.Chapter;
 import com.wanted.momocity.viewing.domain.model.LearningHistory;
 import com.wanted.momocity.viewing.domain.repository.LearningHistoryRepository;
@@ -24,48 +24,48 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class ProgressAdapter
-//        implements ProgressPort
+        implements ProgressPort
 {
 
     private final ChapterPort chapterPort;
     private final LearningHistoryRepository learningHistoryRepository;
 
-//    @Override
-//    public int getTotalProgress(Long userId, Long lectureId) {
-//        List<Chapter> chapters = chapterPort.findAllByLectureId(lectureId);
-//        List<LearningHistory> histories = learningHistoryRepository
-//                .findByUserIdAndLectureId(userId, lectureId);
-//
-//        // 완료 챕터 durationSec 합산
-//        int completedDurationSum = chapters.stream()
-//                .filter(chapter -> histories.stream()
-//                        .anyMatch(h -> h.getChapterId().equals(chapter.getId())
-//                        && h.isCompleted()))
-//                .mapToInt(Chapter::getDurationSec)
-//                .sum();
-//
-//        // 미완료 챕터watchedSeconds 합산
-//        int inProgressWatchedSum = histories.stream()
-//                .filter(h -> !h.isCompleted())
-//                .mapToInt(LearningHistory::getWatchedSeconds)
-//                .sum();
-//
-//        // 전체 durationSec 합산
-//        int totalDurationSum = chapters.stream()
-//                .mapToInt(Chapter::getDurationSec)
-//                .sum();
-//
-//        if (totalDurationSum == 0) return 0;
-//
-//        int result = (int) Math.round(
-//                (double)(completedDurationSum + inProgressWatchedSum)
-//                / totalDurationSum * 100
-//        );
-//
-//        log.debug("[Progress] 진척률 조회 | userId={}, lectureId={}, result={}",
-//                userId, lectureId, result);
-//
-//        return result;
-//
-//    }
+    @Override
+    public int getTotalProgress(Long userId, Long lectureId) {
+        List<Chapter> chapters = chapterPort.findAllByLectureId(lectureId);
+        List<LearningHistory> histories = learningHistoryRepository
+                .findByUserIdAndLectureId(userId, lectureId);
+
+        // 완료 챕터 durationSec 합산
+        int completedDurationSum = chapters.stream()
+                .filter(chapter -> histories.stream()
+                        .anyMatch(h -> h.getChapterId().equals(chapter.getId())
+                        && h.isCompleted()))
+                .mapToInt(Chapter::getDurationSec)
+                .sum();
+
+        // 미완료 챕터watchedSeconds 합산
+        int inProgressWatchedSum = histories.stream()
+                .filter(h -> !h.isCompleted())
+                .mapToInt(LearningHistory::getWatchedSeconds)
+                .sum();
+
+        // 전체 durationSec 합산
+        int totalDurationSum = chapters.stream()
+                .mapToInt(Chapter::getDurationSec)
+                .sum();
+
+        if (totalDurationSum == 0) return 0;
+
+        int result = (int) Math.round(
+                (double)(completedDurationSum + inProgressWatchedSum)
+                / totalDurationSum * 100
+        );
+
+        log.debug("[Progress] 진척률 조회 | userId={}, lectureId={}, result={}",
+                userId, lectureId, result);
+
+        return result;
+
+    }
 }


### PR DESCRIPTION
close #234 

## 작업 내용

-  ProgressPort를 추가했습니다.
-  ProgressAdapter가 ProgressPort를 구현하도록 연결했습니다.
- LearningHistory 데이터를 기반으로 강의 전체 진척도를 계산할 수 있도록 구성했습니다.
- 기존 ProgressAdapter에 있던 주석은 다 해제했습니다.

## 구조 흐름

enrollment
→ ProgressPort 호출
→ viewing ProgressAdapter 구현체 실행
→ LearningHistory / Chapter 정보 기준 진척도 계산
→ enrollment로 totalProgress 반환