### PR TITLE
[REFACTOR] ACTIVE 아닐 때 닉네임 가공 수정(rabbit) & notification 행 추가 수정(서정림) (#313, #324) 

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/application/service/FriendCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/application/service/FriendCommandService.java
@@ -66,10 +66,9 @@ public class FriendCommandService implements FriendCommandUseCase {
 
         //알림 도메인을 위한 이벤트 발행
         eventPublisher.publishEvent(new RequestFriendPublishedEvent(
-                loginUser.getId(),
+                loginUser.getId(), //refId 용도
                 loginUser.getNickname(),
-                targetUser.getId(),
-                savedRelation.getId() //ref_id 용도로 friend_id 추가
+                targetUser.getId() //userId에 해당
         ));
         log.info("[RequestFriendCommandService] friend 행 추가 완료 및 비동기 알림 유도 이벤트 발행 성공(ref_id: {})", savedRelation.getId());
 
@@ -123,7 +122,10 @@ public class FriendCommandService implements FriendCommandUseCase {
 
         //notification에 들어간 행 삭제를 위한 이벤트 발행
         UserWithFMJpaEntity loginUser = friendRepository.findUserById(command.userId()).orElseThrow();
-        eventPublisher.publishEvent(new CancelRequestFriendPublishedEvent(relation.getId()));
+        eventPublisher.publishEvent(new CancelRequestFriendPublishedEvent(
+                loginUser.getId(), //refId가 로그인 유저
+                targetUser.getId() //userId가 상대방(요청 받는 사람)
+        ));
 
         //응답 주머니 조립하여 컨트롤러로 반환
         return new CancelRequestFriendView(
@@ -168,9 +170,9 @@ public class FriendCommandService implements FriendCommandUseCase {
 
         //이벤트 발행
         eventPublisher.publishEvent(new AcceptRequestFriendPublishedEvent(
-                loginUser.getId(),
-                loginUser.getNickname(),
-                relation.getId() //알림 내역 추적용
+                loginUser.getId(), //수락한 사람
+                loginUser.getNickname(), //수락한 사람
+                fromUser.getId() //알림 내역 추적용(먼저 요청 보낸 사람)
         ));
         log.info("[AcceptRequestFriendCommandService] 친구 수락 알림 유도 이벤트 발행 성공 - 수신 대상 유저ID: {}", fromUser.getId());
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/domain/event/AcceptRequestFriendPublishedEvent.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/domain/event/AcceptRequestFriendPublishedEvent.java
@@ -1,8 +1,8 @@
 package com.wanted.momocity.friend.domain.event;
 
 public record AcceptRequestFriendPublishedEvent(
-        Long triggerUserId,
-        String acceptorNickname, //수학한 사람의 닉네임(알림 행: "acceptorNIckname과 친구가 되었습니다.")
-        Long friendId //알림 추적용
+        Long acceptorUserId, //수락한 사람
+        String acceptorNickname, //수락한 사람의 닉네임(알림 행: "acceptorNIckname과 친구가 되었습니다.")
+        Long fromUserId //refId(먼저 요청 보낸 사람)
 ) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/domain/event/CancelRequestFriendPublishedEvent.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/domain/event/CancelRequestFriendPublishedEvent.java
@@ -1,6 +1,7 @@
 package com.wanted.momocity.friend.domain.event;
 
 public record CancelRequestFriendPublishedEvent(
-        Long friendId //요청 시 들어간 friend 테이블의 행 ID
+        Long fromUserId, //요청 시 들어간 요청자 아이디
+        Long toUserId
 ) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/domain/event/RequestFriendPublishedEvent.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/domain/event/RequestFriendPublishedEvent.java
@@ -1,9 +1,8 @@
 package com.wanted.momocity.friend.domain.event;
 
 public record RequestFriendPublishedEvent(
-        Long fromUserId,
+        Long fromUserId, //notification 테이블의 refId
         String fromUserNickname,
-        Long toUserId,
-        Long friendId //알림 테이블의 ref_id로 매핑될 고유 ID
+        Long toUserId //notification 테이블의 userId
 ) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/BlockedFriendResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/BlockedFriendResponse.java
@@ -12,9 +12,10 @@ public record BlockedFriendResponse(
     public static BlockedFriendResponse from(BlockedView view) {
         //ACTIVE가 아니면 (알 수 없음)
         String displayNickname = view.nickname();
-        if (view.isNotActive()) {
-            displayNickname += "(알 수 없음)";
-        }
+//        if (view.isNotActive()) {
+//            displayNickname += "(알 수 없음)";
+//        }
+        //user 담당자가 알 수 없음 가공해서 주기 때문에 주석처리
 
         return new BlockedFriendResponse(
                 view.userId(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/FindUserResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/FindUserResponse.java
@@ -10,8 +10,8 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL) //null일 때 json 미출력
 public record FindUserResponse(
         @Schema(description = "유저 ID", example = "3")Long userId,
-        String nickname,
         String name,
+        String nickname,
         String status,
         String role,
         String lectureTitle,

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/FindUserResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/FindUserResponse.java
@@ -21,9 +21,10 @@ public record FindUserResponse(
     public static FindUserResponse from(FindView view) {
         //비활성 유저 닉네임 가공
         String displayNickname = view.nickname();
-        if (view.isNotActive()) {
+        if (!view.isNotActive() && !"FRIEND".equals(view.status())) {
             displayNickname += "(알 수 없음)";
         }
+        //user 담당자가 ACTIVE가 아닌 건 알 수 없음 가공 처리하기 때문에 ACTIVE이면서 친구가 아닌 경우에 알 수 없음 가공
 
         //강의명 가공
         String finalLectureTitle = null;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/ReceivedRequestResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/ReceivedRequestResponse.java
@@ -12,9 +12,10 @@ public record ReceivedRequestResponse(
     public static ReceivedRequestResponse from(ReceivedRequestView view) {
         //비활성 유저 닉네임 가공
         String displayNickname = view.nickname();
-        if (view.isNotActive()) {
-            displayNickname += "(알 수 없음)";
-        }
+//        if (view.isNotActive()) {
+//            displayNickname += "(알 수 없음)";
+//        }
+        //user 담당자가 가공해서 주석처리함
 
         return new ReceivedRequestResponse(
                 view.userId(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/SentRequestResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/friend/presentation/api/response/SentRequestResponse.java
@@ -13,9 +13,10 @@ public record SentRequestResponse(
         //ACTIVE 아니면 (알 수 없음) 가공
         //비활성 유저 닉네임 가공
         String displayNickname = view.nickname();
-        if (view.isNotActive()) {
-            displayNickname += "(알 수 없음)";
-        }
+//        if (view.isNotActive()) {
+//            displayNickname += "(알 수 없음)";
+//        }
+        //user 담당자가 가공해서 주석처리함
 
         return new SentRequestResponse(
                 view.userId(),

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/policy/MessageEligibilityPolicy.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/policy/MessageEligibilityPolicy.java
@@ -27,20 +27,20 @@ public class MessageEligibilityPolicy {
 
     //유저 상태, 친구 상태, 역할을 종합하여 (알 수 없음) 가공 여부를 판별하는 규칙
     public boolean determineNotActive(UserWithFMJpaEntity targetUser, String friendStatus, Long loginUserId) {
-        //나와의 채팅인 경우 무조건 ACTIVE
+        //나와의 채팅인 경우 무조건 가공 대상 아님
         if (targetUser.getId().equals(loginUserId)) {
             return false;
         }
 
         //상대방이 강사인 경우: user 테이블의 ACTIVE 확인
+        //v2 -> 강사인 경우 친구 관계 변동 없으므로 가공 대상 아님
         if ("TEACHER".equals(targetUser.getRole())) {
-            return !"ACTIVE".equals(targetUser.getStatus());
+            return false;
         }
 
         //상대방이 학생인 경우: user 테이블의 ACTIVE 확인, friend 테이블의 status(BLOCK, none) 확인
-        return !"ACTIVE".equals(targetUser.getStatus())
-                || "BLOCK".equals(friendStatus)
-                || "none".equals(friendStatus);
+        //v2 -> 비활성 여부에 대한 가공은 user담당자가 처리하므로 친구 여부만 검증
+        return "BLOCK".equals(friendStatus) || "none".equals(friendStatus);
     }
 
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageHandlerService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageHandlerService.java
@@ -27,6 +27,7 @@ public class MessageHandlerService {
     private final SpringDataMessageRepository springDataMessageRepository;
 
     //회원가입 성공 후 날라온 이벤트로 나와의 채팅방 최초 1회 생성
+    //v2 -> 결제 완료 시 나와의 채팅방 생성으로 변경?
     public void createSelfChatRoom(Long userId) {
         log.info("[MessageHandlerService] 나와의 채팅방 개설 시작 - 대상 유저ID: {}", userId);
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageQueryService.java
@@ -370,8 +370,8 @@ public class MessageQueryService implements MessageQueryUseCase {
                     null,                                          // createdAt -> null
                     true,
                     false,
-                    true, //채팅방 나감 여부
-                    false,
+                    isLeftRoom, //채팅방 나감 여부
+                    shouldMasked,
                     targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl()
             ));
         } else {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageQueryService.java
@@ -135,14 +135,13 @@ public class MessageQueryService implements MessageQueryUseCase {
 
             //만약 진짜 나와의 채팅이 아닌데 targetUser가 loginUser라면
             //상대방이 나간 방이므료 무조건 (알 수 없음) 처리하기
-            boolean isNotActive;
-            if (isLeftRoom) {
-                isNotActive = true; //상대방이 나갔으므로 (알 수 없음) 띄우기 위함
-            } else {
+            //🚨 v2 -> 일대일 채팅의 경우를 고려해 memberInfo에 데이터 가공 필요.
+            boolean shouldMasked = false;
+            if (targetUser != null){
                 //BLOCK 상태이면 BLOCK으로 넘기되 (알 수 없음)으로 가공하기 위해 연동 준비
                 //서비스 레이어는 비활성화 상태 여부만 체크
                 //정책 클래스에 위임
-                isNotActive = messageEligibilityPolicy.determineNotActive(targetUser, friendStatus,userId);
+                shouldMasked = messageEligibilityPolicy.determineNotActive(targetUser, friendStatus,userId);
             }
 
             //강의명 추출 (나와의 채팅이 아닐 때만)
@@ -193,7 +192,9 @@ public class MessageQueryService implements MessageQueryUseCase {
                     targetUser != null ? targetUser.getNickname() : null, // ◀️ null로 들어감
                     targetUser != null ? targetUser.getRole() : "STUDENT",
                     friendStatus,
-                    isNotActive, //비활성 여부(user 테이블)
+                    targetUser != null && !"ACTIVE".equals(targetUser.getStatus()), //비활성 여부(user 테이블)
+                    shouldMasked,
+                    isLeftRoom,
                     roomId,
                     lastContent,
                     lastChattedAt,
@@ -311,13 +312,9 @@ public class MessageQueryService implements MessageQueryUseCase {
         }
 
         // 4. 활성화 여부 정책 판별
-        boolean isNotActive;
-        if (isLeftRoom) {
-            isNotActive = true;
-        } else if (targetUser != null) {
-            isNotActive = messageEligibilityPolicy.determineNotActive(targetUser, friendStatus, userId);
-        } else {
-            isNotActive = false;
+        boolean shouldMasked = false;
+        if (targetUser != null) {
+            shouldMasked = messageEligibilityPolicy.determineNotActive(targetUser, friendStatus, userId);
         }
 
         // 5. 강의명 리스트 추출
@@ -367,13 +364,14 @@ public class MessageQueryService implements MessageQueryUseCase {
                     targetUser != null ? targetUser.getNickname() : loginUser.getNickname(),
                     targetUser != null ? targetUser.getRole() : loginUser.getRole(),
                     friendStatus,
-                    isNotActive,
+                    targetUser != null && !"ACTIVE".equals(targetUser.getStatus()),
                     lectureTitleList,
                     null,                                          // content -> null
                     null,                                          // createdAt -> null
                     true,
                     false,
                     true, //채팅방 나감 여부
+                    false,
                     targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl()
             ));
         } else {
@@ -386,13 +384,14 @@ public class MessageQueryService implements MessageQueryUseCase {
                         msg.getSenderId().getNickname(),
                         msg.getSenderId().getRole(), //역할
                         friendStatus, //친구 상태
-                        isNotActive,
+                        targetUser != null && !"ACTIVE".equals(targetUser.getStatus()),
                         lectureTitleList,
                         msg.getContent(), // 🎯 빠져있던 본문 추가!
                         msg.getCreatedAt(),
                         true, // 과거 내역은 무조건 다 읽음 처리
                         isMine,
                         isLeftRoom,
+                        shouldMasked,
                         targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl()
                 ));
             }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/service/MessageQueryService.java
@@ -373,6 +373,7 @@ public class MessageQueryService implements MessageQueryUseCase {
                     null,                                          // createdAt -> null
                     true,
                     false,
+                    true, //채팅방 나감 여부
                     targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl()
             ));
         } else {
@@ -391,6 +392,7 @@ public class MessageQueryService implements MessageQueryUseCase {
                         msg.getCreatedAt(),
                         true, // 과거 내역은 무조건 다 읽음 처리
                         isMine,
+                        isLeftRoom,
                         targetUser != null ? targetUser.getProfileImageUrl() : loginUser.getProfileImageUrl()
                 ));
             }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/usecase/MessageQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/usecase/MessageQueryUseCase.java
@@ -39,6 +39,7 @@ public interface MessageQueryUseCase {
             LocalDateTime createdAt,
             boolean isRead,
             boolean isMine,
+            boolean isLeftRoom,
             String profileImageUrl
     ) {}
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/application/usecase/MessageQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/application/usecase/MessageQueryUseCase.java
@@ -15,6 +15,8 @@ public interface MessageQueryUseCase {
             String role,
             String status, //친구 상태
             Boolean isNotActive, //ACTIVE아닌 것
+            boolean shouldMasked,
+            boolean isLeftRoom,
             Long roomId, //채팅방 번호
             String content, //마지막 채팅 내역
             LocalDateTime createdAt, //마지막 채팅 시각
@@ -40,6 +42,7 @@ public interface MessageQueryUseCase {
             boolean isRead,
             boolean isMine,
             boolean isLeftRoom,
+            boolean shouldMasked,
             String profileImageUrl
     ) {}
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/FindChatRoomResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/FindChatRoomResponse.java
@@ -6,6 +6,7 @@ import com.wanted.momocity.message.application.usecase.MessageQueryUseCase.ChatR
 import java.time.LocalDateTime;
 import java.util.List;
 
+//채팅방 목록
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record FindChatRoomResponse(
         Long userId,
@@ -21,6 +22,7 @@ public record FindChatRoomResponse(
         String profileImageUrl
 ) {
     public static FindChatRoomResponse from(ChatRoomView view) {
+        //🚨다대다에서 roomInfo, memberInfo로 줄 땐 닉네임 가공X(메시지 내역에서 가공)
         //ACTIVE아니면 (알 수 없음) 가공
         String displayNickname = (view.nickname() != null) ? view.nickname() : "";
         String finalLectureTitle = null;
@@ -28,15 +30,20 @@ public record FindChatRoomResponse(
         //나와의 채팅 가공
         if ("me".equals(view.status())) {
             displayNickname = "나와의 채팅" + "(" + displayNickname + ")";
-        } else if (view.isNotActive()) {
-            //원래 닉네임이 있었다면 "홍길동(알 수 없음)", null이었다면 그냥 "(알 수 없음)"이 됩니다!
-            if (displayNickname.isEmpty()) {
-                displayNickname = "(알 수 없음)";
-            } else {
-                //ACTIVE가 아니거나 차단 혹은 친구 삭제 상태일 때
-                displayNickname += "(알 수 없음)";
-            }
+            //ACTIVE이면서 친구가 아닌 경우
         }
+//         else if (!view.isNotActive() && !"FRIEND".equals(view.status())) {
+//            //나간 채팅방 처리
+//            //원래 닉네임이 있었다면 "홍길동(알 수 없음)", null이었다면 그냥 "(알 수 없음)"이 됩니다!
+//            if (displayNickname.isEmpty()) {
+//                displayNickname = "(알 수 없음)";
+//            } else {
+//                //ACTIVE가 아니거나 차단 혹은 친구 삭제 상태일 때
+//                //->v2 변경: ACTIVE이면서 친구가 아닐 때
+//                displayNickname += "(알 수 없음)";
+//            }
+//        }
+        //채팅방 목록 조회에선 memberInfo에 가공없이 그대로의 상태를 전달해야 하므로 닉네임 가공 로직 주석 처리
 
         List<String> lectureTitle = view.lectureTitle();
         if (lectureTitle != null && !lectureTitle.isEmpty()) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/FindChatRoomResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/FindChatRoomResponse.java
@@ -32,17 +32,17 @@ public record FindChatRoomResponse(
             displayNickname = "나와의 채팅" + "(" + displayNickname + ")";
             //ACTIVE이면서 친구가 아닌 경우
         }
-//         else if (!view.isNotActive() && !"FRIEND".equals(view.status())) {
-//            //나간 채팅방 처리
-//            //원래 닉네임이 있었다면 "홍길동(알 수 없음)", null이었다면 그냥 "(알 수 없음)"이 됩니다!
-//            if (displayNickname.isEmpty()) {
-//                displayNickname = "(알 수 없음)";
-//            } else {
-//                //ACTIVE가 아니거나 차단 혹은 친구 삭제 상태일 때
-//                //->v2 변경: ACTIVE이면서 친구가 아닐 때
-//                displayNickname += "(알 수 없음)";
-//            }
-//        }
+         else if (!view.isNotActive() && (view.shouldMasked() || displayNickname.isEmpty() || view.isLeftRoom())) {
+            //나간 채팅방 처리
+            //원래 닉네임이 있었다면 "홍길동(알 수 없음)", null이었다면 그냥 "(알 수 없음)"이 됩니다!
+            if (displayNickname.isEmpty()) {
+                displayNickname = "(알 수 없음)";
+            } else {
+                //ACTIVE가 아니거나 차단 혹은 친구 삭제 상태일 때
+                //->v2 변경: ACTIVE이면서 친구가 아닐 때
+                displayNickname += "(알 수 없음)";
+            }
+        }
         //채팅방 목록 조회에선 memberInfo에 가공없이 그대로의 상태를 전달해야 하므로 닉네임 가공 로직 주석 처리
 
         List<String> lectureTitle = view.lectureTitle();

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/FindChatRoomResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/FindChatRoomResponse.java
@@ -23,6 +23,7 @@ public record FindChatRoomResponse(
 ) {
     public static FindChatRoomResponse from(ChatRoomView view) {
         //🚨다대다에서 roomInfo, memberInfo로 줄 땐 닉네임 가공X(메시지 내역에서 가공)
+        //v2 -> 일대일의 경우도 있으므로 가공해야함
         //ACTIVE아니면 (알 수 없음) 가공
         String displayNickname = (view.nickname() != null) ? view.nickname() : "";
         String finalLectureTitle = null;
@@ -43,7 +44,6 @@ public record FindChatRoomResponse(
                 displayNickname += "(알 수 없음)";
             }
         }
-        //채팅방 목록 조회에선 memberInfo에 가공없이 그대로의 상태를 전달해야 하므로 닉네임 가공 로직 주석 처리
 
         List<String> lectureTitle = view.lectureTitle();
         if (lectureTitle != null && !lectureTitle.isEmpty()) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
@@ -10,22 +10,6 @@ import java.util.List;
 public record GetMessageHistoryResponse(
         RoomInfo roomInfo,
         List<MessageDetail> messages
-//        Long messageId,
-//        Long senderId,
-//        String name,
-//        String nickname,
-//        String lectureTitle,
-//        String role,
-//        String status,
-//        String content,
-//        LocalDateTime createdAt,
-//        boolean isRead,
-//        boolean isMine,
-//        String profileImageUrl,
-//        String notMeTargetName,
-//        String notMeNickname,
-//        String notMeRole,
-//        String notMeLectureTitle
 ) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record RoomInfo(
@@ -34,7 +18,8 @@ public record GetMessageHistoryResponse(
             String targetRole,
             String targetName,
             String targetLectureTitle,
-            String targetProfileImageUrl
+            String targetProfileImageUrl,
+            boolean isLeftRoom
     ) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -50,6 +35,7 @@ public record GetMessageHistoryResponse(
             LocalDateTime createdAt,
             boolean isRead,
             boolean isMine,
+            boolean isLeftRoom,
             String profileImageUrl
     ) {}
 
@@ -64,13 +50,25 @@ public record GetMessageHistoryResponse(
 
         // 상대방이 보낸 말풍선 가공 규칙 적용
         if ("me".equals(view.status())) {
-            displayNickname = "나와의 채팅" + "(" + displayNickname + ")";
+//            displayNickname = "나와의 채팅" + "(" + displayNickname + ")";
+            //v2 -> 채팅방 이름을 띄울 것이므로 나와의 채팅 가공 필요 없음
         } else if (view.isMine()) {
             // 내가 보낸 메시지인 경우 마스킹 정책에서 제외하고 내 닉네임 그대로 유지
             displayNickname = view.nickname();
-        } else if (view.isNotActive()) {
+        }
+        if (!"me".equals(view.status()) && !view.isMine()) {
+            //내가 쓴 글이나 나와의 채팅이 아닌, 상대방 메시지 가공
+            if (!view.isNotActive() && (!"FRIEND".equals(view.status()) || displayNickname.isEmpty() || view.isLeftRoom())) {
                 // ACTIVE가 아니거나 차단, 친구 삭제(none) 상태일 때 "(알 수 없음)" 결합
-                displayNickname += "(알 수 없음)";
+                // v2-> ACTIVE이면서 친구가 아니거나 채팅방 나간 경우 가공
+                if (displayNickname.isEmpty()) {
+                    //상대 식별 불가면 (알 수 없음)
+                    displayNickname = "(알 수 없음)";
+                } else {
+                    //상대 식별 가능하면 닉네임(알 수 없음)
+                    displayNickname += "(알 수 없음)";
+                }
+            }
         }
 
 
@@ -79,27 +77,6 @@ public record GetMessageHistoryResponse(
         if (lectureTitle != null && !lectureTitle.isEmpty()) {
             finalLectureTitle = "(" + String.join(", ", lectureTitle) + ")";
         }
-
-//        String responseNotMeTargetName = null;
-//        String responseNotMeNickname = null;
-//        String responseNotMeRole = null;
-//        String responseNotMeLectureTitle= null;
-
-//        if (view.isMine()) {
-//            responseNotMeRole = view.notMeRole(); // 상대방의 Role (STUDENT or TEACHER)
-//
-//            // 💡 [정책 분기] 상대방이 강사(TEACHER)인 경우: 이름과 닉네임 둘 다 노출
-//            if ("TEACHER".equals(view.notMeRole())) {
-//                responseNotMeTargetName = view.notMeTargetName(); // 강사 실제 성함
-//                responseNotMeNickname = view.notMeNickname();     // 강사 닉네임
-//                responseNotMeLectureTitle = finalLectureTitle;
-//            }
-//            // 💡 [정책 분기] 상대방이 학생(STUDENT)인 경우: 이름 노출 차단(null), 닉네임만 노출
-//            else if ("STUDENT".equals(view.notMeRole())) {
-//                responseNotMeTargetName = null;                   // 학생 이름은 프라이버시로 인해 절대 숨김!
-//                responseNotMeNickname = view.notMeNickname();     // 학생 닉네임만 허용
-//            }
-//        }
 
         return new MessageDetail(
                 view.messageId(),
@@ -113,6 +90,7 @@ public record GetMessageHistoryResponse(
                 view.createdAt(), // T 문자열 그대로 노출
                 view.isRead(),    // true
                 view.isMine(),
+                view.isLeftRoom(),
                 view.profileImageUrl()
         );
     }).toList();
@@ -123,6 +101,7 @@ public record GetMessageHistoryResponse(
         String targetName = null;
         String targetLectureTitle = null;
         String targetProfileImageUrl = null;
+        boolean isLeftRoom = false;
 
         if (!views.isEmpty()) {
             MessageHistoryView ref = views.get(0); // 데이터 파이프라인에서 추출
@@ -142,7 +121,7 @@ public record GetMessageHistoryResponse(
             }
         }
 
-        RoomInfo roomInfo = new RoomInfo(roomId, targetNickname, targetRole, targetName, targetLectureTitle, targetProfileImageUrl);
+        RoomInfo roomInfo = new RoomInfo(roomId, targetNickname, targetRole, targetName, targetLectureTitle, targetProfileImageUrl, isLeftRoom);
         return new GetMessageHistoryResponse(roomInfo, detailList);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
@@ -107,6 +107,7 @@ public record GetMessageHistoryResponse(
             MessageHistoryView ref = views.get(0); // 데이터 파이프라인에서 추출
             targetRole = ref.role();
             targetProfileImageUrl = ref.profileImageUrl();
+            isLeftRoom = ref.isLeftRoom(); // view에서 isLeftRoom 추출
 
             if ("TEACHER".equals(ref.role())) {
                 targetName = ref.name();

--- a/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/message/presentation/api/response/GetMessageHistoryResponse.java
@@ -58,7 +58,7 @@ public record GetMessageHistoryResponse(
         }
         if (!"me".equals(view.status()) && !view.isMine()) {
             //내가 쓴 글이나 나와의 채팅이 아닌, 상대방 메시지 가공
-            if (!view.isNotActive() && (!"FRIEND".equals(view.status()) || displayNickname.isEmpty() || view.isLeftRoom())) {
+            if (!view.isNotActive() && (view.shouldMasked() || displayNickname.isEmpty() || view.isLeftRoom())) {
                 // ACTIVE가 아니거나 차단, 친구 삭제(none) 상태일 때 "(알 수 없음)" 결합
                 // v2-> ACTIVE이면서 친구가 아니거나 채팅방 나간 경우 가공
                 if (displayNickname.isEmpty()) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/application/service/NotificationHandlerService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/application/service/NotificationHandlerService.java
@@ -24,14 +24,14 @@ public class NotificationHandlerService {
     /**
      * 친구 요청 알림 생성 및 저장 비즈니스 로직
      */
-    public void createAndSaveFriendRequestNotification(Long toUserId, String fromUserNickname, Long friendId) {
+    public void createAndSaveFriendRequestNotification(Long toUserId, String fromUserNickname, Long fromUserId) {
         log.info("[NotificationHandlerService] 알림 비즈니스 로직 시작 - 대상자 ID: {}", toUserId);
 
         //알림 메시지 조립
         String message = String.format("%s님이 친구 요청을 보냈습니다.", fromUserNickname);
 
         //순수한 도메인 모델 직접 탄생시킴
-        Notification newNotification = Notification.createFriendRequest(toUserId, message, friendId);
+        Notification newNotification = Notification.createFriendRequest(toUserId, message, fromUserId);
 
         //도메인 규격 리포지토리를 통해 저장 수행
         Notification saved = notificationRepository.save(newNotification);
@@ -39,22 +39,22 @@ public class NotificationHandlerService {
     }
 
     //친구 요청 철회 시 친구 요청으로 들어간 notification 행 삭제
-    public void deleteRequestFriendNotification(Long refId) {
-        log.info("[NotificationHandlerService] 친구 요청 철회로 인한 알림 삭제 시도 - refId: {}", refId);
+    public void deleteRequestFriendNotification(Long fromUserId, Long toUserId) {
+        log.info("[NotificationHandlerService] 친구 요청 철회로 인한 알림 삭제 시도 - 철회 요청자: {}", fromUserId);
 
         //"FRIEND_REQUEST" 타입이면서 refId가 일치하면 삭제
-        notificationRepository.deleteByRefIdAndType(refId, "FRIEND_REQUEST");
+        notificationRepository.deleteByRefIdAndUserId_IdAndType(fromUserId, toUserId, "FRIEND_REQUEST");
     }
 
     //친구 요청 수락(상태 변경 SENT -> FRIEND)
-    public void createAndSaveFriendAcceptNotification(Long triggerUserId, String acceptorNickname, Long friendId) {
-        log.info("[NotificationHandlerService] 친구 수락 알림 처리 시작 - 행위 유발자ID: {}, 연결고리friendId: {}", triggerUserId, friendId);
+    public void createAndSaveFriendAcceptNotification(Long acceptorUserId, String acceptorNickname, Long fromUserId) {
+        log.info("[NotificationHandlerService] 친구 수락 알림 처리 시작 - 행위 유발자ID: {}, 요청자ID: {}", acceptorUserId, fromUserId);
 
         //메시지 조립
         String message = String.format("%s님과 친구가 되었습니다. 교류를 시작해보세요!", acceptorNickname);
 
         //순수한 도메인 모델 생성
-        Notification newNotification = Notification.createFriendAccept(triggerUserId, message, friendId);
+        Notification newNotification = Notification.createFriendAccept(acceptorUserId, message, fromUserId);
 
         //레포지토리를 통해 알림 저장
         Notification saved = notificationRepository.save(newNotification);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/domain/model/Notification.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/domain/model/Notification.java
@@ -26,9 +26,9 @@ public class Notification {
     public static Notification createFriendAccept(Long acceptorUserId, String message, Long fromUserId) {
         return new Notification(
                 null,
-                acceptorUserId,
-                "FRIEND_REQUEST",
                 fromUserId,
+                "FRIEND_REQUEST",
+                acceptorUserId,
                 message);
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/domain/model/Notification.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/domain/model/Notification.java
@@ -23,12 +23,12 @@ public class Notification {
     }
 
     //친구 요청 수락
-    public static Notification createFriendAccept(Long triggerUserId, String message, Long friendId) {
+    public static Notification createFriendAccept(Long acceptorUserId, String message, Long fromUserId) {
         return new Notification(
                 null,
-                triggerUserId,
+                acceptorUserId,
                 "FRIEND_REQUEST",
-                friendId,
+                fromUserId,
                 message);
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/domain/repository/NotificationRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/domain/repository/NotificationRepository.java
@@ -10,7 +10,7 @@ public interface NotificationRepository {
     Notification save(Notification notification);
 
     //친구 요청 철회
-    void deleteByRefIdAndType(Long refId, String type);
+    void deleteByRefIdAndUserId_IdAndType(Long refId, Long userId, String type);
 
     //메시지 전송 - 기존 알림 존재 여부 확인(채팅방 번호, 타입, 보낸 사람 아이디)
     Optional<Notification> findByRefIdAndTypeAndUserId_Id(Long roomId, String message, Long senderId);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/infrastructure/catalog/CatalogNotificationRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/infrastructure/catalog/CatalogNotificationRepositoryAdapter.java
@@ -43,11 +43,11 @@ public class CatalogNotificationRepositoryAdapter implements NotificationReposit
     //친구 요청 철회
     @Override
     @Transactional
-    public void deleteByRefIdAndType(Long refId, String type) {
+    public void deleteByRefIdAndUserId_IdAndType(Long refId, Long userId, String type) {
         log.info("[CatalogNotificationRepositoryAdapter] notification 테이블 행 영구 삭제 시도 - refId: {}, type: {}",
                 refId, type);
 
-        springDataNotificationRepository.deleteByRefIdAndType(refId, type);
+        springDataNotificationRepository.deleteByRefIdAndUserId_IdAndType(refId, userId, type);
 
         log.info("[CatalogNotificationRepositoryAdapter] notification 테이블 행 삭제 완료");
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/infrastructure/event/NotificationLifecycleEventHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/infrastructure/event/NotificationLifecycleEventHandler.java
@@ -27,9 +27,9 @@ public class NotificationLifecycleEventHandler {
         log.info("[NotificationLifeCycleEventHandler] 친구 요청 이벤트 수신 -> 서비스로 이동");
         //서비스로 던기지
         notificationHandlerService.createAndSaveFriendRequestNotification(
-                event.toUserId(),
+                event.toUserId(), //userId에 넣기(알림 받는 사람)
                 event.fromUserNickname(),
-                event.friendId() //ref_id 용도
+                event.fromUserId() //ref_id 용도(알림 발생시킨 사람)
         );
     }
 
@@ -40,7 +40,10 @@ public class NotificationLifecycleEventHandler {
         log.info("[NotificationLifecycleEventHandler] 친구 요청 철회 이벤트 수신 -> 알림 서비스로 이동");
 
         //주입받은 알림 서비스로 토스
-        notificationHandlerService.deleteRequestFriendNotification(event.friendId());
+        notificationHandlerService.deleteRequestFriendNotification(
+                event.fromUserId(), //refId 요청자
+                event.toUserId() //userId 대상자
+        );
     }
 
     //친구 요청 수락 완료 후 발행된 이벤트 처리 (요청한 사람에게 친구 완료 알림 저장)
@@ -50,9 +53,9 @@ public class NotificationLifecycleEventHandler {
         log.info("[NotificationLifecycleEventHandler] 친구 요청 수락 이벤트 수신 -> 알림 서비스로 이동");
 
         notificationHandlerService.createAndSaveFriendAcceptNotification(
-                event.triggerUserId(), //알림을 일으킨 사람
+                event.acceptorUserId(), //수락한 사람
                 event.acceptorNickname(), //문구에 들어갈 수락자 닉네임
-                event.friendId() //refId용
+                event.fromUserId() //refId용
         );
 
     }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/notification/infrastructure/persistence/SpringDataNotificationRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/notification/infrastructure/persistence/SpringDataNotificationRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 public interface SpringDataNotificationRepository extends JpaRepository<NotificationJpaEntity, Long> {
 
     //친구 요청 철회
-    void deleteByRefIdAndType(Long refId, String type);
+    void deleteByRefIdAndUserId_IdAndType(Long refId, Long userId, String type);
 
     //메시지 전송
     Optional<NotificationJpaEntity> findByRefIdAndTypeAndUserId_Id(Long refId, String type, Long userId);


### PR DESCRIPTION
친구 목록 관련 ACTIVE 아닐 때 (알 수 없음) 주석 처리.(모듈4 기능 개발하면 수정) 
메시지 조회 관련 ACTIVE 아닐 때 (알 수 없음) 수정.(ACTIVE이면서 친구 아니거나 채팅방 나갔을 때 (알 수 없음).
=>rabbit 주의사항 수정

notification 행 추가 친구 관련 수정
-친구 요청(요청자 아이디: refId, 대상자 아이디: userId)
-친구 요청 철회(위의 사항 바탕으로 삭제)
-친구 요청 수락(수락자 아이디: refId, 기존 요청자 아이디: userId)
=> 메시지 관련 기능 제외 notification 테이블의 userId는 알림을 받을 사람

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 메시지/채팅방 및 요청 응답 화면에서 비활성 닉네임 마스킹과 “알 수 없음” 표시 기준이 더 정교해졌습니다.
  * 교사/학생 대상 상황에 따라 닉네임 처리 및 마스킹 판정이 일관되게 적용됩니다.

* **New Features**
  * 메시지 히스토리 응답에 채팅방 나감 여부 정보가 추가되었습니다.

* **Refactor**
  * 친구 요청/수락/철회 알림의 대상 매칭과 삭제 범위가 개선되어 알림 처리 정확도가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->