### PR TITLE
[REFACT/INFRA]  S3 파일 구조 수정 및 포트 번호 혼선으로 인한 docker yaml 수정

### DIFF
--- a/legend-momo-city/docker-compose.yml
+++ b/legend-momo-city/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     image: mysql:8.0
     container_name: momo-mysql
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: 1234
-      MYSQL_DATABASE: momo
+      MYSQL_DATABASE: legend_momocity
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
@@ -41,7 +41,7 @@ services:
     image: grafana/grafana:latest
     container_name: momo-grafana
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: admin
     volumes:

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/LectureController.java
@@ -111,7 +111,7 @@ public class LectureController {
         request.validateCategory();
         request.validateThumbnailSize();
 
-        String thumbnailUrl = s3UploadPort.upload(request.thumbnail(), "lectuers/");
+        String thumbnailUrl = s3UploadPort.upload(request.thumbnail(), "lectuers");
 
         LectureAggregate lecture = lectureCommandUseCase.createLecture(
                 request.toCommand(teacherId, thumbnailUrl)


### PR DESCRIPTION
1. 기존 String thumbnailUrl = s3UploadPort.upload(request.thumbnail(), "lectuers/"); 에서
lectures/ <- 이거는 맞는 표현이 아니라 오류가 날 수 있어 / 제거

2. 포트 혼선으로 인한 코드 수정
1) 기존 3306으로 하게 되면 오류 3307:3306 으로 수정
2) 윈도우로 설치된 Grafana 서비스로 인한 3000으로 했을 때 오류 발생 -> 3001로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **설정 변경**
  * MySQL 서비스 포트가 3306에서 3307로 변경되었습니다.
  * Grafana 서비스 포트가 3000에서 3001로 변경되었습니다.
  * MySQL 데이터베이스명이 업데이트되었습니다.

* **개선 사항**
  * 강의 썸네일 업로드 처리가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->