### PR TITLE
[PR] 사용자의 상태에 따라 로그인 실패 메시지 다르게 처리 (임수영)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/service/AuthCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/application/service/AuthCommandService.java
@@ -149,7 +149,13 @@ public class AuthCommandService implements AuthCommandUsecase {
 
         if (user.getStatus() != Status.ACTIVE) {
             log.warn("[login] 비활성 계정 로그인 시도 | email={} | status={}", command.email(), user.getStatus());
-            throw new InactiveUserException("로그인이 제한된 계정입니다.");
+            String message = switch (user.getStatus()) {
+                case PENDING -> "강사 승인 대기중입니다.";
+                case REJECTED -> "강사 신청이 반려되었습니다. 증빙자료를 다시 제출해주세요.";
+                case BANNED -> "정지된 계정입니다.";
+                default -> "해당 계정은 현재 로그인이 불가능한 상태입니다.";
+            };
+            throw new InactiveUserException(message, user.getStatus());
         }
 
         if (user.getIsTempPwd() && !emailCodePort.isTempPasswordVerified(command.email())) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/exception/AuthExceptionHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/exception/AuthExceptionHandler.java
@@ -33,7 +33,7 @@ public class AuthExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiErrorResponse.of(
                         HttpStatus.UNAUTHORIZED.value(),
-                        "INACTIVE_USER",
+                        e.getStatus(),
                         e.getMessage()
                 ));
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/exception/InactiveUserException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/domain/exception/InactiveUserException.java
@@ -1,7 +1,16 @@
 package com.wanted.momocity.auth.domain.exception;
 
+import com.wanted.momocity.auth.domain.model.Status;
+
 public class InactiveUserException extends RuntimeException {
-    public InactiveUserException(String message) {
+    private final Status status;
+
+
+    public InactiveUserException(String message, Status status) {
         super(message);
+        this.status = status;
+    }
+    public String getStatus() {
+        return status.name();
     }
 }

--- a/legend-momo-city/src/test/java/com/wanted/momocity/auth/LoginTest.java
+++ b/legend-momo-city/src/test/java/com/wanted/momocity/auth/LoginTest.java
@@ -5,7 +5,7 @@ import com.wanted.momocity.auth.application.port.EmailCodePort;
 import com.wanted.momocity.auth.application.port.LoadUserPort;
 import com.wanted.momocity.auth.application.port.RedisRefreshTokenPort;
 import com.wanted.momocity.auth.application.port.TokenProviderPort;
-import com.wanted.momocity.auth.application.service.LoginService;
+import com.wanted.momocity.auth.application.service.AuthCommandService;
 import com.wanted.momocity.auth.domain.exception.InactiveUserException;
 import com.wanted.momocity.auth.domain.exception.InvalidCredentialsException;
 import com.wanted.momocity.auth.domain.exception.TempPasswordExpiredException;
@@ -40,7 +40,7 @@ public class LoginTest {
     @Mock private EmailCodePort emailCodePort;
 
     @InjectMocks
-    private LoginService loginService;
+    private AuthCommandService loginService;
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
- 기존에는 로그인 실패 시 실패했다는 메시지만 내보냈는데 그러면 다양한 사용자의 상태에 일관된 메시지가 전달되며 ux가 저하되고 프론트측에서도 사용자의 상태에 따라 다른 페이지로 랜더링 하는 것이 불가능함
- 따라서 사용자의 상태에 따라 로그인 메시지를 다르게 하고 응답에 사용자의 status 를 함께 반환하여 다음과 같은 형태로 응답한다.
- `{
    "timestamp": "2026-05-31T16:24:40.6638267",

    "status": 401,

    "code": "REJECTED",

    "message": "강사 신청이 반려되었습니다. 증빙자료를 다시 제출해주세요."
}`
- #264 