### PR TITLE
[PR & BUG] redis 캐싱 역직렬화 오류 해결 및 수강 STOMP 구현

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/RedisConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/RedisConfig.java
@@ -25,20 +25,20 @@ import java.util.Map;
  *  -> @Cacheable, @CacheEvict 등 캐시 어노테이션 활성화
  *  -
  *  [캐시 전략]
- *  chapter  : TTL 1시간 → 챕터 정보는 자주 바뀌지 않음
- *  chapters : TTL 1시간 → 강의 전체 챕터 목록
- *  lecture  : TTL 1시간 → 강의 정보는 자주 바뀌지 않음
+ *  chapter  : TTL 1시간 -> 챕터 정보는 자주 바뀌지 않음
+ *  chapters : TTL 1시간 -> 강의 전체 챕터 목록
+ *  lecture  : TTL 1시간 -> 강의 정보는 자주 바뀌지 않음
  *  -
  *  [왜 캐싱이 필요한가]
  *  saveProgress() 가 5~10초 주기로 호출될 때마다
- *  -> ChapterPort.findById() → DB 조회
- *  -> ChapterPort.findAllByLectureId() → DB 조회
- *  -> LecturePort.findById() → DB 조회
+ *  -> ChapterPort.findById() -> DB 조회
+ *  -> ChapterPort.findAllByLectureId() -> DB 조회
+ *  -> LecturePort.findById() -> DB 조회
  *  -> Redis 캐싱으로 DB 부하 감소
  *  -
  *  [직렬화 설정]
- *  Key   : StringRedisSerializer → 사람이 읽을 수 있는 문자열
- *  Value : GenericJackson2JsonRedisSerializer → JSON 형태로 저장
+ *  Key : StringRedisSerializer -> 사람이 읽을 수 있는 문자열
+ *  Value : GenericJackson2JsonRedisSerializer -> JSON 형태로 저장
  */
 
 // Spring 에서 캐싱 기능 활성화시키는 어노테이션
