### PR TITLE
[PR] 썸네일 크기 제한 추가구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/TeacherLectureController.java
@@ -67,6 +67,8 @@ public class TeacherLectureController {
          * 잘못된 카테고리 요청이면 여기서 400 응답으로 끝나고, 썸네일 파일은 업로드 X
          */
         request.validateCategory();
+        // 썸네일 크기 검증
+        request.validateThumbnailSize();
 
         String thumbnailUrl = s3UploadPort.upload(request.thumbnail());
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateLectureRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/request/CreateLectureRequest.java
@@ -24,6 +24,9 @@ public record CreateLectureRequest(
         MultipartFile thumbnail
 ) {
 
+    // 썸네일 크기 최대 5MB
+    private static final long MAX_THUMBNAIL_SIZE_BYTES = 5 * 1024 * 1024;
+
     // 중복 검증 추가
     public CreateLectureCommand toCommand(Long teacherId, String thumbnailUrl) {
         LectureCategory lectureCategory = parseCategory(category);
@@ -50,4 +53,9 @@ public record CreateLectureRequest(
         }
     }
 
+    public void validateThumbnailSize() {
+        if (thumbnail != null && thumbnail.getSize() > MAX_THUMBNAIL_SIZE_BYTES) {
+            throw new DomainRuleViolationException("썸네일 파일 크기는 5MB 이하만 가능합니다.");
+        }
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 강의 등록 요청에서 썸네일 파일 크기 검증을 추가했습니다.
- 썸네일 파일은 최대 5MB까지만 허용하도록 제한했습니다.
- S3 업로드 전에 검증을 먼저 수행하도록 처리했습니다.
- 잘못된 요청일 경우 S3에 불필요한 파일이 업로드되지 않도록 했습니다.

## 변경 흐름
- 강의 등록 요청 수신
- 카테고리 값 검증
- 썸네일 파일 크기 검증
- S3 썸네일 업로드
- 강의 등록 처리

## 검증 기준
- 썸네일 크기 5MB 이하: 정상 등록 진행
- 썸네일 크기 5MB 초과: 예외 발생
- 실패 시 S3 업로드 로직은 실행되지 않음

## 참고 사항
- 강의 등록은 multipart/form-data 방식으로 처리됩니다.
- 썸네일 검증은 CreateLectureRequest에서 수행합니다.
- 실제 S3 업로드는 검증 완료 후 진행됩니다.

close #266 