### PR TITLE
[PR] 401 / 403 에러 핸들러 응답 포멧 통일

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/handler/CustomAccessDeniedHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/handler/CustomAccessDeniedHandler.java
@@ -19,7 +19,9 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
         response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{ 접근 권한이 없습니다. }");
+        response.getWriter().write(
+                "{\"timestamp\": \"" + java.time.LocalDateTime.now() + "\", \"status\": 403, \"code\": \"FORBIDDEN\", \"message\": \"접근 권한이 없습니다.\"}"
+        );
     }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/handler/CustomAuthenticationEntryPoint.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/auth/infrastructure/handler/CustomAuthenticationEntryPoint.java
@@ -19,12 +19,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("""
-                {
-                    "success": false,
-                    "message": "다시 로그인 해주세요."
-                }
-                """);
+        response.getWriter().write(
+                "{\"timestamp\": \"" + java.time.LocalDateTime.now() + "\", \"status\": 401, \"code\": \"UNAUTHORIZED\", \"message\": \"다시 로그인 해주세요.\"}"
+        );
     }
 
 


### PR DESCRIPTION
응답 형식 통일

## 1.CustomAccessDeniedHandler
기존 : { 접근 권한이 없습니다. }
변경 : "{
                 \"timestamp\": \"" + java.time.LocalDateTime.now() + "\", 
                 \"status\": 401, 
                 \"code\": \"UNAUTHORIZED\",
                 \"message\": \"다시 로그인 해주세요.\"
           }"

---

## 2.CustomAuthenticationEntryPoint
기존 : 
                {
                    "success": false,
                    "message": "다시 로그인 해주세요."
                }
변경 : "{
                 \"timestamp\": \"" + java.time.LocalDateTime.now() + "\", 
                 \"status\": 401, 
                 \"code\": \"UNAUTHORIZED\",
                 \"message\": \"다시 로그인 해주세요.\"
           }"


--- 

둘 다 응답 포멧을 APiErrorResponse랑 동일한 칼럼으로 통일 수정

### 최종형태 
{
    "timestamp": "2026-06-05T10:37:46.213246",
    "status": 401,
    "code": "UNAUTHORIZED",
    "message": "다시 로그인 해주세요."
}