### PR TITLE
[PR] Lecture 패키지 S3 파일 구조 수정

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/SecurityConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -127,6 +128,7 @@ public class SecurityConfig {
                         // 메서드 레벨에서 2차 방호벽 구축
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/lectures").permitAll()
                         // /api/v1/reports : URL 역할 규칙 제거 → 메서드 레벨 @PreAuthorize 로 인가 (GET=ADMIN 조회 / POST=인증 회원 신고)
                         .requestMatchers("/api/v1/error-logs").hasAnyAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/v1/teacher/**").hasAnyAuthority("ROLE_TEACHER")

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/LectureQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/query/LectureQuery.java
@@ -54,7 +54,6 @@ public final class LectureQuery {
     public record GetLecturesQuery(
             Long userId,
             LectureCategory category,
-            Boolean enrolled,
             String keyword,
             int page,
             int size

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureCommandService.java
@@ -196,7 +196,11 @@ public class LectureCommandService implements
             throw new DomainRuleViolationException("동영상 파일 크기는 500MB 이하만 가능합니다.");
         }
 
-        String videoUrl = s3UploadPort.upload(command.video());
+        // S3 파일 구조에 맞게 수정
+        // EX) Lecutures/1/chapters/1
+        String videoUrl = s3UploadPort.upload(
+                command.video(),
+                "lectures/" + command.lectureId() + "/chapters/" + command.chapterId());
 
         LectureChapter updatedChapter = chapter.registerVideo(
                 videoUrl,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -67,28 +67,45 @@ public class LectureQueryService implements
     // 강사 이름, 프로필 이미지 조회를 위한 auth 포트
     private final LoadUserPort loadUserPort;
 
-    // 학생 기준 강의 목록 조회.
+    // 학생/비로그인 기준 강의 목록 조회.
     @Override
     public StudentLecturePageResponse getLectures(GetLecturesQuery query) {
-        Long studentId = studentAccountPort.getStudentId(query.userId());
 
-        List<Long> enrolledLectureIds =
-                lectureEnrollmentQueryPort.findLectureIdsByUserId(studentId);
+        // userId가 있으면 로그인 학생의 "내 수강 강의" 조회
+        // userId가 없으면 비로그인 공개 강의 조회
+        boolean enrolledOnly = query.userId() != null;
+
+        List<Long> enrolledLectureId = List.of();
+
+        if (enrolledOnly) {
+            Long studentId = studentAccountPort.getStudentId(query.userId());
+
+            enrolledLectureId =
+                    lectureEnrollmentQueryPort.findLectureIdsByUserId(studentId);
+
+            // 로그인 학생인데 수강 중인 강의가 없으면 빈 페이지 반환
+            if (enrolledLectureId.isEmpty()) {
+                return new StudentLecturePageResponse(
+                        List.of(),
+                        query.page(),
+                        query.size(),
+                        0,
+                        0
+                );
+            }
+        }
 
         var lecturePage = lectureRepository.findLectures(
                 query.category(),
                 query.keyword(),
-                query.enrolled(),
-                enrolledLectureIds,
+                enrolledOnly,
+                enrolledLectureId,
                 query.page(),
                 query.size()
         );
 
         List<StudentLectureListItemResponse> content = lecturePage.content().stream()
-                .map(lecture -> toStudentListItemResponse(
-                        lecture,
-                        enrolledLectureIds.contains(lecture.getId())
-                ))
+                .map(this::toStudentListItemResponse)
                 .toList();
 
         return new StudentLecturePageResponse(
@@ -255,23 +272,17 @@ public class LectureQueryService implements
 
     // 학생 강의 목록용 응답 객체로 변환
     private StudentLectureListItemResponse toStudentListItemResponse(
-            LectureAggregate lecture,
-            boolean enrolled
+            LectureAggregate lecture
     ) {
-        return new StudentLectureListItemResponse(
-                lecture.getId(),
-                lecture.getTeacherId(),
-                null,
-                lecture.getTitle(),
-                lecture.getDescription(),
-                lecture.getThumbnailUrl(),
-                lecture.getCategory().name(),
-                lecture.getStatus().name(),
-                lecture.getCompletedUserCount(),
-                0.0,
-                0,
-                enrolled,
-                lecture.getCreatedAt()
+        String teacherName = null;
+        double averageRating = 0.0;
+        int reviewCount = 0;
+
+        return StudentLectureListItemResponse.from(
+                lecture,
+                teacherName,
+                averageRating,
+                reviewCount
         );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/domain/repository/LectureRepository.java
@@ -25,7 +25,7 @@ public interface LectureRepository {
     LecturePage findLectures(
             LectureCategory category,
             String keyword,
-            Boolean enrolled,
+            boolean enrolledOnly,
             List<Long> enrolledLectureIds,
             int page,
             int size

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -73,7 +73,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
     public LecturePage findLectures(
             LectureCategory category,
             String keyword,
-            Boolean enrolled,
+            boolean enrolledOnly,
             List<Long> enrolledLectureIds,
             int page,
             int size
@@ -85,7 +85,7 @@ public class LectureRepositoryAdapter implements LectureRepository {
         Page<LectureJpaEntity> lecturePage = findLecturePage(
                 category,
                 normalizedKeyword,
-                enrolled,
+                enrolledOnly,
                 enrolledLectureIds,
                 pageable
         );

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -111,7 +111,7 @@ public class LectureController {
         request.validateCategory();
         request.validateThumbnailSize();
 
-        String thumbnailUrl = s3UploadPort.upload(request.thumbnail());
+        String thumbnailUrl = s3UploadPort.upload(request.thumbnail(), "lectuers/");
 
         LectureAggregate lecture = lectureCommandUseCase.createLecture(
                 request.toCommand(teacherId, thumbnailUrl)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -235,14 +235,13 @@ public class LectureController {
     public ResponseEntity<ApiResponse<?>> getLectures(
             Authentication authentication,
             @RequestParam(required = false) String category,
-            @RequestParam(required = false) Boolean enrolled,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String status,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        String role = getRole(authentication);
-        Long userId = Long.parseLong(authentication.getName());
+        String role = getRoleOrAnonymous(authentication);
+        Long userId = getUserIdOrNull(authentication);
 
         if ("ROLE_ADMIN".equals(role)) {
             GetAdminLecturesQuery query = new GetAdminLecturesQuery(
@@ -281,10 +280,10 @@ public class LectureController {
             ));
         }
 
+        // 토큰 없음 또는 학생
         GetLecturesQuery query = new GetLecturesQuery(
                 userId,
                 parseCategory(category),
-                enrolled,
                 keyword,
                 page,
                 size
@@ -524,4 +523,29 @@ public class LectureController {
             throw new DomainRuleViolationException("허용되지 않은 강의 카테고리입니다.");
         }
     }
+
+    private String getRoleOrAnonymous(Authentication authentication) {
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return "ANONYMOUS";
+        }
+
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .findFirst()
+                .orElse("ANONYMOUS");
+    }
+
+    private Long getUserIdOrNull(Authentication authentication) {
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureResponse.java
@@ -146,7 +146,6 @@ public class StudentLectureResponse {
             int completedUserCount,      // 수강 완료 인원
             double averageRating,        // 평균 평점
             int reviewCount,             // 수강평 개수
-            boolean isEnrolled,          // 현재 로그인한 학생의 수강 여부
             LocalDateTime createdAt      // 강의 생성일
     ) {
         /* comment
@@ -157,8 +156,7 @@ public class StudentLectureResponse {
                 LectureAggregate lecture,
                 String teacherName,
                 double averageRating,
-                int reviewCount,
-                boolean isEnrolled
+                int reviewCount
         ) {
             return new StudentLectureListItemResponse(
                     lecture.getId(),
@@ -172,7 +170,6 @@ public class StudentLectureResponse {
                     lecture.getCompletedUserCount(),
                     averageRating,
                     reviewCount,
-                    isEnrolled,
                     lecture.getCreatedAt()
             );
         }

--- a/legend-momo-city/src/test/java/com/wanted/momocity/lecture/TeacherLectureAggregateRegisterTest.java
+++ b/legend-momo-city/src/test/java/com/wanted/momocity/lecture/TeacherLectureAggregateRegisterTest.java
@@ -1,7 +1,8 @@
 package com.wanted.momocity.lecture;
 
 import com.wanted.momocity.global.application.s3.S3UploadPort;
-import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCase;
+
+import com.wanted.momocity.lecture.application.usecase.LectureCommandUseCases;
 import com.wanted.momocity.lecture.application.usecase.LectureQueryUseCases;
 import com.wanted.momocity.lecture.domain.model.LectureAggregate;
 import com.wanted.momocity.lecture.domain.model.LectureChapter;
@@ -46,21 +47,21 @@ class TeacherLectureAggregateRegisterTest {
 
     // 강의 등록 UseCase를 Mock으로 대체한다.
     @MockitoBean
-    private LectureCommandUseCase lectureCommandUseCase;
+    private LectureCommandUseCases.LectureCommandUseCase lectureCommandUseCase;
 
     // TeacherLectureController 생성자 의존성 때문에 필요하다.
     @MockitoBean
-    private ChapterCommandUseCase chapterCommandUseCase;
+    private LectureCommandUseCases.ChapterCommandUseCase chapterCommandUseCase;
 
     // TeacherLectureController 생성자 의존성 때문에 필요하다.
     @MockitoBean
     private LectureQueryUseCases lectureQueryUseCase;
 
     @MockitoBean
-    private AdminLectureQueryUseCase adminLectureQueryUseCase;
+    private LectureQueryUseCases.AdminLectureQueryUseCase adminLectureQueryUseCase;
 
     @MockitoBean
-    private AdminLectureCommandUseCase adminLectureCommandUseCase;
+    private LectureCommandUseCases.AdminLectureCommandUseCase adminLectureCommandUseCase;
 
     // 실제 S3 업로드 대신 URL만 반환하도록 Mock 처리한다.
     @MockitoBean
@@ -73,7 +74,7 @@ class TeacherLectureAggregateRegisterTest {
         String thumbnailUrl = "https://example.com/images/spring-boot.png";
 
         // S3 업로드 성공 시 썸네일 URL이 반환된다고 가정한다.
-        when(s3UploadPort.upload(any()))
+        when(s3UploadPort.upload(any(), any()))
                 .thenReturn(thumbnailUrl);
 
         // 강의 등록 UseCase가 반환할 도메인 객체를 준비한다.
@@ -122,7 +123,7 @@ class TeacherLectureAggregateRegisterTest {
                 .andExpect(jsonPath("$.data.createdAt").exists())
                 .andExpect(jsonPath("$.data.updatedAt").exists());
 
-        verify(s3UploadPort).upload(any());
+        verify(s3UploadPort).upload(any(), any());
         verify(lectureCommandUseCase).createLecture(any());
     }
 
@@ -197,7 +198,7 @@ class TeacherLectureAggregateRegisterTest {
                 .andExpect(status().isBadRequest());
 
         // 입력값 검증에서 막혀야 하므로 S3 업로드와 UseCase 호출은 발생하면 안 된다.
-        verify(s3UploadPort, never()).upload(any());
+        verify(s3UploadPort, never()).upload(any(), any());
         verify(lectureCommandUseCase, never()).createLecture(any());
     }
 
@@ -223,7 +224,7 @@ class TeacherLectureAggregateRegisterTest {
                 .andExpect(jsonPath("$.message").exists());
 
         // category 검증은 S3 업로드보다 먼저 수행되어야 한다.
-        verify(s3UploadPort, never()).upload(any());
+        verify(s3UploadPort, never()).upload(any(), any());
         verify(lectureCommandUseCase, never()).createLecture(any());
     }
 
@@ -238,7 +239,7 @@ class TeacherLectureAggregateRegisterTest {
                 .andExpect(status().isBadRequest());
 
         // 썸네일이 없으면 S3 업로드와 UseCase 호출이 발생하면 안 된다.
-        verify(s3UploadPort, never()).upload(any());
+        verify(s3UploadPort, never()).upload(any(), any());
         verify(lectureCommandUseCase, never()).createLecture(any());
     }
 


### PR DESCRIPTION
close #308 

## 최종 api 명세 내용 작성

### 1. header / body request 값

#### 공통 Header
```http
Authorization: Bearer {accessToken}
```


1. 강의 썸네일 업로드
POST /api/v1/lectures

Content-Type: multipart/form-data
title: String
description: String
category: String
thumbnail: MultipartFile

2. 챕터 강의 영상 업로드
PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}/video

Content-Type: multipart/form-data
video: MultipartFile
durationSec: Integer


### 2. response 값
기존 응답 구조는 변경하지 않았습니다.

강의 등록 응답
```
{
  "code": "CREATED",
  "message": "강의가 등록되었습니다.",
  "data": {
    "lectureId": 1,
    "thumbnailUrl": "lectures/{uuid}_{filename}",
    "...": "기존 응답 필드 유지"
  }
}
```

챕터 영상 등록 응답
```
{
  "code": "SUCCESS",
  "message": "챕터 동영상이 등록되었습니다.",
  "data": {
    "lectureId": 1,
    "chapterId": 1,
    "videoUrl": "lectures/1/chapters/1/{uuid}_{filename}",
    "videoStatus": "UPLOADING",
    "...": "기존 응답 필드 유지"
  }
}
```

## 작업 내용 명세
### 1. 어떤 기능을 구현했는지
S3 파일 업로드 시 파일 유형별로 폴더 경로를 분리하여 저장되도록 수정했습니다.

기존에는 S3에 모든 파일이 루트 경로에 저장되어 강사 증빙자료, 프로필 이미지, 강의 자료, 강의 영상 등이 구분되지 않았습니다.
이번 작업으로 Lecture 패키지에서 업로드하는 파일이 S3 폴더 구조에 맞게 저장됩니다.

### 2. 변경 사항이 무엇인지
- S3UploadPort.upload() 호출 시 folder 파라미터 전달
- 강의 썸네일 업로드 경로 변경
     - 기존: {uuid}_{filename}
     - 변경: lectures/{uuid}_{filename}
- 챕터 영상 업로드 경로 변경
     - 기존: {uuid}_{filename}
     - 변경: lectures/{lectureId}/chapters/{chapterId}/{uuid}_{filename}
     
## 1. postman 검증 결과 화면
1. 강의 썸네일 등록    
 <img width="662" height="354" alt="image" src="https://github.com/user-attachments/assets/c74ba17c-3324-45c2-a139-da0e623fb973" />
    
## 3. 예외 케이스 - 에러코드 및 에러메시지 포함
### 썸네일 파일 누락
```
{
  "code": "BAD_REQUEST",
  "message": "썸네일 이미지는 필수입니다."
}
```

### 썸네일 파일 크기 초과
```
{
  "code": "BAD_REQUEST",
  "message": "썸네일 파일 크기는 5MB 이하만 가능합니다."
}
```

## 동영상 파일 누락
```
{
  "code": "BAD_REQUEST",
  "message": "동영상 파일은 필수입니다."
}
```

## 동영상 파일 크기 초과
```
{
  "code": "BAD_REQUEST",
  "message": "동영상 파일 크기는 500MB 이하만 가능합니다."
}
```

## S3 업로드 실패
```
{
  "code": "INTERNAL_SERVER_ERROR",
  "message": "파일 업로드 실패"
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 강의 동영상과 썸네일의 S3 저장 경로 구조를 강의/챕터 기반으로 개선
  * 강의 목록 조회 엔드포인트(/api/v1/lectures)를 공개 접근으로 허용

* **Bug Fixes**
  * 학생·비로그인 조회 흐름 통합 및 불필요한 수강 여부 표시 제거(목록 아이템에 수강 여부 미노출)

* **Tests**
  * S3 업로드 호출 시그니처 변경에 따른 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->