### PR TITLE
[PR] 핵심 비즈니스 흐름 로그 추가 및 테스트 패키지명 및 코드 수정

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentCommandService.java
@@ -11,6 +11,7 @@ import com.wanted.momocity.enrollment.domain.model.Enrollment;
 import com.wanted.momocity.enrollment.domain.repository.EnrollmentRepository;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class EnrollmentCommandService implements EnrollmentCommandUseCase {
 
     // 수강신청 저장소
@@ -71,6 +73,13 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
                 savedEnrollment.getUserId(),
                 savedEnrollment.getLectureId()
         ));
+
+        // 수강신청 완료와 이벤트 발행 여부를 추적하기 위한 로그
+        // 수강신청 후 강사 자동 친구 추가 이벤트가 이어지므로 enrollmentId, userId, lectureId를 남긴다.
+        log.info("수강신청 완료 - enrollmentId={}, userId={}, lectureId={}",
+                savedEnrollment.getId(),
+                savedEnrollment.getUserId(),
+                savedEnrollment.getLectureId());
 
         // 저장된 수강신청 도메인 객체를 반환
         return savedEnrollment;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/AdminLectureCommandService.java
@@ -11,6 +11,7 @@ import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
 import com.wanted.momocity.lecture.presentation.api.response.AdminChangeLectureStatusResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class AdminLectureCommandService implements AdminLectureCommandUseCase {
 
     private final LectureRepository lectureRepository;
@@ -45,6 +47,13 @@ public class AdminLectureCommandService implements AdminLectureCommandUseCase {
         // 변경된 강의 상태를 저장
         LectureAggregate savedLecture =
                 lectureRepository.save(changedLecture);
+
+        // 관리자 승인/거절 결과를 추적하기 위한 로그
+        // ACTIVE는 승인, HOLD는 거절 상태로 사용되므로 adminId와 변경된 상태를 남긴다.
+        log.info("관리자 강의 상태 변경 완료 - adminId={}, lectureId={}, lectureStatus={}",
+                command.adminId(),
+                savedLecture.getId(),
+                savedLecture.getStatus());
 
         // 변경 결과를 응답 DTO로 변환
         return AdminChangeLectureStatusResponse.from(savedLecture);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/ChapterCommandService.java
@@ -12,6 +12,7 @@ import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
 import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 // ChapterCommandService는 챕터 등록 유스케이스를 처리하는 Service
 @Service
 @Transactional
+@Slf4j
 public class ChapterCommandService implements ChapterCommandUseCase {
 
     // 한 강의에 등록 가능한 최대 챕터 개수
@@ -85,7 +87,16 @@ public class ChapterCommandService implements ChapterCommandUseCase {
         );
 
         // 생성된 챕터를 저장합니다.
-        return chapterRepository.save(chapter);
+        LectureChapter savedChapter = chapterRepository.save(chapter);
+
+        // 챕터 등록 성공 여부를 추적하기 위한 로그
+        // 강의 승인 조건에 챕터 존재 여부가 포함되므로 lectureId와 orderNo를 함께 남긴다.
+        log.info("챕터 등록 완료 - chapterId={}, lectureId={}, orderNo={}",
+                savedChapter.getId(),
+                savedChapter.getLectureId(),
+                savedChapter.getOrderNo());
+
+        return savedChapter;
     }
 
     @Override
@@ -138,7 +149,17 @@ public class ChapterCommandService implements ChapterCommandUseCase {
         );
 
         // 변경된 챕터 정보를 저장
-        return chapterRepository.save(updatedChapter);
+        LectureChapter savedChapter = chapterRepository.save(updatedChapter);
+
+        // S3 업로드 후 챕터에 동영상 정보가 정상 연결되었는지 추적하기 위한 로그
+        // 파일 원본명이나 URL 전체는 민감하거나 길 수 있으므로 상태와 크기 중심으로 남긴다.
+        log.info("챕터 동영상 등록 완료 - chapterId={}, lectureId={}, videoStatus={}, videoSizeBytes={}",
+                savedChapter.getId(),
+                savedChapter.getLectureId(),
+                savedChapter.getVideoStatus(),
+                savedChapter.getVideoSizeBytes());
+
+        return savedChapter;
     }
 
 
@@ -174,7 +195,16 @@ public class ChapterCommandService implements ChapterCommandUseCase {
         LectureChapter changedChapter = chapter.changeVideoStatus(command.videoStatus());
 
         // 변경된 챕터를 저장
-        return chapterRepository.save(changedChapter);
+        LectureChapter savedChapter = chapterRepository.save(changedChapter);
+
+        // 동영상 상태 변경 결과를 추적하기 위한 로그
+        // READY 전환 여부가 학생 화면 노출과 연결되므로 videoStatus를 남긴다.
+        log.info("챕터 동영상 상태 변경 완료 - chapterId={}, lectureId={}, videoStatus={}",
+                savedChapter.getId(),
+                savedChapter.getLectureId(),
+                savedChapter.getVideoStatus());
+
+        return savedChapter;
     }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
@@ -11,6 +11,7 @@ import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
 import com.wanted.momocity.lecture.domain.repository.ChapterRepository;
 import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import java.time.Instant;
 // LectureCommandService는 강의 등록 유스케이스의 실제 흐름을 담당
 @Service
 @Transactional
+@Slf4j
 public class LectureCommandService implements LectureCommandUseCase {
 
     private final LectureRepository lectureRepository;
@@ -64,6 +66,13 @@ public class LectureCommandService implements LectureCommandUseCase {
                 savedLecture.getTitle(),
                 Instant.now()
         ));
+
+        // 강의 등록이 정상 완료되었는지 추적하기 위한 로그
+        // S3 업로드 후 DB 저장까지 성공한 시점이므로 lectureId, teacherId, status만 남긴다.
+        log.info("강의 등록 완료 - lectureId={}, teacherId={}, status={}",
+                savedLecture.getId(),
+                savedLecture.getTeacherId(),
+                savedLecture.getStatus());
 
         return savedLecture;
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -284,7 +284,19 @@ public class TeacherLectureController {
                 response
         ));
     }
