### PR TITLE
[REFACTOR] 메시지 내역 조회 상대방 정보 이슈(서정림)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/GetMessageHistoryQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/GetMessageHistoryQueryService.java
@@ -88,6 +88,7 @@ public class GetMessageHistoryQueryService implements GetMessageHistoryQueryUseC
             }
         }
 
+
         // 2. 상대방 유저 특정 및 나가기 역추적 (목록 조회 로직 이식)
         UserWithFMJpaEntity targetUser = null;
         for (ChatRoomMemberJpaEntity member : allMembers) {
@@ -191,6 +192,17 @@ public class GetMessageHistoryQueryService implements GetMessageHistoryQueryUseC
         List<MessageHistoryView> viewList = new ArrayList<>();
         for (MessageJpaEntity msg : sortedMessages) {
             boolean isMine = msg.getSenderId().getId().equals(userId);
+            UserWithFMJpaEntity sender = msg.getSenderId();
+
+            String notMeTargetName = sender.getName();
+            String notMeNickname = sender.getNickname();
+            String notMeRole = sender.getRole();
+
+            if (isMine && targetUser != null) {
+                notMeTargetName = targetUser.getName();
+                notMeNickname = targetUser.getNickname();
+                notMeRole = targetUser.getRole();
+            }
 
             viewList.add(new MessageHistoryView(
                     msg.getId(),
@@ -205,7 +217,10 @@ public class GetMessageHistoryQueryService implements GetMessageHistoryQueryUseC
                     msg.getCreatedAt(),
                     true, // 과거 내역은 무조건 다 읽음 처리
                     isMine,
-                    targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl()
+                    targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl(),
+                    notMeTargetName,
+                    notMeNickname,
+                    notMeRole
             ));
         }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/usecase/GetMessageHistoryQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/usecase/GetMessageHistoryQueryUseCase.java
@@ -19,6 +19,9 @@ public interface GetMessageHistoryQueryUseCase {
             LocalDateTime createdAt,
             boolean isRead,
             boolean isMine,
-            String profileImageUrl
+            String profileImageUrl,
+            String notMeTargetName,
+            String notMeNickname,
+            String notMeRole
     ) {}
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
@@ -22,7 +22,8 @@ public record GetMessageHistoryResponse(
         String profileImageUrl,
         String notMeTargetName,
         String notMeNickname,
-        String notMeRole
+        String notMeRole,
+        String notMeLectureTitle
 ) {
     public static GetMessageHistoryResponse from(MessageHistoryView view) {
 
@@ -51,6 +52,7 @@ public record GetMessageHistoryResponse(
         String responseNotMeTargetName = null;
         String responseNotMeNickname = null;
         String responseNotMeRole = null;
+        String responseNotMeLectureTitle= null;
 
         if (view.isMine()) {
             responseNotMeRole = view.notMeRole(); // 상대방의 Role (STUDENT or TEACHER)
@@ -59,6 +61,7 @@ public record GetMessageHistoryResponse(
             if ("TEACHER".equals(view.notMeRole())) {
                 responseNotMeTargetName = view.notMeTargetName(); // 강사 실제 성함
                 responseNotMeNickname = view.notMeNickname();     // 강사 닉네임
+                responseNotMeLectureTitle = finalLectureTitle;
             }
             // 💡 [정책 분기] 상대방이 학생(STUDENT)인 경우: 이름 노출 차단(null), 닉네임만 노출
             else if ("STUDENT".equals(view.notMeRole())) {
@@ -82,7 +85,8 @@ public record GetMessageHistoryResponse(
                 view.profileImageUrl(),
                 responseNotMeTargetName,
                 responseNotMeNickname,
-                responseNotMeRole
+                responseNotMeRole,
+                responseNotMeLectureTitle
         );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
@@ -19,7 +19,10 @@ public record GetMessageHistoryResponse(
         LocalDateTime createdAt,
         boolean isRead,
         boolean isMine,
-        String profileImageUrl
+        String profileImageUrl,
+        String notMeTargetName,
+        String notMeNickname,
+        String notMeRole
 ) {
     public static GetMessageHistoryResponse from(MessageHistoryView view) {
 
@@ -57,7 +60,10 @@ public record GetMessageHistoryResponse(
                 view.createdAt(), // T 문자열 그대로 노출
                 view.isRead(),    // true
                 view.isMine(),
-                view.profileImageUrl()
+                view.profileImageUrl(),
+                view.notMeTargetName(),
+                "TEACHER".equals(view.role()) && !view.isMine() ? view.notMeNickname() : null,
+                view.notMeRole()
         );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
@@ -48,6 +48,25 @@ public record GetMessageHistoryResponse(
             finalLectureTitle = "(" + String.join(", ", lectureTitle) + ")";
         }
 
+        String responseNotMeTargetName = null;
+        String responseNotMeNickname = null;
+        String responseNotMeRole = null;
+
+        if (view.isMine()) {
+            responseNotMeRole = view.notMeRole(); // 상대방의 Role (STUDENT or TEACHER)
+
+            // 💡 [정책 분기] 상대방이 강사(TEACHER)인 경우: 이름과 닉네임 둘 다 노출
+            if ("TEACHER".equals(view.notMeRole())) {
+                responseNotMeTargetName = view.notMeTargetName(); // 강사 실제 성함
+                responseNotMeNickname = view.notMeNickname();     // 강사 닉네임
+            }
+            // 💡 [정책 분기] 상대방이 학생(STUDENT)인 경우: 이름 노출 차단(null), 닉네임만 노출
+            else if ("STUDENT".equals(view.notMeRole())) {
+                responseNotMeTargetName = null;                   // 학생 이름은 프라이버시로 인해 절대 숨김!
+                responseNotMeNickname = view.notMeNickname();     // 학생 닉네임만 허용
+            }
+        }
+
         return new GetMessageHistoryResponse(
                 view.messageId(),
                 view.senderId(),
@@ -61,9 +80,9 @@ public record GetMessageHistoryResponse(
                 view.isRead(),    // true
                 view.isMine(),
                 view.profileImageUrl(),
-                view.notMeTargetName(),
-                "TEACHER".equals(view.role()) && !view.isMine() ? view.notMeNickname() : null,
-                view.notMeRole()
+                responseNotMeTargetName,
+                responseNotMeNickname,
+                responseNotMeRole
         );
     }
 }


### PR DESCRIPTION
로그인 유저가 메시지 20개 넘게 보내면 상대방 정보 알 수 없음
로그인 유저가 보낸 메시지에만 상대방 정보 이중으로 담음
상대방 역할이 강사면: 이름, 닉네임, 강의명, 역할
상대방 역할이 학생이면: 닉네임, 역할