### PR TITLE
[REFACT] 회원 신고 접수(POST /api/v1/reports) 실패 수정

### DIFF
--- a/legend-momo-city/db/seed-dummy.sql
+++ b/legend-momo-city/db/seed-dummy.sql
@@ -890,7 +890,7 @@ INSERT INTO `error_log` (`id`,`level`,`source`,`message`,`occurred_at`,`created_
 -- #####################################################################
 UPDATE `lecture`
 SET `thumbnail_url` = CONCAT('https://picsum.photos/seed/momolecture', `id`, '/400/250')
-WHERE `thumbnail_url` IS NULL;
+WHERE `id` > 0 AND `thumbnail_url` IS NULL;   -- id(PK) 조건: Workbench Safe Update Mode(Error 1175) 통과용
 
 -- =====================================================================
 --  END OF SEED  (25 tables + error_log / 기존 236행 + 페이지네이션 +520행)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/SecurityConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/SecurityConfig.java
@@ -127,7 +127,7 @@ public class SecurityConfig {
                         // 메서드 레벨에서 2차 방호벽 구축
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/api/v1/reports", "/api/v1/reports/**").hasAnyAuthority("ROLE_ADMIN")
+                        // /api/v1/reports : URL 역할 규칙 제거 → 메서드 레벨 @PreAuthorize 로 인가 (GET=ADMIN 조회 / POST=인증 회원 신고)
                         .requestMatchers("/api/v1/error-logs").hasAnyAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/v1/teacher/**").hasAnyAuthority("ROLE_TEACHER")
                         .requestMatchers("/api/v1/auth/login/completed").authenticated()

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/command/SubmitReportCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/command/SubmitReportCommand.java
@@ -14,14 +14,14 @@ import com.wanted.momocity.report.domain.model.ReportTargetType;
        → Command : 응용 계층
        → 두 계층을 분리하면 HTTP 구조 바뀌어도 Command 는 안바뀐다.
     5. 필드 5개 의미
-       - reporterEmail : 신고자의 로그인 email
+       - reporterUserId : 신고자의 userId (인증 principal 에서 추출)
        - targetType : 신고 대상 종류
        - targetId : 신고 대상 ID
        - reason : 신고 사유 ENUM
        - detail : 자유 설명
  */
 public record SubmitReportCommand(
-        String reporterEmail,
+        Long reporterUserId,
         ReportTargetType targetType,
         Long targetId,
         ReportReason reason,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/port/ReporterAccountPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/port/ReporterAccountPort.java
@@ -1,21 +1,29 @@
-package com.wanted.momocity.report.application.port;
-
-/* comment.
-    ReporterAccountPort 정리
-    1. 역할 : 신고자의 email 을 받아서 내부 PK 로 변환해주는
-    2. 위치 : 응용 계층 - 외부 BC 접근 인터페이스
-    3. WHY Port 패턴 사용
-       → 신고 도메인은 회원 BC 를 직접 import 하면 BC 경계가 깨지기 때문이다.
-       → Port 인터페이스만 응용 계층에만 두고, 실제 회원 조회는 인프라 계층의 Adapter 가 담당하게 된다.
-       → 신고 도메인 코어는 회원 BC 의 존재를 모른다.
-    4. WHY 단일 메서드만 (getReporterId)
-       → 신고가 회원에 대해 알아야할 정보는 userId 밖에 없다.
-       → 회원의 다른 정보에 대해서는 신고 도메인이 알아야할 필요가 없다.
-    5. enrollment 의 StudentAccountPort 와 차이
-       → StudentAccountPort : 학생 권한만 허용 (수강신청은 학생만 가능)
-       → ReporterAccountPort : 모든 회원이 신고 가능하다. role 체크가 없다.
- */
-public interface ReporterAccountPort {
-
-    Long getReporterId(String email);
-}
+// ============================================================================
+// [DEACTIVATED / 전체 주석처리 — 2026-06-01 신고 접수 리팩토링]
+// 사유: ReportController 가 인증 principal(CustomUserDetails.getUserId())에서
+//       신고자 userId 를 직접 얻도록 변경됨 → email→userId 변환용 이 port 가 불필요.
+//       (FriendController / LectureController 와 동일한 principal 사용 컨벤션으로 통일)
+// 복구: 아래 주석 해제 + ReportController / ReportCommandService 를 원복.
+// ============================================================================
+//
+// package com.wanted.momocity.report.application.port;
+//
+// /* comment.
+//     ReporterAccountPort 정리
+//     1. 역할 : 신고자의 email 을 받아서 내부 PK 로 변환해주는
+//     2. 위치 : 응용 계층 - 외부 BC 접근 인터페이스
+//     3. WHY Port 패턴 사용
+//        → 신고 도메인은 회원 BC 를 직접 import 하면 BC 경계가 깨지기 때문이다.
+//        → Port 인터페이스만 응용 계층에만 두고, 실제 회원 조회는 인프라 계층의 Adapter 가 담당하게 된다.
+//        → 신고 도메인 코어는 회원 BC 의 존재를 모른다.
+//     4. WHY 단일 메서드만 (getReporterId)
+//        → 신고가 회원에 대해 알아야할 정보는 userId 밖에 없다.
+//        → 회원의 다른 정보에 대해서는 신고 도메인이 알아야할 필요가 없다.
+//     5. enrollment 의 StudentAccountPort 와 차이
+//        → StudentAccountPort : 학생 권한만 허용 (수강신청은 학생만 가능)
+//        → ReporterAccountPort : 모든 회원이 신고 가능하다. role 체크가 없다.
+//  */
+// public interface ReporterAccountPort {
+//
+//     Long getReporterId(String email);
+// }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportCommandService.java
@@ -1,7 +1,6 @@
 package com.wanted.momocity.report.application.service;
 
 import com.wanted.momocity.report.application.command.SubmitReportCommand;
-import com.wanted.momocity.report.application.port.ReporterAccountPort;
 import com.wanted.momocity.report.application.usecase.ReportCommandUseCase;
 import com.wanted.momocity.report.domain.model.Report;
 import com.wanted.momocity.report.domain.repository.ReportRepository;
@@ -21,11 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
     4. WHY @RequiredArgsConstructor (Lombok)
        → final 필드 받는 생성자 자동 생성
        → 의존성이 늘어나더라도 생성자 코드 건드리지 않게 된다.
-    5. 의존성 2개의 역할
-       - ReporterAccountPort : email -> userId 변환
+    5. 의존성 1개의 역할
        - ReportRepository : 도메인 Report 객체 저장
+       (신고자 userId 는 Controller 가 인증 principal 에서 추출해 Command 로 전달 → 외부 BC 조회 불필요)
     6. submitReport 처리 흐름 4단계
-        a) command.reporterEmail() → ReporterAccountPort.getReporterId() → reporterUserId 획득
+        a) command.reporterUserId() 로 신고자 id 확보 (인증 principal 출처)
         b) Report.submit() 정적 팩토리로 도메인 객체 생성 (PENDING + now)
         c) reportRepository.save() 로 영속화
         d) 저장된 Report (id 부여됨) 반환
@@ -37,13 +36,12 @@ public class ReportCommandService implements ReportCommandUseCase {
 
     private static final Logger log = LoggerFactory.getLogger(ReportCommandService.class);
 
-    private final ReporterAccountPort reporterAccountPort;
     private final ReportRepository reportRepository;
 
     @Override
     public Report submitReport(SubmitReportCommand command) {
-        // 1. email → reporterUserId 변환 (외부 BC 호출)
-        Long reporterUserId = reporterAccountPort.getReporterId(command.reporterEmail());
+        // 1. 신고자 userId 확보 (Controller 가 인증 principal 에서 추출해 Command 로 전달)
+        Long reporterUserId = command.reporterUserId();
 
         // 2. 도메인 정적 팩토리로 신규 Report 생성 (status=PENDING, reportedAt=now)
         Report report = Report.submit(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/adapter/AuthReporterAccountAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/adapter/AuthReporterAccountAdapter.java
@@ -1,45 +1,53 @@
-package com.wanted.momocity.report.infrastructure.adapter;
-
-import com.wanted.momocity.auth.application.port.LoadUserPort;
-import com.wanted.momocity.auth.domain.model.User;
-import com.wanted.momocity.report.application.port.ReporterAccountPort;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.stereotype.Component;
-
-/* comment.
-    AuthReporterAccountAdapter 정리
-    1. 역할 : ReporterAccountPort 인터페이스 auth BC 의 LoadUserPort 로 구현하는 어댑터
-    2. 위치 : 인프라 계층 - 외부 BC 접근 어댑터
-    3. WHY @Component 사용
-       → Spring 이 빈으로 등록 -> Service 에 자동 주입
-       → DB가 아니라 외부 BC 호출이기 때문에 @Repository 어노테이션 대신 @Component 를 사용
-    4. WHY LoadUserPort 를 주입받음
-       → 신고 BC 는 회원 DB 에 직접 접근하면 BC 경계를 침범하게 된다.
-       → auth BC 가 제공하는 LoadUserPort 를 빌려 쓰면 BC 격리 유지
-       → email -> User 변환 책임 auth BC 에 위임
-    5. WHY role 체크 없음 (StudentAccountAdapter 와 차이)
-       → 수강신청은 학생만 가능
-       → 신고는 모든 회원이 가능
-    6. 의존 방향
-       - implements ReporterAccountPort : 인프라가 도메인 약속 지킴
-       - LoadUserPort 주입 : 다른 BC 의 응용 계층
-       - User 사용 : 인프라가 외부 BC 도메인
- */
-@Component
-public class AuthReporterAccountAdapter implements ReporterAccountPort {
-
-    private final LoadUserPort loadUserPort;
-
-    public AuthReporterAccountAdapter(LoadUserPort loadUserPort) {
-        this.loadUserPort = loadUserPort;
-    }
-
-    @Override
-    public Long getReporterId(String email) {
-        User user = loadUserPort.findByEmail(email)
-                .orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
-                        "인증된 사용자 정보를 찾을 수 없습니다."
-                ));
-        return user.getId();
-    }
-}
+// ============================================================================
+// [DEACTIVATED / 전체 주석처리 — 2026-06-01 신고 접수 리팩토링]
+// 사유: ReportController 가 인증 principal(CustomUserDetails.getUserId())에서
+//       신고자 userId 를 직접 얻도록 변경됨 → auth BC 로 건너가 email→userId 조회하던
+//       이 어댑터가 불필요해짐. (회원은 이미 인증된 principal 에 userId 를 보유)
+// 복구: 아래 주석 해제 + ReportController / ReportCommandService 를 원복.
+// ============================================================================
+//
+// package com.wanted.momocity.report.infrastructure.adapter;
+//
+// import com.wanted.momocity.auth.application.port.LoadUserPort;
+// import com.wanted.momocity.auth.domain.model.User;
+// import com.wanted.momocity.report.application.port.ReporterAccountPort;
+// import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+// import org.springframework.stereotype.Component;
+//
+// /* comment.
+//     AuthReporterAccountAdapter 정리
+//     1. 역할 : ReporterAccountPort 인터페이스 auth BC 의 LoadUserPort 로 구현하는 어댑터
+//     2. 위치 : 인프라 계층 - 외부 BC 접근 어댑터
+//     3. WHY @Component 사용
+//        → Spring 이 빈으로 등록 -> Service 에 자동 주입
+//        → DB가 아니라 외부 BC 호출이기 때문에 @Repository 어노테이션 대신 @Component 를 사용
+//     4. WHY LoadUserPort 를 주입받음
+//        → 신고 BC 는 회원 DB 에 직접 접근하면 BC 경계를 침범하게 된다.
+//        → auth BC 가 제공하는 LoadUserPort 를 빌려 쓰면 BC 격리 유지
+//        → email -> User 변환 책임 auth BC 에 위임
+//     5. WHY role 체크 없음 (StudentAccountAdapter 와 차이)
+//        → 수강신청은 학생만 가능
+//        → 신고는 모든 회원이 가능
+//     6. 의존 방향
+//        - implements ReporterAccountPort : 인프라가 도메인 약속 지킴
+//        - LoadUserPort 주입 : 다른 BC 의 응용 계층
+//        - User 사용 : 인프라가 외부 BC 도메인
+//  */
+// @Component
+// public class AuthReporterAccountAdapter implements ReporterAccountPort {
+//
+//     private final LoadUserPort loadUserPort;
+//
+//     public AuthReporterAccountAdapter(LoadUserPort loadUserPort) {
+//         this.loadUserPort = loadUserPort;
+//     }
+//
+//     @Override
+//     public Long getReporterId(String email) {
+//         User user = loadUserPort.findByEmail(email)
+//                 .orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+//                         "인증된 사용자 정보를 찾을 수 없습니다."
+//                 ));
+//         return user.getId();
+//     }
+// }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/ReportController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/ReportController.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.report.presentation.api;
 
+import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.report.application.command.SubmitReportCommand;
@@ -14,7 +15,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,6 +56,7 @@ public class ReportController {
     private final ReportCommandUseCase reportCommandUseCase;
 
     @PostMapping
+    @PreAuthorize("isAuthenticated()") // 신고는 로그인 회원이면 누구나 (직군 제한 없음) — 인가를 어노테이션으로 명시
     @Operation(
             summary = "신고 접수",
             description = "로그인한 회원이 게시글/댓글/회원/강의를 신고한다."
@@ -67,14 +70,14 @@ public class ReportController {
                     responseCode = "401", description = "인증 토큰 누락 또는 만료")
     })
     public ResponseEntity<ApiResponse<SubmitReportResponse>> submitReport(
-            Authentication authentication,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SubmitReportRequest request
     ) {
-        // 1. Authentication 에서 신고자 email 추출
-        String reporterEmail = authentication.getName();
+        // 1. 인증 principal 에서 신고자 userId 추출 (FriendController 와 동일 방식)
+        Long reporterUserId = userDetails.getUserId();
 
         // 2. Request → Command 변환 (Request 의 toCommand 메서드 활용)
-        SubmitReportCommand command = request.toCommand(reporterEmail);
+        SubmitReportCommand command = request.toCommand(reporterUserId);
 
         // 3. UseCase 호출 → 도메인 객체 반환
         Report report = reportCommandUseCase.submitReport(command);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/request/SubmitReportRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/request/SubmitReportRequest.java
@@ -51,9 +51,9 @@ public record SubmitReportRequest(
         String detail
 ) {
 
-    public SubmitReportCommand toCommand(String reporterEmail) {
+    public SubmitReportCommand toCommand(Long reporterUserId) {
         return new SubmitReportCommand(
-                reporterEmail,
+                reporterUserId,
                 targetType,
                 targetId,
                 reason,


### PR DESCRIPTION
# [리팩토링] 회원 신고 접수(POST /api/v1/reports) 실패 수정

회원이 신고를 접수하면 항상 실패(403/401)하던 문제 수정.
원인은 DB가 아닌 BE 인가·인증 로직 2건.

## ① 왜 문제가 발생했나
- **인가**: SecurityConfig가 `/api/v1/reports` URL 전체를 ROLE_ADMIN으로 잠금
  → GET(관리자 조회)·POST(회원 접수)가 한 규칙에 묶여 같이 차단됨.
- **인증**: 토큰 subject는 userId인데, 신고 접수 코드만 그 값을 email로 간주
  → `findByEmail`로 회원을 못 찾음.

## ② 문제를 어떻게 알았나
- 회원 토큰 POST → 403 / 관리자 토큰 POST → 401 로 응답이 갈림.
- 같은 토큰으로 GET·POST 비교: 회원은 보안 단에서 차단(403), 관리자는 통과 후 컨트롤러 안에서 401.
- 다른 BC(friend/lecture)는 principal에서 userId를 직접 읽는데 신고만 email로 읽는 것을 확인.

## ③ 어떻게 수정했나
- **인가**: URL 역할 규칙 제거 → 메서드 레벨 `@PreAuthorize`로 통일
  (GET=`hasRole('ADMIN')`, POST=`isAuthenticated()`). 기존 컨벤션과 일치.
- **인증**: 컨트롤러가 `@AuthenticationPrincipal CustomUserDetails.getUserId()`로 userId 직접 사용.
  email→id 변환용 `ReporterAccountPort`/`AuthReporterAccountAdapter` 비활성화(불필요한 BC 횡단 제거).

## ④ 문제를 없앴다 (검증)
- 회원 POST → **201** (정상 접수, reporterUserId 정확)
- 회원 GET 403 / 관리자 GET 200 → **회귀 없음**

## 변경 파일
SecurityConfig · ReportController · SubmitReportCommand · SubmitReportRequest
· ReportCommandService · ReporterAccountPort(주석) · AuthReporterAccountAdapter(주석)