### PR TITLE
[PR] 밤티 알림 기능 (임수영)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserCommandService.java
@@ -95,4 +95,11 @@ public class UserCommandService implements UserCommandUsecase {
         log.info("[teacher] 강사 반려 처리 | userId={} | reason={}", command.userId(), command.reason());
         return new TeacherActionResult(command.userId(), "REJECTED", command.reason(), LocalDateTime.now());
     }
+
+
+    // 밤티 알림 설정
+    @Override
+    public boolean setAlarm(Long userId) {
+       return userRepository.setAlarm(userId);
+    }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserCommandUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserCommandUsecase.java
@@ -19,6 +19,9 @@ public interface UserCommandUsecase {
     // 강사 거절 처리
     TeacherActionResult reject(RejectTeacherCommand command);
 
+    // 밤티 알림 설정
+    boolean setAlarm(Long userId);
+
     /**
      * 승인/반려 처리 결과.
      * status: ACTIVE (승인) 또는 REJECTED (반려)

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/exception/UserExceptionHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/exception/UserExceptionHandler.java
@@ -52,4 +52,15 @@ public class UserExceptionHandler {
                 ));
     }
 
+    // 사용자를 찾지 못했을 때
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleUserNotFoundException(UserNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.NOT_FOUND.value(),
+                        "USER_NOT_FOUND",
+                        e.getMessage()
+                ));
+    }
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/exception/UserNotFoundException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.wanted.momocity.user.domain.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
@@ -49,4 +49,6 @@ public interface UserRepository {
 
     long countForAdmin(Role role, Status status);
 
+    // 밤티 알림 설정
+    boolean setAlarm(Long userId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -94,7 +94,7 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
     // 밤티 알림 설정
     // 기존에 true 이면 false로
     // 기존에 false면 true로
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE UserUser u SET u.doNotDisturb = CASE " +
             "WHEN u.doNotDisturb = true " +
             "THEN false " +

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -90,4 +90,15 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
             @Param("role") Role role,
             @Param("status") Status status
     );
+
+    // 밤티 알림 설정
+    // 기존에 true 이면 false로
+    // 기존에 false면 true로
+    @Modifying
+    @Query("UPDATE UserUser u SET u.doNotDisturb = CASE " +
+            "WHEN u.doNotDisturb = true " +
+            "THEN false " +
+            "ELSE true END WHERE u.id = :userId")
+    void setAlarm(@Param("userId") Long userId);
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.wanted.momocity.user.infrastructure.persistence;
 
 import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
+import com.wanted.momocity.user.domain.exception.UserNotFoundException;
 import com.wanted.momocity.user.domain.model.Role;
 import com.wanted.momocity.user.domain.model.Status;
 import com.wanted.momocity.user.domain.model.TeacherApplication;
@@ -107,6 +108,15 @@ public class UserRepositoryAdapter implements UserRepository {
         return springDataUserRepository.countForAdmin(role, status);
     }
 
+
+    // 밤티 알림 설정
+    @Override
+    public boolean setAlarm(Long userId) {
+        springDataUserRepository.setAlarm(userId);
+        return springDataUserRepository.findById(userId)
+                .map(UserJpaEntity::isDoNotDisturb)
+                .orElse(false);
+    }
 
 
     // 마이페이지 내 정보 조회용

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -115,7 +115,7 @@ public class UserRepositoryAdapter implements UserRepository {
         springDataUserRepository.setAlarm(userId);
         return springDataUserRepository.findById(userId)
                 .map(UserJpaEntity::isDoNotDisturb)
-                .orElse(false);
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
     }
 
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/user")
 @Tag(name="User - 사용자 정보 관리", description = "user 정보를 다루기 위한 User api 관련 컨트롤러")
 public class UserController {
 
@@ -38,7 +38,7 @@ public class UserController {
     private final RedisRefreshTokenPort redisRefreshTokenPort;
 
 
-    @GetMapping("/user/detail")
+    @GetMapping("/detail")
     @Operation(
             summary = "회원 1명의 정보 조회",
             description = "마이페이지에서 사용자에게 제시될 정보 조회"
@@ -59,7 +59,7 @@ public class UserController {
     }
 
 
-    @PatchMapping("/user/register/nickname")
+    @PatchMapping("/register/nickname")
     @Operation(summary = "사용자의 닉네임 등록을 위한 api")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 등록 성공"),
@@ -82,7 +82,7 @@ public class UserController {
     }
 
 
-    @PatchMapping("/user/update")
+    @PatchMapping("/update")
     @Operation(summary = "사용자 정보 수정",
             description = "프로필 이미지(모듈4부터), 닉네임, 비밀번호 변경 가능")
     @ApiResponses({
@@ -122,7 +122,7 @@ public class UserController {
                 ));
     }
 
-    @PostMapping("/user/nickname/check")
+    @PostMapping("/nickname/check")
     @Operation(summary = "닉네임 중복 확인")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용 가능한 닉네임"),
@@ -142,7 +142,7 @@ public class UserController {
                 ));
     }
 
-    @GetMapping("/users")
+    @GetMapping("/list")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(
             summary = "관리자 회원 목록 조회",

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
@@ -142,6 +142,30 @@ public class UserController {
                 ));
     }
 
+
+    @PatchMapping("/settings/alarm")
+    @Operation(summary = "알림 설정",
+                description = "do_not_disturb 칼럼 활용해서 기존에 true명 false로, false면 true로 변경한다,")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    public ResponseEntity<ApiResponse<AlarmSetResponse>> setAlarm(
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        boolean do_not_disturb = userCommandUsecase.setAlarm(userDetails.getUserId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(
+                        UserResponseCode.SUCCESS,
+                        UserResponseMessage.USER_INFO_UPDATE_SUCCESS,
+                        new AlarmSetResponse(do_not_disturb)
+                ));
+    }
+
+
+
     @GetMapping("/list")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/AlarmSetResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/AlarmSetResponse.java
@@ -1,0 +1,6 @@
+package com.wanted.momocity.user.presentation.api.response;
+
+public record AlarmSetResponse(
+        boolean do_not_disturb
+) {
+}


### PR DESCRIPTION
#323 

---
## 밤티 알림 설정 api : api/v1/user/settings/alarm 
- (디폴트는 방해금지 off = 알림켜져 있는 상태 = do_not_disturb : 0)
### 📥 Request

**Headers** 

```
Authorization: Bearer {accessToken}
```

---

### 📤 Response

### ✅ 200 OK — 성공

<aside>

기존에 true → false로 
기존에 fasle → true 

response에 담기는 boolean값은 변경 후의 값 = 현재 상태 

</aside>

```json
{
    "timestamp": "2026-06-11T11:40:53.1094623",
    "status": 200,
    "code": "SUCCESS",
    "message": "정보가 수정되었습니다. ",
    "data": {
        "do_not_disturb": false
    }
}
```

### ❌ 실패 — (401) - 토큰 이슈

```json
{
    "timestamp": "2026-06-11T11:50:31.164933100",
    "status": 401,
    "code": "UNAUTHORIZED",
    "message": "다시 로그인해 주세요."
}
```


### ❌ 실패 —  사용자를 찾지 못 했을 때?

이거는 404 띄야하는데 애초에 토큰 인증이 먼저 선행되는 기능이라 뺐습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 야간 방해 금지(알림) 설정 기능을 추가했으며, `PATCH /settings/alarm`으로 알림 수신 상태를 변경할 수 있습니다.
  * 변경 결과는 `do_not_disturb`로 응답됩니다.

* **개선 사항**
  * 사용자 관련 API 엔드포인트 경로가 `/api/v1/user` 기준으로 재정렬되었습니다(예: 관리자 목록 조회 `GET /list`).
  * 사용자를 찾지 못하는 경우 404 응답과 표준 에러 코드로 처리하도록 오류 처리가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->