### PR TITLE
[PR] 관리자 회원조회 기능에서 rejected인 강사는 조회목록에서 제거 

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/SecurityConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/SecurityConfig.java
@@ -123,9 +123,11 @@ public class SecurityConfig {
                         // /api/user/ 하위에 endpoint 중에 admin / user 권한 별로 접근하기 위해서는
                         // 메서드 레벨에서 2차 방호벽 구축
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/api/v1/admin/**").hasAnyAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/v1/reports", "/api/v1/reports/**").hasAnyAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/v1/error-logs").hasAnyAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/v1/teacher/**").hasAnyAuthority("ROLE_TEACHER")
                         .requestMatchers("/api/v1/auth/login/completed").authenticated()
+                        .requestMatchers("/api/v1/auth/newtoken").authenticated()
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         // 임시 비밀번호 발급도 인증 토큰 필요
                         .requestMatchers("/api/v1/auth/**").permitAll() // 인증 없이 허용

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/email/UserEmailSendAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/email/UserEmailSendAdapter.java
@@ -19,8 +19,8 @@ public class UserEmailSendAdapter implements UserEmailSendPort {
     public void sendTeacherResult(String toEmail, String status, String reason) {
         String type = "ACTIVE".equals(status) ? "강사 신청 승인" : "강사 신청 반려";
         String content = "ACTIVE".equals(status)
-                ? "강사 신청이 승인되었습니다."
-                : "강사 신청이 반려되었습니다.<br>반려 사유: " + reason;
+                ? "강사 신청이 승인되었습니다.🎉"
+                : "강사 신청이 반려되었습니다.<br><hr>반려 사유: " + reason;
         sendEmail(toEmail, content, type);
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -70,7 +70,7 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
      *                     role = 값 있으면 해당 role만
      * */
     @Query("SELECT u FROM UserUser u WHERE " +
-            "u.role <> 'ADMIN' AND (" +
+            "u.role <> 'ADMIN' AND u.status <> 'REJECTED' AND (" +
             "(:status = 'DELETED' AND u.status = :status) OR " +
             "(:status IS NULL AND u.status <> 'DELETED' AND (:role IS NULL OR u.role = :role)))")
     List<UserJpaEntity> findAllForAdmin(
@@ -81,7 +81,7 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
 
     // 관리자 회원 목록 전체 개수 조회 (페이지네이션 totalElements 계산용)
     @Query("SELECT COUNT(u) FROM UserUser u WHERE " +
-            "u.role <> 'ADMIN' AND (" +
+            "u.role <> 'ADMIN' AND u.status <> 'REJECTED' AND (" +
             "(:status = 'DELETED' AND u.status = :status) OR " +
             "(:status IS NULL AND u.status <> 'DELETED' AND (:role IS NULL OR u.role = :role)))")
     long countForAdmin(


### PR DESCRIPTION
- 관리자 회원조회 기능에서 rejected인 강사는 조회목록에 나타나지 않아야하는데 함께 조회되고 있어, 쿼리문 수정을 통해 조회되지 않도록 수정 
- 강사 승인/거절 이메일 꾸미기작업
- Security Config에서 url별 입장 규칙 추가 (reports / error-logs / 등) 