@@ -49,7 +49,7 @@ public class RedisConfig {
     /*
     * comment.
     *  RedisCacheManager : @Cacheable, @CacheEvict 등 어노테이션이 실제로 Redis 에 저장/조회/삭제하도록 연결해주는 관리자
-    *  → Spring 이 캐시 작업 시 이 Bean 을 찾아서 실행
+    *  -> Spring 이 캐시 작업 시 이 Bean 을 찾아서 실행
     * */
 
     @Bean
@@ -57,13 +57,13 @@ public class RedisConfig {
 
         /*
         * comment.
-        *  serializer : Java 객체 ↔ JSON 변환 담당
+        *  serializer : Java 객체 <-> JSON 변환 담당
         *  -> Redis 는 바이트 데이터만 저장 가능
         *  -> Java 객체를 JSON 으로 변환해서 저장, 꺼낼 때 JSON 을 Java 객체로 복원
         *  -
         *  redisObjectMapper() : activateDefaultTyping 이 설정된 ObjectMapper 사용
         *  -> 타입 정보(@class) 포함해서 저장
-        *  ->d 역직렬화 시 정확한 타입으로 복원 가능
+        *  -> 역직렬화 시 정확한 타입으로 복원 가능
         * */
 
         GenericJackson2JsonRedisSerializer serializer =

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/WebSocketConfig.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.global.infrastructure.config;
 
+import com.wanted.momocity.viewing.infrastructure.stomp.ViewingProgressChannelInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -14,6 +15,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final TopicSubscriptionInterceptor subscriptionInterceptor;
+    private final ViewingProgressChannelInterceptor viewingProgressChannelInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -34,6 +36,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         //프론트에서 들어오는 신호 길목에 인터셉터 장착
-        registration.interceptors(subscriptionInterceptor);
+        registration.interceptors(
+                subscriptionInterceptor,
+                // 수강 페이지 STOMP JWT 검증 인터셉터
+                viewingProgressChannelInterceptor
+        );
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/s3/S3PresignedUrlAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/infrastructure/s3/S3PresignedUrlAdapter.java
@@ -1,4 +1,4 @@
-package com.wanted.momocity.viewing.infrastructure.adapter;
+package com.wanted.momocity.global.infrastructure.s3;
 
 import com.wanted.momocity.viewing.application.port.S3Port;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class S3PresignedUrlAdapter implements S3Port {
 
-    // S3Presigner: AWS SDK 가 제공하는 Presigned URL 생성 전용 객체
+    // S3Presigned: AWS SDK 가 제공하는 Presigned URL 생성 전용 객체
     // S3Config 에서 Bean 으로 등록해둔 것을 주입받음
     private final S3Presigner s3Presigner;
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/policy/EnrollmentAccessPolicy.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/policy/EnrollmentAccessPolicy.java
@@ -1,13 +1,14 @@
 package com.wanted.momocity.viewing.application.policy;
 
+import com.wanted.momocity.auth.domain.model.Role;
+import com.wanted.momocity.auth.domain.model.User;
 import com.wanted.momocity.global.domain.common.exception.DomainRuleViolationException;
 import com.wanted.momocity.viewing.application.port.EnrollmentPort;
 import com.wanted.momocity.viewing.application.port.LecturePort;
+import com.wanted.momocity.viewing.application.port.UserPort;
 import com.wanted.momocity.viewing.domain.exception.ViewingAccessDeniedException;
 import com.wanted.momocity.viewing.domain.model.Lecture;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /*
@@ -26,22 +27,27 @@ public class EnrollmentAccessPolicy {
 
     private final EnrollmentPort enrollmentPort;
     private final LecturePort lecturePort;
+    private final UserPort userPort;
 
     public void ensureEnrolled(Long userId, Long lectureId) {
-        // 현재 사용자 권한 확인
-        Authentication auth = SecurityContextHolder
-                .getContext().getAuthentication();
+
+        /*
+         * SecurityContextHolder 제거
+         * → STOMP 스레드에서 SecurityContext 가 없어서 NPE 발생
+         * → userId 로 직접 DB 조회해서 role 확인하는 방식으로 변경
+         */
+        User user = userPort.findById(userId)
+                .orElseThrow(() -> new DomainRuleViolationException(
+                        "유저를 찾을 수 없습니다."
+                ));
 
         // 관리자는 모든 강의 접근 가능
-        if (auth.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
+        if (user.getRole() == Role.ADMIN) {
             return;
         }
 
         // 강사는 본인 강의 접근 가능
-        if (auth.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_INSTRUCTOR"))) {
-            // LecturePort 로 강의 조회 후 teacherId 확인
+        if (user.getRole() == Role.TEACHER) {
             Lecture lecture = lecturePort.findById(lectureId);
             if (lecture.getTeacherId().equals(userId)) return;
         }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/UserPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/port/UserPort.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.viewing.application.port;
+
+import com.wanted.momocity.auth.domain.model.User;
+
+import java.util.Optional;
+
+public interface UserPort {
+    Optional<User> findById(Long userId);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingCommandService.java
@@ -96,7 +96,7 @@ public class ViewingCommandService implements ViewingCommandUseCase {
                 ));
 
         // 완료 전 상태 저장
-        // → 이미 완료된 챕터 재시청 시 이벤트 중복 발행 방지
+        // -> 이미 완료된 챕터 재시청 시 이벤트 중복 발행 방지
         boolean wasCompleted = history.isCompleted();
 
         // 진척도 업데이트 (도메인 메서드)
@@ -114,7 +114,7 @@ public class ViewingCommandService implements ViewingCommandUseCase {
         LearningHistory savedHistory = learningHistoryRepository.save(history);
 
         // 챕터 완료 시 이벤트 발행
-        // wasCompleted = false → isCompleted = true 일 때만 발행
+        // wasCompleted = false -> isCompleted = true 일 때만 발행
         if (!wasCompleted && savedHistory.isCompleted()) {
             eventPublisher.publishEvent(new ChapterCompletedEvent(
                     command.userId(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/application/service/ViewingQueryService.java
@@ -59,7 +59,7 @@ public class ViewingQueryService implements ViewingQueryUseCase {
         }
 
         // 순차 시청 제한 (Policy)
-        sequentialAccessPolicy.ensureSequentialAccess(userId, lectureId, chapterId);  // ← 추가
+        sequentialAccessPolicy.ensureSequentialAccess(userId, lectureId, chapterId);
 
         // S3 Presigned URL 발급
         String presignedUrl = s3Port.generatePresignedUrl(chapter.getVideoUrl());

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Chapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Chapter.java
@@ -18,18 +18,17 @@ import java.io.Serializable;
 
 /*
 * Unrecognized field "playable"
-→ Chapter 에 isPlayable() 메서드가 있는데
-→ Jackson 이 getter 로 인식해서
-  "playable" 필드로 직렬화
-→ 역직렬화 시 "playable" 필드 없어서 오류
-
-isPlayable() → @Getter 때문에
-Jackson 이 playable 이라는 프로퍼티로 인식
+* -> Chapter 에 isPlayable() 메서드가 있는데
+* -> Jackson 이 getter 로 인식해서 "playable" 필드로 직렬화
+* -> 역직렬화 시 "playable" 필드 없어서 오류
+*
+* isPlayable() -> @Getter 때문에
+* Jackson 이 playable 이라는 프로퍼티로 인식
 * */
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+//@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 public class Chapter implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/LearningHistory.java
@@ -98,6 +98,7 @@ public class LearningHistory {
      *  -> 앞으로 당겨서 나간 것으로 판단
      *  -> 실제로 본 위치부터 이어보기
      */
+
     public void saveLastPosition(int lastPositionSec) {
         if (this.isCompleted) {
             // isCompleted = ture -> 나간 위치 그대로 저장

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Lecture.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/domain/model/Lecture.java
@@ -6,17 +6,6 @@ import lombok.Getter;
 
 import java.io.Serializable;
 
-/*
-* Unrecognized field "playable"
-→ Chapter 에 isPlayable() 메서드가 있는데
-→ Jackson 이 getter 로 인식해서
-  "playable" 필드로 직렬화
-→ 역직렬화 시 "playable" 필드 없어서 오류
-
-isPlayable() → @Getter 때문에
-Jackson 이 playable 이라는 프로퍼티로 인식
-* */
-
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/ChapterCatalogAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/ChapterCatalogAdapter.java
@@ -8,10 +8,9 @@ import com.wanted.momocity.lecture.infrastructure.persistence.ChapterJpaEntity;
 import com.wanted.momocity.lecture.infrastructure.persistence.SpringDataChapterRepository;
 import com.wanted.momocity.viewing.application.port.ChapterPort;
 import com.wanted.momocity.viewing.domain.model.Chapter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -26,7 +25,7 @@ import java.util.Optional;
 *  -
 *  [Redis 캐싱 전략]
  * @Cacheable("chapter")  → chapterId 기준 단건 캐싱
- * @Cacheable("chapters") → lectureId 기준 전체 챕터 목록 캐싱
+ * findAllByLectureId()   → StringRedisTemplate 직접 사용
  * -
  * 왜 캐싱이 필요한가:
  * -> saveProgress() 5~10초 주기 호출 시
@@ -43,24 +42,45 @@ import java.util.Optional;
 * [변환이 필요한 이유]
 * - ChapterJpaEntity.toDomain() → LectureChapter 반환
 * - Viewing 은 Chapter 도메인 사용
-* → 두 도메인이 다르므로 직접 변환 필요 (toChapter()로 변환)
+* -> 두 도메인이 다르므로 직접 변환 필요 (toChapter()로 변환)
 *
 * [VideoStatus 변환]
 * 팀원: com.wanted.momocity.lecture.domain.model.VideoStatus
-* 누님: Chapter.VideoStatus (내부 enum)
-* → toVideoStatus() 로 변환
+* -> Chapter.VideoStatus (내부 enum)
+* -> toVideoStatus() 로 변환
 * */
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class ChapterCatalogAdapter implements ChapterPort {
 
     // SpringDataChapterRepository 주입
-    // → JpaRepository 상속받아 findById, findAllByLectureIdOrderByOrderNoAsc 등 제공
+    // -> JpaRepository 상속받아 findById, findAllByLectureIdOrderByOrderNoAsc 등 제공
     private final SpringDataChapterRepository springDataChapterRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final ObjectMapper objectMapper;
+    /*
+     * StringRedisTemplate
+     * -> String 타입 전용 RedisTemplate
+     * -> 저장/조회 시 raw JSON 문자열 그대로 처리
+     * -> GenericJackson2JsonRedisSerializer 를 거치지 않아 @class 타입 정보 충돌 문제 없음
+     */
+    private final StringRedisTemplate stringRedisTemplate;
+    /*
+     * plainObjectMapper
+     * -> @class 타입 정보 없이 순수 JSON 으로 직렬화/역직렬화
+     * -> activateDefaultTyping 비활성화 상태
+     * -> Chapter.java 의 @JsonTypeInfo 제거와 함께 사용
+     * -> HTTP 응답 직렬화에도 영향 없음 (Spring 기본 ObjectMapper 와 별개)
+     */
+    private final ObjectMapper plainObjectMapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+
+    public ChapterCatalogAdapter(
+            SpringDataChapterRepository springDataChapterRepository,
+            StringRedisTemplate stringRedisTemplate
+    ) {
+        this.springDataChapterRepository = springDataChapterRepository;
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
 
     /*
      * comment.
@@ -88,14 +108,15 @@ public class ChapterCatalogAdapter implements ChapterPort {
     /*
      * comment.
      *  강의 전체 챕터 목록 조회
-     *  @Cacheable("chapters")
-     *  -> 처음 호출 시 강의 전체 챕터 목록 DB 조회 후 Redis 에 저장
-     *  -> 이후 호출 시 Redis 에서 반환
-     *  -> key = "chapters::1", "chapters::2" 형태로 저장
+     *  StringRedisTemplate 직접 사용
+     *  -> @Cacheable 은 List<Chapter> 역직렬화 시 GenericJackson2JsonRedisSerializer 의 @class 타입 정보와 충돌 발생
+     *  -> StringRedisTemplate 으로 raw JSON 문자열 직접 저장/조회
+     *  -> plainObjectMapper 로 순수 JSON 직렬화/역직렬화
      *  -
-     *  - RedisTemplate 직접 사용
-     *  -> List<Chapter> 역직렬화 문제 해결
-     *  -> TypeReference 로 정확한 타입 지정
+     *  - 저장 형태
+     *  -> key   : "chapters::6"
+     *  -> value : [{"id":6,"lectureId":6,"title":"변수와 타입",...}, ...]
+     *  -> TTL   : 1시간
      */
     @Override
     public List<Chapter> findAllByLectureId(Long lectureId) {
@@ -103,19 +124,20 @@ public class ChapterCatalogAdapter implements ChapterPort {
         String cacheKey = "chapters::" + lectureId;
 
         try {
-            // Redis 에서 캐시 조회
-            Object cached = redisTemplate.opsForValue().get(cacheKey);
-            if (cached != null) {
-                // TypeReference 로 List<Chapter> 정확히 변환
-                List<Chapter> chapters = objectMapper.convertValue(
-                        cached,
+            // StringRedisTemplate 으로 raw JSON 문자열 조회
+            String json = stringRedisTemplate.opsForValue().get(cacheKey);
+            if (json != null) {
+                // plainObjectMapper 로 List<Chapter> 역직렬화
+                List<Chapter> chapters = plainObjectMapper.readValue(
+                        json,
                         new TypeReference<List<Chapter>>() {}
                 );
                 log.debug("[Viewing] chapters 캐시 히트 | lectureId={}", lectureId);
                 return chapters;
             }
         } catch (Exception e) {
-            log.warn("[Viewing] chapters 캐시 조회 실패, DB 조회로 fallback | lectureId={}", lectureId);
+            log.warn("[Viewing] chapters 캐시 조회 실패, DB 조회로 fallback | lectureId={} | 예외={}",
+                    lectureId, e.getMessage());
         }
 
         // findAllByLectureIdOrderByOrderNoAsc: lectureId 기준 챕터 목록 orderNo 오름차순 조회
@@ -126,9 +148,10 @@ public class ChapterCatalogAdapter implements ChapterPort {
                 .map(this::toChapter)
                 .toList();
 
-        // Redis 에 저장 (TTL 1시간)
+        // plainObjectMapper 로 순수 JSON 직렬화 후 StringRedisTemplate 으로 저장
         try {
-            redisTemplate.opsForValue().set(cacheKey, chapters, Duration.ofHours(1));
+            String json = plainObjectMapper.writeValueAsString(chapters);
+            stringRedisTemplate.opsForValue().set(cacheKey, json, Duration.ofHours(1));
             log.debug("[Viewing] chapters 캐시 저장 | lectureId={}", lectureId);
         } catch (Exception e) {
             log.warn("[Viewing] chapters 캐시 저장 실패 | lectureId={}", lectureId);
@@ -150,7 +173,7 @@ public class ChapterCatalogAdapter implements ChapterPort {
 
     /*
      * toChapter
-     * ChapterJpaEntity → Chapter 도메인 변환
+     * ChapterJpaEntity -> Chapter 도메인 변환
      * durationSec null 가능 → 0 처리
      */
     private Chapter toChapter(ChapterJpaEntity entity) {
@@ -162,7 +185,7 @@ public class ChapterCatalogAdapter implements ChapterPort {
                 entity.getVideoUrl(),
                 // durationSec null 가능 → 0 처리
                 entity.getDurationSec() != null ? entity.getDurationSec() : 0,
-                // VideoStatus → Chapter.VideoStatus 변환
+                // VideoStatus -> Chapter.VideoStatus 변환
                 toVideoStatus(entity.getVideoStatus())
         );
     }
@@ -170,7 +193,7 @@ public class ChapterCatalogAdapter implements ChapterPort {
     /*
      * toVideoStatus
      * VideoStatus → Chapter.VideoStatus 변환
-     * → 두 enum 값 동일하지만 패키지가 달라서 직접 변환 필요
+     * -> 두 enum 값 동일하지만 패키지가 달라서 직접 변환 필요
      */
     private Chapter.VideoStatus toVideoStatus(
             VideoStatus videoStatus

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/UserCatalogAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/UserCatalogAdapter.java
@@ -1,0 +1,28 @@
+package com.wanted.momocity.viewing.infrastructure.catalog;
+
+import com.wanted.momocity.auth.domain.model.User;
+import com.wanted.momocity.auth.infrastructure.persistence.UserRepositoryAdapter;
+import com.wanted.momocity.viewing.application.port.UserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/*
+* comment.
+*  [역할]
+*  auth 컨텍스트의 User 를 Viewing 에서 READ 전용으로 조회
+*  EnrollmentAccessPolicy 에서 userId 로 role 확인 시 사용
+* */
+
+@Component
+@RequiredArgsConstructor
+public class UserCatalogAdapter implements UserPort {
+
+    private final UserRepositoryAdapter userRepositoryAdapter;
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        return userRepositoryAdapter.findById(userId);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingProgressChannelInterceptor.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingProgressChannelInterceptor.java
@@ -48,35 +48,32 @@ public class ViewingProgressChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
-        /*
-        * CONNECT 명령일 때만 JWT 검증
-        * 최초 연결 시 한 번만 검증 -> 이후 메세지는 세션에서 userId 꺼내서 사용
-        * */
 
+        // CONNECT 명령일 때만 JWT 검증
+        // 최초 연결 시 한 번만 검증 -> 이후 메세지는 세션에서 userId 꺼내서 사용
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
 
-            /*
-            * Authorization 헤더에서 JWT 추출
-            * 프론트가 STOMP CONNECT 시 헤더에 포함해서 전송 -> "Bearer {token}" 형태
-            * */
-
+            // Authorization 헤더에서 JWT 추출
+            // 프론트가 STOMP CONNECT 시 헤더에 포함해서 전송 -> "Bearer {token}" 형태
             String authHeader = accessor.getFirstNativeHeader("Authorization");
 
-            if (authHeader == null || !authHeader.startsWith("Bearer")) {
-                log.warn("[Viewing] STOMP CONNECT 실패 - Authorization 헤더 없음");
+            // "Bearer " (공백 포함) 로 시작하는지 정확히 검증
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
                 throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
             }
 
-            String token = authHeader.substring(7);
+            // "Bearer " 이후 토큰 추출
+            // -> "Bearer " 이후 토큰 추출 -> trim() 으로 공백 제거 -> 빈 토큰 여부 추가 검증
+            String token = authHeader.substring("Bearer ".length()).trim();
+            if (token.isEmpty()) {
+                throw new IllegalArgumentException("JWT 토큰이 비어 있습니다.");
+            }
 
             // JWT 검증 -> 유효하지 않으면 예외 발생 -> 연결 거부
             jwtTokenProvider.validateToken(token);
 
-            /*
-            * userId 세션에 저장 -> getAuthentication() 으로 CustomUSerDetails 추출
-            * -> userId 를 세션 attributes 에 저장 -> 이후 @MessageMApping 에서 꺼내서 사용
-            * */
-
+            // userId 세션에 저장 -> getAuthentication() 으로 CustomUSerDetails 추출
+            // -> userId 를 세션 attributes 에 저장 -> 이후 @MessageMApping 에서 꺼내서 사용
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
             Long userId = userDetails.getUserId();

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingProgressChannelInterceptor.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingProgressChannelInterceptor.java
@@ -1,0 +1,95 @@
+package com.wanted.momocity.viewing.infrastructure.stomp;
+
+import com.wanted.momocity.auth.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/*
+* comment.
+*  [역할]
+*  STOMP CONNECT 시점에 JWT 검증 후 userId 를 세션에 저장
+*  -
+*  [흐름]
+*  프론트 -> STOMP CONNECT (헤더에 JWT 포함) -> preSend() 에서 CONNECT 명령 감지
+*  -> Authorization 헤더에서 JWT 추출 -> JwtTokenProvider 로 검증
+*  -> userId 를 세션에 저장 -> 이후 @MessageMApping 에서 세션에서 userId 꺼내서 사용
+*  -
+*  [ChannelInterceptor 사용 이유]
+*  STOMP 메세지가 채널을 통해 전달되기 전에 가로채서 처리
+*  HTTP 필터와 동일한 역할을 STOMP 에서 담당
+* */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewingProgressChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    // preSend : 메세지가 채널로 전송되기 전에 호출
+    // -> CONNECT 명령일 때만 JWT 검증 수행 -> 나머지 명령 (SEND, SUBSCRIBE) 은 그냥 통과
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(
+                message, StompHeaderAccessor.class
+        );
+
+        if (accessor == null) {
+            return message;
+        }
+
+        /*
+        * CONNECT 명령일 때만 JWT 검증
+        * 최초 연결 시 한 번만 검증 -> 이후 메세지는 세션에서 userId 꺼내서 사용
+        * */
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+
+            /*
+            * Authorization 헤더에서 JWT 추출
+            * 프론트가 STOMP CONNECT 시 헤더에 포함해서 전송 -> "Bearer {token}" 형태
+            * */
+
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+            if (authHeader == null || !authHeader.startsWith("Bearer")) {
+                log.warn("[Viewing] STOMP CONNECT 실패 - Authorization 헤더 없음");
+                throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
+            }
+
+            String token = authHeader.substring(7);
+
+            // JWT 검증 -> 유효하지 않으면 예외 발생 -> 연결 거부
+            jwtTokenProvider.validateToken(token);
+
+            /*
+            * userId 세션에 저장 -> getAuthentication() 으로 CustomUSerDetails 추출
+            * -> userId 를 세션 attributes 에 저장 -> 이후 @MessageMApping 에서 꺼내서 사용
+            * */
+
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            Long userId = userDetails.getUserId();
+
+            accessor.getSessionAttributes().put("userId", userId);
+            accessor.setUser(authentication);
+
+            log.debug("[Viewing] STOMP CONNECT 성공 | userId={}, sessionId={}",
+                    userId, accessor.getSessionId());
+
+        }
+        return message;
+
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingSessionDisconnectHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingSessionDisconnectHandler.java
@@ -1,0 +1,71 @@
+package com.wanted.momocity.viewing.infrastructure.stomp;
+
+import com.wanted.momocity.viewing.application.command.SaveProgressCommand;
+import com.wanted.momocity.viewing.application.usecase.ViewingCommandUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewingSessionDisconnectHandler {
+
+    private final ViewingSessionRegistry sessionRegistry;
+    private final ViewingCommandUseCase viewingCommandUseCase;
+    // @EventListener(SessionDisconenectEvent.class)
+    // STOMP 연결 끊김 시 자동 호출 -> SessionDisconnectEvent 에서 SessionId 추출
+    @EventListener
+    public void handleDisconnect (SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+
+        // getAndRemove
+        // 세션 정보 꺼내고 삭제 -> null 이면 진척도 저장 없이 종료 (영상 재생 없이 연결만 끊긴 경우)
+        ViewingSessionRegistry.ViewingSessionInfo info
+                = sessionRegistry.getAndRemove(sessionId);
+
+        if (info == null) {
+            log.debug("[Viewing] 세션 정보 없음, lastPositionSec 저장 생략 | sessionId={}", sessionId);
+            return;
+        }
+
+        log.info("[Viewing] STOMP 연결 끊김 감지 | sessionId={}, userId={}, chapterId={}, lastPlaybackSeconds={}",
+        sessionId, info.userId(), info.chapterId(), info.lastPlaybackSeconds());
+
+        try {
+
+            /*
+            * lastPositionSec 저장
+            * 마지막으로 받은 playbackSeconds 를 lastPositionSec 으로 전달
+            * ViewingCommandService 내부에서 isCompleted 여부에 따라 저장 분기 처리
+            * */
+
+            viewingCommandUseCase.handle(
+                    new SaveProgressCommand(
+                    info.userId(),
+                    info.lectureId(),
+                    info.chapterId(),
+                    // playbackSeconds = 진척도 업데이트
+                    info.lastPlaybackSeconds(),
+                    // lastPositionSec = 이어보기 위치 저장용
+                    info.lastPlaybackSeconds()
+            ));
+
+            log.info("[Viewing] lastPositionSec 저장 완료 | userId={}, chapterId={}, lastPositionSec={}",
+                    info.userId(), info.chapterId(), info.lastPlaybackSeconds());
+
+        } catch (Exception e) {
+
+            /*
+            * 연결 끊김 시 저장 실패는 치명적이지 않음
+            * -> 예외 발생해도 서버 장애로 이어지지 않도록 catch
+            * -> 로그만 남기고 계속 진행
+            * */
+
+            log.warn("[Viewing] lastPositionSec 저장 실패 | userId={}, chapterId={} | 예외={}",
+                    info.userId(), info.chapterId(), e.getMessage());
+        }
+}
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingSessionDisconnectHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingSessionDisconnectHandler.java
@@ -36,12 +36,9 @@ public class ViewingSessionDisconnectHandler {
 
         try {
 
-            /*
-            * lastPositionSec 저장
-            * 마지막으로 받은 playbackSeconds 를 lastPositionSec 으로 전달
-            * ViewingCommandService 내부에서 isCompleted 여부에 따라 저장 분기 처리
-            * */
-
+            // lastPositionSec 저장
+            // 마지막으로 받은 playbackSeconds 를 lastPositionSec 으로 전달
+            // ViewingCommandService 내부에서 isCompleted 여부에 따라 저장 분기 처리
             viewingCommandUseCase.handle(
                     new SaveProgressCommand(
                     info.userId(),
@@ -58,12 +55,9 @@ public class ViewingSessionDisconnectHandler {
 
         } catch (Exception e) {
 
-            /*
-            * 연결 끊김 시 저장 실패는 치명적이지 않음
-            * -> 예외 발생해도 서버 장애로 이어지지 않도록 catch
-            * -> 로그만 남기고 계속 진행
-            * */
-
+            // 연결 끊김 시 저장 실패는 치명적이지 않음
+            // -> 예외 발생해도 서버 장애로 이어지지 않도록 catch
+            // -> 로그만 남기고 계속 진행
             log.warn("[Viewing] lastPositionSec 저장 실패 | userId={}, chapterId={} | 예외={}",
                     info.userId(), info.chapterId(), e.getMessage());
         }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingSessionRegistry.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/stomp/ViewingSessionRegistry.java
@@ -1,0 +1,57 @@
+package com.wanted.momocity.viewing.infrastructure.stomp;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+* comment.
+*  [역할]
+*  STOMP 세션 별 마지막 재생 상태를 메모리에 저장
+*  -> 연결 끊김 시 lastPositionSec 저장에 사용
+*  -
+*  [저장 구조]
+*  sessionId -> ViewingSessionInfo (userId, lectureId, chapterId, lastPlaybackSeconds)
+*  -
+*  [ConcurrentHashMap 사용 이유]
+*  - 다중 사용자가 동시에 접근 -> thread-safe 자료구조 필요
+*  -> HashMap 은 thread-safe 하지 않아 동시성 문제 발생 가능
+* */
+
+@Slf4j
+@Component
+public class ViewingSessionRegistry {
+
+    // ConcurrentHashMap
+    // key : STOMP 세션 ID (연결마다 고유)
+    // value : 세션 정보 (userId, lectureId, chapterId, lastPlaybackSeconds)
+    private final ConcurrentHashMap<String, ViewingSessionInfo> sessionMap
+            = new ConcurrentHashMap<>();
+
+    // saveOrUpdate : STOMP 메세지 수신 시마다 호출 -> 세션 정보 저장 또는 업데이트
+    public void saveOrUpdate(String sessionId, Long userId, Long lectureId,
+                             Long chapterId, int playbackSeconds) {
+        sessionMap.put(sessionId, new ViewingSessionInfo(
+                userId, lectureId, chapterId, playbackSeconds
+        ));
+        log.debug("[Viewing] 세션 정보 업데이트 | sessionId={}, userId={}, chapterId={}, playbackSeconds={}",
+                sessionId, userId, chapterId, playbackSeconds);
+    }
+
+    // getAndRemove : 연결 끊김 시 호출 -> 세션 정보 꺼내고 삭제
+    public ViewingSessionInfo getAndRemove(String sessionId) {
+        ViewingSessionInfo info = sessionMap.remove(sessionId);
+        log.debug("[Viewing] 세션 정보 제거 | sessionId={}, info={}",
+                sessionId, info);
+        return info;
+    }
+
+    // ViewingSessionInfo : 세션별 저장 데이터 -> Record 로 불변 객체 설계
+    public record ViewingSessionInfo(
+            Long userId,
+            Long lectureId,
+            Long chapterId,
+            int lastPlaybackSeconds
+    ) {}
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/ViewingController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/ViewingController.java
@@ -51,7 +51,6 @@ public class ViewingController {
 
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -78,7 +77,6 @@ public class ViewingController {
 
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -108,7 +106,6 @@ public class ViewingController {
 
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -161,7 +158,6 @@ public class ViewingController {
 
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -188,7 +184,6 @@ public class ViewingController {
 
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -214,7 +209,6 @@ public class ViewingController {
 
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -238,7 +232,6 @@ public class ViewingController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
-//        Long userId = 1L;
         Long userId = userDetails.getUserId();
 
         return ResponseEntity.ok(ApiResponse.success(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterProgressResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/response/ChapterProgressResponse.java
@@ -21,7 +21,7 @@ public record ChapterProgressResponse(
      *  -> 실제로 본 최대 위치
      *  -> 뒤로 감기 시 감소 없음
      *  -> 앞으로 당기기 10초 초과 시 반영 안 함
-     *  ->durationSec 초과 불가 (Math.min 처리)
+     *  -> durationSec 초과 불가 (Math.min 처리)
      *  -
      *  progressRate:
      *  -> watchedSeconds / durationSec * 100

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/stomp/ViewingProgressMessage.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/stomp/ViewingProgressMessage.java
@@ -1,0 +1,34 @@
+package com.wanted.momocity.viewing.presentation.api.stomp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/*
+* comment.
+*  [역할]
+*  - 프론트 -> 서버로 STOMP 메세지로 전송되는 진척도 데이터 DTO
+*  -
+*  [record 사용 이윺]
+*  - HTTP Request DTO 와 동일하게 불변 객체로 설계
+*  - Jackson 역직렬화를 위해 기본 생성자 필요 → @JsonCreator 로 처리
+* */
+
+public record ViewingProgressMessage (
+        Long lectureId,
+        Long chapterId,
+        int playbackSeconds
+){
+    // Jackson 이 JSON -> Record 역직렬화 시 사용할 사용자 명시
+    // -> record 는 기본 생성자가 없어서 명시하지 않으면 역직렬화 실패
+    @JsonCreator
+    public ViewingProgressMessage(
+            // JSON 필드명과 파라미터명 매핑
+            @JsonProperty("lectureId") Long lectureId,
+            @JsonProperty("chapterId") Long chapterId,
+            @JsonProperty("playbackSeconds") int playbackSeconds
+    ) {
+        this.lectureId = lectureId;
+        this.chapterId = chapterId;
+        this.playbackSeconds = playbackSeconds;
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/stomp/ViewingStompController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/stomp/ViewingStompController.java
@@ -47,12 +47,26 @@ public class ViewingStompController {
         // STOMP 연결마다 고유한 세션 ID -> 연결 끊김 이벤트에서 세션 정보 꺼낼 때 사용
         String sessionId = headerAccessor.getSessionId();
 
-        // userId
-        // STOMP CONNECT 시점에 JWT 검증 후 세션에 저장한 값 -> HeadAccessor 로 꺼냄
-        Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
+        // sessionAttributes null 체크 -> getSessionAttributes() 자체가 null 이면 NPE 발생
+        // -> STOMP 세션이 정상적으로 맺어지지 않은 경우 방어
+        if (headerAccessor.getSessionAttributes() == null) {
+            log.warn("[Viewing] STOMP 메시지 수신 실패 - sessionAttributes 없음 | sessionId={}", sessionId);
+            return;
+        }
 
-        if (userId == null) {
-            log.warn("[Viewing] STOMP 메시지 수신 실패 - userId 없음 | sessionId={}", sessionId);
+        // userId 타입 안전하게 추출 -> instanceof 패턴 매칭으러 타입 불일치 방어
+        // -> null 이거나 Long 이 아니면 경고 로그 후 종료
+        Object rawUserId = headerAccessor.getSessionAttributes().get("userId");
+        if (!(rawUserId instanceof Long userId)) {
+            log.warn("[Viewing] STOMP 메시지 수신 실패 - userId 없음/타입 불일치 | sessionId={}", sessionId);
+            return;
+        }
+
+        // payload 검증 -> lectureId, chapterId null 체크
+        // -> playbackSeconds 음수 방어 -> 잘못된 데이터가 저장 경로로 넘어가지 않도록 차단
+        if (message.lectureId() == null || message.chapterId() == null || message.playbackSeconds() < 0) {
+            log.warn("[Viewing] STOMP 메시지 수신 실패 - 잘못된 payload | sessionId={}, lectureId={}, chapterId={}, playbackSeconds={}",
+                    sessionId, message.lectureId(), message.chapterId(), message.playbackSeconds());
             return;
         }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/stomp/ViewingStompController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/presentation/api/stomp/ViewingStompController.java
@@ -1,0 +1,83 @@
+package com.wanted.momocity.viewing.presentation.api.stomp;
+
+import com.wanted.momocity.viewing.application.command.SaveProgressCommand;
+import com.wanted.momocity.viewing.application.usecase.ViewingCommandUseCase;
+import com.wanted.momocity.viewing.infrastructure.stomp.ViewingSessionRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Controller;
+
+/*
+* comment.
+*  [역할]
+*  STOMP 메세지를 받아서 진척도 저장 UseCase 호출
+*  -
+*  [흐름]
+*  프론트 -> /pub/viewing/progress 로 메세지 전송
+*  -> @MessageMapping("/viewing/progress") 에서 수신
+*  -> ViewingSessionRegistry 에 세션 정보 업데이트
+*  -> ViewingCommandUseCase.handle() 호출
+*  -
+*  [@RestController 사용 이유]
+*  - STOMP 핸들러는 HTTP 응답을 반환하지 않음
+*  - @Restcontroller 는 HTTP 응답 전용
+*  - @Controller 로 선언해야 @MessageMapping 이 정상 동작
+* */
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ViewingStompController {
+
+    private final ViewingCommandUseCase viewingCommandUseCase;
+    private final ViewingSessionRegistry sessionRegistry;
+
+    // @MessageMapping("/viewing/progress")
+    // WebSocketConfig 에서 설정한 /pub prefix 포함 -> 실제 destination: /pub/viewing/progress
+    @MessageMapping("/viewing/progress")
+    public void handleProgress(
+            ViewingProgressMessage message,
+            // SimpMessageHeaderAccessor
+            // STOMP 메시지 헤더에서 sessionId, userId 추출 -> HandshakeInterceptor 에서 세션에 저장한 userId 를 꺼냄
+            SimpMessageHeaderAccessor headerAccessor
+    ) {
+        // sessionId
+        // STOMP 연결마다 고유한 세션 ID -> 연결 끊김 이벤트에서 세션 정보 꺼낼 때 사용
+        String sessionId = headerAccessor.getSessionId();
+
+        // userId
+        // STOMP CONNECT 시점에 JWT 검증 후 세션에 저장한 값 -> HeadAccessor 로 꺼냄
+        Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
+
+        if (userId == null) {
+            log.warn("[Viewing] STOMP 메시지 수신 실패 - userId 없음 | sessionId={}", sessionId);
+            return;
+        }
+
+        log.debug("[Viewing] STOMP 진척도 메시지 수신 | sessionId={}, userId={}, chapterId={}, playbackSeconds={}",
+                sessionId, userId, message.chapterId(), message.playbackSeconds());
+
+        // 세션 정보 업데이트 -> 연결 끊김 시 lastPositionSec 저장에 사용
+        sessionRegistry.saveOrUpdate(
+                sessionId,
+                userId,
+                message.lectureId(),
+                message.chapterId(),
+                message.playbackSeconds()
+        );
+
+        // 진척도 저장 UseCase 호출 -> 기존 HTTP 방식과 동일한 로직 재사용
+        viewingCommandUseCase.handle(new SaveProgressCommand(
+                userId,
+                message.lectureId(),
+                message.chapterId(),
+                message.playbackSeconds(),
+                // lastPositionSec 연결 끊김 시 별도 저장
+                null
+        ));
+
+    }
+
+}


### PR DESCRIPTION
최종 api 명세 내용 작성
---
## 📥 Request

`PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}/progress`

**Headers** (필요 시)

```
PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}/progress
Content-Type: application/json
Authorization: Bearer {access_token}
```

**Body**

```json
{
  "lectureId": 6,
   "chapterId": 6,
  "playbackSeconds": 360
}
```

<img width="412" height="320" alt="스크린샷 2026-06-15 12 46 18" src="https://github.com/user-attachments/assets/77a21ea8-6992-4ef9-81be-cb9c58810b66" />

---
### 어떤 기능을 구현했는지
Redis 캐싱 역직렬화 오류 해결
수강 페이지 STOMP 구현
<img width="1038" height="742" alt="스크린샷 2026-06-15 12 42 30" src="https://github.com/user-attachments/assets/91fbee45-91d8-4348-90c7-b3200b8d7133" />
---
### postman 검증 결과 화면
restAPI 변화 없음
추후 작업
---
체크리스트 형식으로 추후 진행예정 작업 명시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 웹소켓(STOMP) 기반 실시간 강의 재생 진척도 전송 기능 추가
  * 세션 종료 시 자동으로 진척도를 저장
  * 이어보기 진척도 복구/갱신 흐름 강화

* **Bug Fixes**
  * 인증 주체 기반으로 사용자 식별값을 정확히 사용하도록 수정
  * 수강/시청 권한 판단을 역할 및 수강 여부 기준으로 정교화

* **Chores**
  * 주석/문서 표기 및 캐싱 처리 방식 관련 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->