### PR TITLE
[REFACT] 회원/비회원 토큰 주입 시 값 변경 수정

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -70,23 +70,41 @@ public class LectureQueryService implements
     @Override
     public StudentLecturePageResponse getLectures(GetLecturesQuery query) {
 
-        /* comment
-        *   학생 강의 목록은 비로그인/로그인 모두 ACTIVE 강의 전체 조회
-        *   로그인한 학생 정보는 목록 필터링에서 사용하지 않고, 진행률 표시용으로만 사용한다.
-        * */
+        /*
+         * comment
+         * 비회원은 전체 ACTIVE 강의 목록을 조회한다.
+         * 학생 회원은 본인이 수강 신청한 ACTIVE 강의 목록만 조회한다.
+         * category, keyword, page, size 조건은 두 경우 모두 동일하게 적용된다.
+         */
+        boolean enrolledOnly = query.userId() != null;
         Long studentId = null;
+        List<Long> enrolledLectureIds = List.of();
 
-        if (query.userId() != null) {
+        if (enrolledOnly) {
             studentId = studentAccountPort.getStudentId(query.userId());
+
+            enrolledLectureIds = lectureEnrollmentQueryPort.findLectureIdsByUserId(studentId);
+
+            /*
+             * comment
+             * 로그인한 학생이 수강 신청한 강의가 없으면 빈 페이지를 반환한다.
+             */
+            if (enrolledLectureIds.isEmpty()) {
+                return new StudentLecturePageResponse(
+                        List.of(),
+                        query.page(),
+                        query.size(),
+                        0,
+                        0
+                );
+            }
         }
 
         var lecturePage = lectureRepository.findLectures(
                 query.category(),
                 query.keyword(),
-
-                // 전체 조회 API 이므로 수강 여부로 강의 목록을 필터링 X
-                false,
-                List.of(),
+                enrolledOnly,
+                enrolledLectureIds,
                 query.page(),
                 query.size()
         );
@@ -260,6 +278,7 @@ public class LectureQueryService implements
     }
 
     // 학생 강의 목록용 응답 객체로 변환
+    // 학생 강의 목록용 응답 객체로 변환
     private StudentLectureListItemResponse toStudentListItemResponse(
             LectureAggregate lecture,
             Long studentId
@@ -270,15 +289,18 @@ public class LectureQueryService implements
         // 현재 강의의 전체 챕터 수를 조회
         int chapterCount = chapterRepository.countByLectureId(lecture.getId());
 
+        /*
+         * comment
+         * 비회원 또는 미수강 강의는 진행 정보가 없으므로 null로 둔다.
+         * @JsonInclude(JsonInclude.Include.NON_NULL)에 의해 JSON 응답에서 제외된다.
+         */
         Integer totalProgress = null;
         Boolean isCompleted = null;
 
         var progress = studentId == null
                 ? java.util.Optional.<LectureEnrollmentQueryPort.EnrollmentProgress>empty()
-                // 수강 중인지 확인하고 수강 중이면 진행률을 가지고 와라
                 : lectureEnrollmentQueryPort.findByUserIdAndLectureId(studentId, lecture.getId());
 
-        // 수강 정보가 있으면 실행
         if (progress.isPresent()) {
             totalProgress = progress.get().totalProgress();
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/service/LectureQueryService.java
@@ -294,7 +294,7 @@ public class LectureQueryService implements
          * 비회원 또는 미수강 강의는 진행 정보가 없으므로 null로 둔다.
          * @JsonInclude(JsonInclude.Include.NON_NULL)에 의해 JSON 응답에서 제외된다.
          */
-        Integer totalProgress = null;
+        Integer lectureProgress = null;
         Boolean isCompleted = null;
 
         var progress = studentId == null
@@ -302,7 +302,7 @@ public class LectureQueryService implements
                 : lectureEnrollmentQueryPort.findByUserIdAndLectureId(studentId, lecture.getId());
 
         if (progress.isPresent()) {
-            totalProgress = progress.get().totalProgress();
+            lectureProgress = progress.get().totalProgress();
 
             // 완료 여부는 전체 챕터 수와 완료 챕터 수를 기준으로 판단
             isCompleted = chapterCount > 0 && progress.get().completedCount() >= chapterCount;
@@ -312,7 +312,7 @@ public class LectureQueryService implements
                 lecture,
                 averageRating,
                 reviewCount,
-                totalProgress,
+                lectureProgress,
                 isCompleted,
                 chapterCount
         );

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/presentation/api/response/StudentLectureResponse.java
@@ -149,7 +149,7 @@ public class StudentLectureResponse {
             *   로그인한 학생이 해당 강의 수강 중이면 enrollment 진행률을 내려준다.(강의 총 진척도)
             *   비로그인 또는 미수강 강의면 0으로 내려준다
             * */
-            Integer totalProgress,
+            Integer lectureProgress,
 
             /* comment
             *   로그인 한 학생이 해당 강의를 완료했는지 여부 확인
@@ -168,7 +168,7 @@ public class StudentLectureResponse {
                 LectureAggregate lecture,
                 double averageRating,
                 int reviewCount,
-                Integer totalProgress,
+                Integer lectureProgress,
                 Boolean isCompleted,
                 int chapterCount
         ) {
@@ -181,7 +181,7 @@ public class StudentLectureResponse {
                     lecture.getStatus().name(),
                     averageRating,
                     reviewCount,
-                    totalProgress,
+                    lectureProgress,
                     isCompleted,
                     chapterCount,
                     lecture.getCreatedAt()


### PR DESCRIPTION
기존 방식은 비회원/회원 토큰이 없을 경우에는 전체 강의 목록 출력
토큰이 있는 경우 전체 강의에서 회원이 듣는 강의도 출력하는 것

BUT 완전히 잘못 된 방식

비회원/회원 토큰이 없는 경우에는 모든 강의 출력이 맞지만. 토큰을 주입했을 경우 회원이 듣고 있는 강의만 출력으로 재구현

1. 비회원 (토큰 X)
<img width="613" height="479" alt="image" src="https://github.com/user-attachments/assets/af34d471-5209-4082-b083-488111224c5b" />

2. 회원 (토큰 주입 시)
<img width="632" height="487" alt="image" src="https://github.com/user-attachments/assets/f430d68d-f0fc-44ed-a75f-6e25a36832f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 로그인 여부에 따라 학생 강의 목록 조회 범위를 정확히 분기하도록 개선
  * 수강 신청 상태를 반영해 강의 목록 필터링이 올바르게 동작하도록 수정
  * 미로그인/미수강 케이스에서 진행값이 일관되게 비어 있는 형태로 반환

* **Refactor**
  * 강의 진척도 응답 필드를 `totalProgress` → `lectureProgress`로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->