### PR TITLE
viewing 도메인 진척률 계산 오류 수정

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/RedisConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/RedisConfig.java
@@ -54,23 +54,7 @@ public class RedisConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        // 날짜/시간 모듈 등록
-        // LocalDateTime 등을 처리하기 위해 필요
-        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
-
-        BasicPolymorphicTypeValidator typeValidator =
-                BasicPolymorphicTypeValidator.builder()
-                        .allowIfBaseType(Object.class).build();
-
-        objectMapper.activateDefaultTyping(
-                typeValidator,
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                JsonTypeInfo.As.PROPERTY
-        );
-
+        
         /*
         * comment.
         *  serializer : Java 객체 ↔ JSON 변환 담당

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/RedisConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/RedisConfig.java
@@ -54,7 +54,7 @@ public class RedisConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        
+
         /*
         * comment.
         *  serializer : Java 객체 ↔ JSON 변환 담당

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingCommandService.java
@@ -165,9 +165,19 @@ public class ViewingCommandService implements ViewingCommandUseCase {
                 .sum();
 
         // 미완료 챕터 watchedSeconds 합산
+        // watchedSeconds 가 durationSec 초과 방지
         int inProgressWatchedSum = histories.stream()
                 .filter(h -> !h.isCompleted())
-                .mapToInt(LearningHistory::getWatchedSeconds)
+                .mapToInt(h ->{
+                    // 해당 챕터의 durationSec 찾기
+                    int durationSec = chapters.stream()
+                            .filter(c -> c.getId().equals(h.getChapterId()))
+                            .findFirst()
+                            .map(Chapter::getDurationSec)
+                            .orElse(0);
+                    // watchedSeconds 가 durationSec 초과 방지
+                    return Math.min(h.getWatchedSeconds(), durationSec);
+                })
                 .sum();
 
         // 전체 durationSec 합산

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingQueryService.java
@@ -200,7 +200,7 @@ public class ViewingQueryService implements ViewingQueryUseCase {
 
                     return new ChapterProgressResponse.ChapterProgressItem(
                             chapter.getId(), chapter.getTitle(), chapter.getOrderNo(),
-                            history.getWatchedSeconds(), chapter.getDurationSec(),
+                            Math.min(history.getWatchedSeconds(), chapter.getDurationSec()), chapter.getDurationSec(),
                             history.getProgressRate(), history.isCompleted()
                     );
                 })
@@ -266,7 +266,16 @@ public class ViewingQueryService implements ViewingQueryUseCase {
         // 미완료 챕터 watchedSeconds 합산
         int inProgressWatchedSum = histories.stream()
                 .filter(h -> !h.isCompleted())
-                .mapToInt(LearningHistory::getWatchedSeconds)
+                .mapToInt(h -> {
+                    // 해당 챕터의 durationSec 찾기
+                    int durationSec = chapters.stream()
+                            .filter(c -> c.getId().equals(h.getChapterId()))
+                            .findFirst()
+                            .map(Chapter::getDurationSec)
+                            .orElse(0);
+                    // watchedSeconds 가 durationSec 초과 방지
+                    return Math.min(h.getWatchedSeconds(), durationSec);
+                })
                 .sum();
 
         // 전체 durationSec 합산

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
@@ -79,17 +79,32 @@ public class LearningHistory {
 
     // 챕터 완료처리
     public void complete (int playbackSeconds, int durationSec) {
-        if(!this.isCompleted && playbackSeconds >= durationSec * 0.9) {
+        if(!this.isCompleted && watchedSeconds >= durationSec * 0.9) {
             this.isCompleted = true;
             this.progressRate = 100;
             this.watchedSeconds = durationSec;
         }
     }
 
-    // 나가기 버튼 클릭 시 이어보기 지점 저장
-    // 조건 없이 현재 위치로 덮어씀
+    /*
+     * comment.
+     *  나가기 버튼 클릭 시 이어보기 지점 저장
+     *  -
+     *  progressRate >= 90 (거의 다 본 경우):
+     *  -> lastPositionSec 저장
+     *  -> 정상적으로 시청한 것으로 판단
+     *  -
+     *  progressRate < 90:
+     *  -> watchedSeconds 저장
+     *  -> 앞으로 당겨서 나간 것으로 판단
+     *  -> 실제로 본 위치부터 이어보기
+     */
     public void saveLastPosition(int lastPositionSec) {
-        this.lastPositionSec = lastPositionSec;
+        if (this.progressRate >= 90) {
+            this.lastPositionSec = lastPositionSec;
+        } else {
+            this.lastPositionSec = this.watchedSeconds;
+        }
     }
 
     // DB 에서 조회한 데이터로 도메인 객체 복원용

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
@@ -9,7 +9,8 @@ public class LearningHistory {
     private Long userId;
     private Long lectureId;
     private Long chapterId;
-    // 최대 누적 시청 시간 (감소 안 함)
+    // 실제로 본 최대 위치 저장
+    // 뒤로 감기해도 감소안됨, 앞으로 당기기 반영 안함 (10초 초과시 무시)
     private int watchedSeconds;
     private boolean isCompleted;
     // 마지막 재생 위치 (이어보기용)
@@ -35,20 +36,46 @@ public class LearningHistory {
     }
 
     // 진척도 업데이트
+    /*
+    * comment.
+    *  1. playbackSeconds > watchedSeconds → 앞으로 진행
+    *    AND playbackSeconds - watchedSeconds <= 10 -> 정상 시청 범위
+    *    -> watchedSeconds = playbackSeconds
+    *  -
+    *  2. playbackSeconds < watchedSeconds -> 뒤로 감기
+    *    -> watchedSeconds 업데이트 안 함
+    *  -
+    *  3. playbackSeconds - watchedSeconds > 10 -> 앞으로 당기기
+    *    -> watchedSeconds 업데이트 안 함
+    *  -
+    *  progressRate = watchedSeconds / durationSec * 100
+    * */
+
     public void updateProgress (
             // 현재 재생 위치
             int playbackSeconds, int durationSec
     ) {
-        if (playbackSeconds > this.watchedSeconds) {
+        // watchedSeconds 업데이트
+        if (playbackSeconds > this.watchedSeconds
+                && playbackSeconds - this.watchedSeconds <= 10) {
             this.watchedSeconds = playbackSeconds;
-            this.progressRate = (int) Math.round(
-                    (double) this.watchedSeconds / durationSec * 100
-            );
-            if (this.progressRate >= 100) {
-                this.progressRate = 100;
-            }
+        }
+
+        // progressRate = watchedSeconds 기준
+        this.progressRate = (int) Math.round(
+                (double) this.watchedSeconds / durationSec * 100
+        );
+        if (this.progressRate >= 100) {
+            this.progressRate = 100;
         }
     }
+
+    /*
+    * comment.
+    *  playbackSeconds >= durationSec * 0.9 시 챕터 완료 처리
+     * -> isCompleted = true
+     * -> progressRate = 100
+    * */
 
     // 챕터 완료처리
     public void complete (int playbackSeconds, int durationSec) {
@@ -60,6 +87,7 @@ public class LearningHistory {
     }
 
     // 나가기 버튼 클릭 시 이어보기 지점 저장
+    // 조건 없이 현재 위치로 덮어씀
     public void saveLastPosition(int lastPositionSec) {
         this.lastPositionSec = lastPositionSec;
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterProgressResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterProgressResponse.java
@@ -14,6 +14,19 @@ public record ChapterProgressResponse(
         Long lectureId,
         List<ChapterProgressItem> chapters
 ) {
+
+    /*
+     * comment.
+     *  watchedSeconds:
+     *  -> 실제로 본 최대 위치
+     *  -> 뒤로 감기 시 감소 없음
+     *  -> 앞으로 당기기 10초 초과 시 반영 안 함
+     *  ->durationSec 초과 불가 (Math.min 처리)
+     *  -
+     *  progressRate:
+     *  -> watchedSeconds / durationSec * 100
+     */
+
     public record ChapterProgressItem(
             Long chapterId,
             String title,


### PR DESCRIPTION
Viewing 도메인 내 사용자가 강의 시청 중 임의로 영상시간을 조작할 때 DB 에 저장 되는 값을 막아 수강률 계산 로직을 다시 구현함
#256 