+    @Operation(
+            summary = "챕터 동영상 상태 변경",
+            description = """
+                강사가 본인이 등록한 강의의 챕터 동영상 상태를 변경합니다.
+                동영상 업로드 또는 인코딩 처리 이후 READY 상태로 변경할 때 사용합니다.
 
+                변경 가능한 상태값:
+                - UPLOADING: 업로드 중
+                - ENCODING: 인코딩 중
+                - READY: 재생 가능
+                - FAILED: 처리 실패
+                """
+    )
     @PatchMapping("/{lectureId}/chapters/{chapterId}/video/status")
     @PreAuthorize("hasAuthority('ROLE_TEACHER')")
     public ResponseEntity<ApiResponse<RegisterChapterVideoResponse>> changeChapterVideoStatus(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/RegisterChapterVideoRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/RegisterChapterVideoRequest.java
@@ -1,7 +1,6 @@
 package com.wanted.momocity.lecture.presentation.api.request;
 
 import com.wanted.momocity.lecture.application.command.RegisterChapterVideoCommand;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,12 +9,10 @@ import org.springframework.web.multipart.MultipartFile;
 public record RegisterChapterVideoRequest(
 
         // 업로드할 동영상 파일
-        @Schema(description = "업로드할 동영상 파일", type = "string", format = "binary")
         @NotNull(message = "동영상 파일은 필수입니다.")
         MultipartFile video,
 
         // 동영상 재생 시간
-        @Schema(description = "동영상 재생 시간(초)", example = "600")
         @NotNull(message = "동영상 재생 시간은 필수입니다.")
         @Min(value = 1, message = "동영상 재생 시간은 1초 이상이어야 합니다.")
         Integer durationSec

--- a/legend-momo-city/src/test/java/com/wanted/momocity/lecture/TeacherLectureAggregateRegisterTest.java
+++ b/legend-momo-city/src/test/java/com/wanted/momocity/lecture/TeacherLectureAggregateRegisterTest.java
@@ -1,4 +1,4 @@
-﻿package com.wanted.momocity.mosungjin;
+﻿package com.wanted.momocity.lecture;
 
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;

--- a/legend-momo-city/src/test/java/com/wanted/momocity/lecture/TeacherLectureAggregateRegisterTest.java
+++ b/legend-momo-city/src/test/java/com/wanted/momocity/lecture/TeacherLectureAggregateRegisterTest.java
@@ -3,6 +3,7 @@
 import com.wanted.momocity.global.application.s3.S3UploadPort;
 import com.wanted.momocity.lecture.application.usecase.ChapterCommandUseCase;
 import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
+import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureCategory;
 import com.wanted.momocity.lecture.domain.model.LectureStatus;
@@ -30,10 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /*
- * TeacherLectureAggregateRegisterTest는 강사의 강의 등록 API를 검증하는 Controller 테스트입니다.
- *
- * 실제 JWT 검증, 실제 S3 업로드, 실제 DB 저장은 수행하지 않고,
- * multipart/form-data 요청이 Controller에서 정상 처리되는지 확인합니다.
+ * 강사 강의 등록 API Controller 테스트.
+ * 실제 S3, DB, JWT 검증은 사용하지 않고 Controller 요청/응답 흐름만 검증한다.
  */
 @WebMvcTest(TeacherLectureController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -41,45 +40,36 @@ class TeacherLectureAggregateRegisterTest {
 
     private static final String CREATE_LECTURE_URL = "/api/v1/teacher/lectures";
 
-    /*
-     * MockMvc는 실제 서버를 띄우지 않고 HTTP 요청처럼 Controller를 테스트하게 해줍니다.
-     */
     @Autowired
     private MockMvc mockMvc;
 
-    /*
-     * Controller가 의존하는 강의 UseCase를 Mock으로 대체합니다.
-     */
+    // 강의 등록 UseCase를 Mock으로 대체한다.
     @MockitoBean
     private LectureCommandUseCase lectureCommandUseCase;
 
-    /*
-     * TeacherLectureController 생성자 의존성 때문에 챕터 UseCase도 Mock으로 등록합니다.
-     */
+    // TeacherLectureController 생성자 의존성 때문에 필요하다.
     @MockitoBean
     private ChapterCommandUseCase chapterCommandUseCase;
 
-    /*
-     * 실제 S3 업로드 대신 Mock으로 URL을 반환하게 합니다.
-     */
+    // TeacherLectureController 생성자 의존성 때문에 필요하다.
+    @MockitoBean
+    private LectureQueryUseCase lectureQueryUseCase;
+
+    // 실제 S3 업로드 대신 URL만 반환하도록 Mock 처리한다.
     @MockitoBean
     private S3UploadPort s3UploadPort;
 
     @Test
-    @DisplayName("강사가 form-data로 강의를 등록하면 201 응답을 반환한다")
-    void createLecture() throws Exception {
+    @DisplayName("강사가 form-data로 강의를 등록하면 201 Created를 반환한다")
+    void createLectureSuccess() throws Exception {
         LocalDateTime now = LocalDateTime.of(2026, 5, 19, 10, 30);
         String thumbnailUrl = "https://example.com/images/spring-boot.png";
 
-        /*
-         * S3 업로드가 성공하면 thumbnailUrl을 반환한다고 가정합니다.
-         */
+        // S3 업로드 성공 시 썸네일 URL이 반환된다고 가정한다.
         when(s3UploadPort.upload(any()))
                 .thenReturn(thumbnailUrl);
 
-        /*
-         * UseCase가 반환할 가짜 Lecture 객체를 준비합니다.
-         */
+        // 강의 등록 UseCase가 반환할 도메인 객체를 준비한다.
         LectureAggregate lecture = LectureAggregate.restore(
                 10L,
                 3L,
@@ -96,9 +86,7 @@ class TeacherLectureAggregateRegisterTest {
         when(lectureCommandUseCase.createLecture(any()))
                 .thenReturn(lecture);
 
-        /*
-         * form-data의 thumbnail 파일 파트입니다.
-         */
+        // multipart/form-data의 thumbnail 파일 파트.
         MockMultipartFile thumbnail = new MockMultipartFile(
                 "thumbnail",
                 "spring-boot.png",
@@ -126,11 +114,14 @@ class TeacherLectureAggregateRegisterTest {
                 .andExpect(jsonPath("$.data.completedUserCount").value(0))
                 .andExpect(jsonPath("$.data.createdAt").exists())
                 .andExpect(jsonPath("$.data.updatedAt").exists());
+
+        verify(s3UploadPort).upload(any());
+        verify(lectureCommandUseCase).createLecture(any());
     }
 
     @Test
-    @DisplayName("강의 등록 시 필수값이 누락되면 400 응답을 반환한다")
-    void createLectureFailByInvalidRequest() throws Exception {
+    @DisplayName("강의 등록 시 제목이 비어 있으면 400 Bad Request를 반환한다")
+    void createLectureFailByBlankTitle() throws Exception {
         MockMultipartFile thumbnail = new MockMultipartFile(
                 "thumbnail",
                 "spring-boot.png",
@@ -144,14 +135,15 @@ class TeacherLectureAggregateRegisterTest {
                         .param("description", "Spring Boot 기초부터 REST API 개발까지 배우는 강의입니다.")
                         .param("category", "STUDY")
                         .principal(teacherAuthentication()))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.code").value("COMMON-VALIDATION-ERROR"))
-                .andExpect(jsonPath("$.message").exists());
+                .andExpect(status().isBadRequest());
+
+        // 입력값 검증에서 막혀야 하므로 S3 업로드와 UseCase 호출은 발생하면 안 된다.
+        verify(s3UploadPort, never()).upload(any());
+        verify(lectureCommandUseCase, never()).createLecture(any());
     }
 
     @Test
-    @DisplayName("강의 등록 시 허용되지 않은 카테고리면 400 응답을 반환하고 S3 업로드를 하지 않는다")
+    @DisplayName("강의 등록 시 허용되지 않은 카테고리면 400 Bad Request를 반환하고 S3 업로드를 하지 않는다")
     void createLectureFailByInvalidCategory() throws Exception {
         MockMultipartFile thumbnail = new MockMultipartFile(
                 "thumbnail",
@@ -171,14 +163,13 @@ class TeacherLectureAggregateRegisterTest {
                 .andExpect(jsonPath("$.code").value("COMMON-DOMAIN-RULE-VIOLATION"))
                 .andExpect(jsonPath("$.message").exists());
 
-        /*
-         * category 검증이 S3 업로드보다 먼저 실행되어야 합니다.
-         */
+        // category 검증은 S3 업로드보다 먼저 수행되어야 한다.
         verify(s3UploadPort, never()).upload(any());
+        verify(lectureCommandUseCase, never()).createLecture(any());
     }
 
     @Test
-    @DisplayName("강의 등록 시 썸네일 파일이 없으면 400 응답을 반환한다")
+    @DisplayName("강의 등록 시 썸네일 파일이 없으면 400 Bad Request를 반환한다")
     void createLectureFailWithoutThumbnail() throws Exception {
         mockMvc.perform(multipart(CREATE_LECTURE_URL)
                         .param("title", "Spring Boot 입문")
@@ -186,15 +177,19 @@ class TeacherLectureAggregateRegisterTest {
                         .param("category", "STUDY")
                         .principal(teacherAuthentication()))
                 .andExpect(status().isBadRequest());
+
+        // 썸네일이 없으면 S3 업로드와 UseCase 호출이 발생하면 안 된다.
+        verify(s3UploadPort, never()).upload(any());
+        verify(lectureCommandUseCase, never()).createLecture(any());
     }
 
     /*
-     * 강사 권한을 가진 인증 객체를 만듭니다.
-     * principal 값인 teacher@example.com은 실제 JWT subject에 해당하는 email 역할입니다.
+     * 현재 Controller는 authentication.getName()을 Long으로 변환한다.
+     * 따라서 테스트 principal도 email이 아니라 userId 문자열로 둔다.
      */
     private UsernamePasswordAuthenticationToken teacherAuthentication() {
         return new UsernamePasswordAuthenticationToken(
-                "teacher@example.com",
+                "3",
                 null,
                 List.of(new SimpleGrantedAuthority("ROLE_TEACHER"))
         );


### PR DESCRIPTION
close #240 

## 작업 내용

- 강의 등록 성공 로그를 추가했습니다.
- 챕터 등록 성공 로그를 추가했습니다.
- 챕터 동영상 등록 성공 로그를 추가했습니다.
- 챕터 동영상 상태 변경 성공 로그를 추가했습니다.
- 관리자 강의 승인/거절 상태 변경 성공 로그를 추가했습니다.
- 수강신청 완료 및 이벤트 발행 이후 로그를 추가했습니다.

- 테스트 패키지 mosungjin -> lecture 로 수정
- 테스트 코드 수정

## 로그 추가 기준

- 운영 중 추적이 필요한 핵심 비즈니스 이벤트에만 로그를 추가했습니다.
- 단순 조회 API, Controller, Repository Adapter에는 로그를 추가하지 않았습니다.
- 로그에는 ID와 상태값 중심으로만 남기고 민감 정보는 제외했습니다.

## 주요 로그 지점

- 강의 등록 완료
- 챕터 등록 완료
- 챕터 동영상 등록 완료
- 챕터 동영상 상태 변경 완료
- 관리자 강의 상태 변경 완료
- 수강신청 완료