### PR TITLE
[PR] 관리자 회원관리 페이지에서 회원조회 기능 구현

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/presentation/api/common/ApiResponseMessage.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/presentation/api/common/ApiResponseMessage.java
@@ -16,10 +16,10 @@ public final class ApiResponseMessage {
     public static final String CREATED = "Resource created successfully.";
 
     // ===== 공통 실패 =====
-    public static final String VALIDATION_ERROR        = "Validation failed.";
-    public static final String DOMAIN_RULE_VIOLATION   = "Domain rule violated.";
-    public static final String NOT_FOUND               = "Resource not found.";
-    public static final String UNAUTHORIZED            = "Authentication required.";
-    public static final String FORBIDDEN               = "Access denied.";
-    public static final String INTERNAL_ERROR          = "Unexpected server error.";
+    public static final String VALIDATION_ERROR        = "입력값이 올바르지 않습니다.";
+    public static final String DOMAIN_RULE_VIOLATION   = "요청을 처리할 수 없습니다.";
+    public static final String NOT_FOUND               = "조회하신 내용을 찾을 수 없습니다.";
+    public static final String UNAUTHORIZED            = "다시 로그인 해주세요.";
+    public static final String FORBIDDEN               = "접근 권한이 없습니다.";
+    public static final String INTERNAL_ERROR          = "알 수 없는 문제가 발생했습니다. ";
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
@@ -75,7 +75,7 @@ public class UserQueryService implements UserQueryUsecase {
                 .orElseThrow(() -> new DomainRuleViolationException("해당 강사 신청자를 찾을 수 없습니다."));
     }
 
-    // 관리자 회원관리용ㅇ 회원 조회
+    // 관리자 회원관리용 회원 조회
     @Override
     public AdminUserListResult getAdminUserList(String role, String status, int page, int size) {
         // role이랑 status가 컨트롤러에서 String으로 넘어와서 서비스에서 enum 타입으로 변환

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
@@ -9,6 +9,7 @@ import com.wanted.momocity.user.domain.model.TeacherApplication;
 import com.wanted.momocity.user.domain.model.User;
 import com.wanted.momocity.user.domain.repository.BuildingRepository;
 import com.wanted.momocity.user.domain.repository.UserRepository;
+import com.wanted.momocity.user.presentation.api.response.AdminUserListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,5 +73,36 @@ public class UserQueryService implements UserQueryUsecase {
     public TeacherApplication getApplicationDetail(Long userId) {
         return userRepository.findTeacherApplicationById(userId)
                 .orElseThrow(() -> new DomainRuleViolationException("해당 강사 신청자를 찾을 수 없습니다."));
+    }
+
+    // 관리자 회원관리용ㅇ 회원 조회
+    @Override
+    public AdminUserListResult getAdminUserList(String role, String status, int page, int size) {
+        // role이랑 status가 컨트롤러에서 String으로 넘어와서 서비스에서 enum 타입으로 변환
+        Role roleEnum = role != null ? Role.valueOf(role) : null;
+        Status statusEnum = status != null ? Status.valueOf(status) : null;
+
+        List<?> list = userRepository.findAllForAdmin(roleEnum, statusEnum, page, size)
+                .stream()
+                .map(user -> {
+                    if (statusEnum == Status.DELETED) {
+                        return new AdminUserListResponse.Deleted(
+                                user.getId(), user.getName(), user.getRole().name(), user.getEmail(), user.getDeletedAt());
+                    } else if (user.getRole() == Role.TEACHER) {
+                        return new AdminUserListResponse.Teacher(
+                                user.getId(), user.getName(), user.getRole().name(), user.getEmail(),
+                                user.getCreatedAt(), user.getStatus().name(), user.getProof());
+                    } else {
+                        return new AdminUserListResponse.Default(
+                                user.getId(), user.getName(), user.getRole().name(), user.getEmail(),
+                                user.getCreatedAt(), user.getStatus().name());
+                    }
+                })
+                .toList();
+
+        long totalElements = userRepository.countForAdmin(roleEnum, statusEnum);
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+
+        return new AdminUserListResult(list, page, size, totalElements, totalPages);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
@@ -47,4 +47,15 @@ public interface UserQueryUsecase {
             int totalPages
     ) {
     }
+
+    // 관리자 회원관리용 사용자 조회
+    AdminUserListResult getAdminUserList(String role, String status, int page, int size);
+
+    record AdminUserListResult(
+            List<?> users,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {}
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/User.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/User.java
@@ -63,6 +63,22 @@ public class User {
                 .build();
     }
 
+    // 광리자 대시보드용 사용자 정보 덩어리 가져오기
+    public static User restoreForAdmin(Long id, String name, Role role, String email,
+                                       LocalDateTime createdAt, LocalDateTime deletedAt,
+                                       Status status, String proof) {
+        return User.builder()
+                .id(id)
+                .name(name)
+                .role(role)
+                .email(email)
+                .createdAt(createdAt)
+                .deletedAt(deletedAt)
+                .status(status)
+                .proof(proof)
+                .build();
+    }
+
 
     public Long getId() {
         return id;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
@@ -44,4 +44,9 @@ public interface UserRepository {
     // 강사 승인 여부에 따른 status 업데이트
     void updateRoleAndStatus(Long userId, Role role, Status status);
 
+    // 관리자 회원관리에서 사용자 조회
+    List<User> findAllForAdmin(Role role, Status status, int page, int size);
+
+    long countForAdmin(Role role, Status status);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -61,4 +61,31 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
 
     // 특정 날짜 이전의 active인 사용자 수 세기
     long countByStatusAndCreatedAtBefore(Status status, LocalDateTime localDateTime);
+
+    // 관리자 회원 목록 조회용
+    /*
+     * status = DELETED  → 탈퇴회원만 조회
+     * status = null     → 탈퇴회원 제외 전체 조회
+     *                     role = null  이면 전체 (STUDENT + TEACHER)
+     *                     role = 값 있으면 해당 role만
+     * */
+    @Query("SELECT u FROM UserUser u WHERE " +
+            "u.role <> 'ADMIN' AND (" +
+            "(:status = 'DELETED' AND u.status = :status) OR " +
+            "(:status IS NULL AND u.status <> 'DELETED' AND (:role IS NULL OR u.role = :role)))")
+    List<UserJpaEntity> findAllForAdmin(
+            @Param("role") Role role,
+            @Param("status") Status status,
+            Pageable pageable
+    );
+
+    // 관리자 회원 목록 전체 개수 조회 (페이지네이션 totalElements 계산용)
+    @Query("SELECT COUNT(u) FROM UserUser u WHERE " +
+            "u.role <> 'ADMIN' AND (" +
+            "(:status = 'DELETED' AND u.status = :status) OR " +
+            "(:status IS NULL AND u.status <> 'DELETED' AND (:role IS NULL OR u.role = :role)))")
+    long countForAdmin(
+            @Param("role") Role role,
+            @Param("status") Status status
+    );
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -93,6 +93,21 @@ public class UserRepositoryAdapter implements UserRepository {
         springDataUserRepository.updateRoleAndStatus(userId, role, status, LocalDateTime.now());
     }
 
+    // 관리자 회원관리용 회원 목록 조회 - role/status 조건에 따라
+    @Override
+    public List<User> findAllForAdmin(Role role, Status status, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return springDataUserRepository.findAllForAdmin(role, status, pageable)
+                .stream().map(this::toDomainForAdmin).toList();
+    }
+
+    // 페이지네이션 totalElements 계산용 전체 개수 조회
+    @Override
+    public long countForAdmin(Role role, Status status) {
+        return springDataUserRepository.countForAdmin(role, status);
+    }
+
+
 
     // 마이페이지 내 정보 조회용
     private User toDomain(UserJpaEntity entity) {
@@ -119,6 +134,20 @@ public class UserRepositoryAdapter implements UserRepository {
                 entity.getCategory() != null ? entity.getCategory().name() : null,
                 entity.getProof(),
                 entity.getUpdatedAt()
+        );
+    }
+
+    // 관리자 회원관리 회원 조회용
+    private User toDomainForAdmin(UserJpaEntity entity) {
+        return User.restoreForAdmin(
+                entity.getId(),
+                entity.getName(),
+                entity.getRole(),
+                entity.getEmail(),
+                entity.getCreatedAt(),
+                entity.getDeletedAt(),
+                entity.getStatus(),
+                entity.getRole() == Role.TEACHER ? entity.getProof() : null
         );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/TeacherApplicationController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/TeacherApplicationController.java
@@ -60,7 +60,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/admin")
+@RequestMapping("/api/v1")
 @PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Teacher - 강사 신청 관리", description = "강사 신청자 조회 및 승인/반려 (MS-3, MS-4, MS-5)")
 public class TeacherApplicationController {
@@ -68,7 +68,7 @@ public class TeacherApplicationController {
     private final UserCommandUsecase userCommandUsecase;
     private final UserQueryUsecase userQueryUsecase;
 
-    @GetMapping("/users/instructor-applications")
+    @GetMapping("/admin/users/instructor-applications")
     @Operation(summary = "강사 신청자 목록 조회 (MS-3)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "강사 신청자 목록 조회 성공"),
@@ -96,7 +96,7 @@ public class TeacherApplicationController {
         ));
     }
 
-    @GetMapping("/users/instructor-applications/{userId}")
+    @GetMapping("/admin/users/instructor-applications/{userId}")
     @Operation(summary = "강사 신청자 상세 조회 (MS-4)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "강사 신청자 상세 조회 성공"),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
@@ -11,20 +11,18 @@ import com.wanted.momocity.user.application.usecase.UserCommandUsecase;
 import com.wanted.momocity.user.application.usecase.UserQueryUsecase;
 import com.wanted.momocity.user.presentation.api.request.NicknameRequest;
 import com.wanted.momocity.user.presentation.api.request.UpdateUserInfoRequest;
-import com.wanted.momocity.user.presentation.api.response.NicknameRegisterResponse;
-import com.wanted.momocity.user.presentation.api.response.UserInfoUpdateResponse;
-import com.wanted.momocity.user.presentation.api.response.UserResponseCode;
-import com.wanted.momocity.user.presentation.api.response.UserResponseMessage;
+import com.wanted.momocity.user.presentation.api.response.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
 
 @RestController
 @RequiredArgsConstructor
@@ -144,5 +142,26 @@ public class UserController {
                 ));
     }
 
+    @GetMapping("/users")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "관리자 회원 목록 조회",
+            description = "파라미터 없으면 탈퇴회원 제외 전체 조회. role=STUDENT/TEACHER 또는 status=DELETED 로 필터링")
+    public ResponseEntity<ApiResponse<UserQueryUsecase.AdminUserListResult>> getUserList(
+            @Parameter(description = "회원 역할 필터 (STUDENT / TEACHER), 없으면 전체", example = "TEACHER")
+            @RequestParam(required = false) String role,
+            @Parameter(description = "탈퇴회원 조회 시 DELETED 입력", example = "DELETED")
+            @RequestParam(required = false) String status,
+            @Parameter(description = "페이지 번호 (1-base)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.SUCCESS,
+                UserResponseMessage.VIEW_SUCCESS,
+                userQueryUsecase.getAdminUserList(role, status, page, size)
+        ));
+    }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/AdminUserListResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/AdminUserListResponse.java
@@ -1,0 +1,36 @@
+package com.wanted.momocity.user.presentation.api.response;
+
+import java.time.LocalDateTime;
+
+public class AdminUserListResponse {
+
+    // 학생 조회 / 기본 전체 조회
+    public record Default(
+            Long id,
+            String name,
+            String role,
+            String email,
+            LocalDateTime createdAt,
+            String status
+    ) {}
+
+    // 강사조회
+    public record Teacher(
+            Long id,
+            String name,
+            String role,
+            String email,
+            LocalDateTime createdAt,
+            String status,
+            String proof
+    ) {}
+
+    // 탈퇴한 사용자 조회
+    public record Deleted(
+            Long id,
+            String name,
+            String role,
+            String email,
+            LocalDateTime deletedAt
+    ) {}
+}


### PR DESCRIPTION
- #265 
- ---
-  사용자 관리 페이지에서 4개의 항목으로 사용자를 조회함 
1. 전체(탈퇴회원 제외) 
2. 학생만
3. 강사만
4. 탈퇴한 회원만

- 따라서 api/v1/users 라는 경로에 쿼리스트링이 붙어
GET /api/v1/users                                 → findAllExcludeDeleted (탈퇴 제외 전체)
GET /api/v1/users?role=STUDENT       → findAllByRole(STUDENT)
GET /api/v1/users?role=TEACHER        → findAllByRole(TEACHER)
GET /api/v1/users?status=DELETED     → findDeletedUsers
이러한 형식으로 사용자를 조회합니다 

- 이러한 로직을 거쳐 사용자를 조회합니다
status = DELETED  → 탈퇴회원만 조회
status = null          → 탈퇴회원 제외 전체 조회
                              role = null  이면 전체 (STUDENT + TEACHER)
                               role = 값 있으면 해당 role만
