### PR TITLE
[REFACTOR] Report 도메인 status → isRead 단순화

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/port/ReportStatsPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/admin/application/port/ReportStatsPort.java
@@ -1,18 +1,8 @@
 package com.wanted.momocity.admin.application.port;
 
-/* comment.
-    ReportStatsPort 정리
-    1. 역할 : admin BC 가 report BC 의 신고 통계를 가져오기 위한 외부 BC 접근 계약
-    2. 위치 : admin/application/port (응용 계층 - 외부 BC 접근 인터페이스)
-    3. WHY Port 패턴 사용 (직접 의존 X)
-       → admin BC 는 report BC 의 내부 구현을 모름 (BC 격리)
-       → MemberStatsPort / LectureStatsPort 와 동일 패턴 → BC 정합성
-    4. WHY countAll 단일 메서드
-       → 대시보드 위젯이 필요한 정보는 "전체 신고 수" 하나
-       → 추가 통계 필요 시 메서드 확장 (예: countByStatus)
- */
 public interface ReportStatsPort {
 
-    /** 전체 신고 수 (대시보드 통계용) */
+    // 전체 신고 수 (대시보드 통계 용)
     long countAll();
+
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/service/ReportQueryService.java
@@ -1,7 +1,6 @@
 package com.wanted.momocity.report.application.service;
 
 import com.wanted.momocity.report.application.usecase.ReportQueryUseCase;
-import com.wanted.momocity.report.domain.model.ReportStatus;
 import com.wanted.momocity.report.domain.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
        - 트랜잭션 : Command 는 쓰기(@Transactional), Query 는 읽기(@Transactional(readOnly = true))
     6. 메서드 2개 처리 흐름
        a) getRecent(limit) : repository.findRecent(limit) 호출 → List<Report> 받음 → ReportList 로 감싸 반환
-       b) getByStatus(status, limit) : repository.findByStatus(status, limit) 호출 → 동일하게 감싸 반환
+       b) getByIsRead(isRead, limit) : repository.findByIsRead(isRead, limit) 호출 → 동일하게 감싸 반환
  */
 @Service
 @RequiredArgsConstructor
@@ -37,7 +36,7 @@ public class ReportQueryService implements ReportQueryUseCase {
     }
 
     @Override
-    public ReportList getByStatus(ReportStatus status, int limit) {
-        return new ReportList(reportRepository.findByStatus(status, limit));
+    public ReportList getByIsRead(boolean isRead, int limit) {
+        return new ReportList(reportRepository.findByIsRead(isRead, limit));
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/application/usecase/ReportQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/application/usecase/ReportQueryUseCase.java
@@ -1,8 +1,6 @@
 package com.wanted.momocity.report.application.usecase;
 
 import com.wanted.momocity.report.domain.model.Report;
-import com.wanted.momocity.report.domain.model.ReportStatus;
-
 import java.util.List;
 
 /* comment.
@@ -13,9 +11,9 @@ import java.util.List;
         Query: 데이터 조회 → 읽기 전용 트랜잭션 (@Transactional(readOnly = true))
         Command: 데이터 변경 → 쓰기 트랜잭션
         CQRS 경량 적용 → 책임/트랜잭션 정책 분리
-    4. WHY 메서드 2개 (getRecent + getByStatus)
-        getRecent : 전체 최근 N개 (status 필터 없음)
-        getByStatus : 특정 상태(예: PENDING) 의 최근 N개
+    4. WHY 메서드 2개 (getRecent + getByIsRead)
+        getRecent : 전체 최근 N개 (읽음 여부 필터 없음)
+        getByIsRead : 읽음 여부 기준 최근 N개 (false=미읽음, true=읽음)
     5. WHY ReportList record 를 내부에 두는가
         UseCase 의 출력 계약을 같은 파일에 두면 한눈에 파악
         ErrorLogQueryUseCase 의 ErrorLogList 와 동일 패턴
@@ -28,7 +26,7 @@ public interface ReportQueryUseCase {
 
     ReportList getRecent(int limit);
 
-    ReportList getByStatus(ReportStatus status, int limit);
+    ReportList getByIsRead(boolean isRead, int limit);
 
     /* comment.
         ReportList 정리

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/model/Report.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/model/Report.java
@@ -15,20 +15,18 @@ import java.time.LocalDateTime;
         - targetId        : 신고 대상 ID (외부 참조, BC 경계 침범 X)
         - reason          : 신고 사유 (SPAM/ABUSE/...)
         - detail          : 자유 설명 (nullable)
-        - status          : 신고 처리 상태 (PENDING/REVIEWING/CONFIRMED/REJECTED)
+        - isRead          : 읽음 여부 (false=미읽음, true=읽음)
         - reportedAt      : 접수 시각
         - handledAt       : 처리 시각 (검토 후, nullable)
         - handlerAdminId  : 처리자 (검토 후, nullable)
     4. 불변/가변 구분 :
         - 불변(final) : id, reporterUserId, targetType, targetId, reason, detail, reportedAt
-        - 가변        : status, handledAt, handlerAdminId (review/confirm/reject 로 변경)
+        - 가변        : isRead, handledAt, handlerAdminId (markAsRead 로 변경)
     5. 정적 팩토리 2개 의도 :
-        - submit()  : 신규 신고 접수 (id=null, status=PENDING, reportedAt=now)
+        - submit()  : 신규 신고 접수 (id=null, isRead=false, reportedAt=now)
         - restore() : DB 복원 (모든 필드 그대로)
-    6. 도메인 행위 3개 (module04 stub) :
-        - review()         : PENDING → REVIEWING 전이 (module04)
-        - confirm(adminId) : REVIEWING → CONFIRMED 전이 (module04)
-        - reject(adminId)  : REVIEWING → REJECTED 전이 (module04)
+    6. 도메인 행위 :
+        - markAsRead() : 신고를 읽음 처리 (isRead = true)
  */
 public class Report {
 
@@ -39,7 +37,7 @@ public class Report {
     private final Long targetId;
     private final ReportReason reason;
     private final String detail;
-    private ReportStatus status;
+    private boolean isRead;
     private final LocalDateTime reportedAt;
     private LocalDateTime handledAt;
     private Long handlerAdminId;
@@ -49,7 +47,7 @@ public class Report {
         외부에서 호출 차단 (submit / restore 통해서만 생성)
      */
     private Report(Long id, Long reporterUserId, ReportTargetType targetType, Long targetId,
-                   ReportReason reason, String detail, ReportStatus status,
+                   ReportReason reason, String detail, boolean isRead,
                    LocalDateTime reportedAt, LocalDateTime handledAt, Long handlerAdminId) {
 
         if (reporterUserId == null) {
@@ -61,9 +59,6 @@ public class Report {
         if (reason == null) {
             throw new DomainRuleViolationException("신고 사유는 필수입니다.");
         }
-        if (status == null) {
-            throw new DomainRuleViolationException("신고 상태는 필수입니다.");
-        }
         if (reportedAt == null) {
             throw new DomainRuleViolationException("신고 시각은 필수입니다.");
         }
@@ -74,7 +69,7 @@ public class Report {
         this.targetId = targetId;
         this.reason = reason;
         this.detail = detail;
-        this.status = status;
+        this.isRead = isRead;
         this.reportedAt = reportedAt;
         this.handledAt = handledAt;
         this.handlerAdminId = handlerAdminId;
@@ -83,11 +78,11 @@ public class Report {
     /**
      * 신규 신고 접수 (사용자가 신고 버튼 누름)
      * - id = null (DB 가 부여)
-     * - status = PENDING
+     * - isRead = false (신규 신고는 미읽음 상태로 시작)
      * - reportedAt = now()
      * - handledAt, handlerAdminId = null
      */
-    // 신규 신고 접수 - 항상 PENDING 상태로 진행하며 현재 시각으로 시작된다.
+    // 신규 신고 접수 - isRead=false 로 시작하며 현재 시각으로 접수된다.
     public static Report submit(Long reporterUserId, ReportTargetType targetType, Long targetId,
                                 ReportReason reason, String detail) {
         return new Report(
@@ -97,7 +92,7 @@ public class Report {
                 targetId,
                 reason,
                 detail, // null 허용
-                ReportStatus.PENDING, // 신규는 무조건 PENDING
+                false,
                 LocalDateTime.now(), // 접수 시각 = 호출 시점
                 null, // handledAt : 검토 전이라 null
                 null // handlerAdminId : 검토 전이라 null
@@ -108,27 +103,14 @@ public class Report {
      * DB 에서 읽어온 값으로 기존 객체 복원
      */
     public static Report restore(Long id, Long reporterUserId, ReportTargetType targetType, Long targetId,
-                                 ReportReason reason, String detail, ReportStatus status,
+                                 ReportReason reason, String detail, boolean isRead,
                                  LocalDateTime reportedAt, LocalDateTime handledAt, Long handlerAdminId) {
-        return new Report(id, reporterUserId, targetType, targetId, reason, detail, status,
+        return new Report(id, reporterUserId, targetType, targetId, reason, detail, isRead,
                 reportedAt, handledAt, handlerAdminId);
     }
 
-    // === 도메인 행위 (module04 stub) ===
-
-    // PENDING → REVIEWING 전이
-    public void review() {
-        throw new UnsupportedOperationException("TODO: module04 - 신고 검토 시작");
-    }
-
-    // REVIEWING → CONFIRMED 전이 (관리자 인정)
-    public void confirm(Long adminId) {
-        throw new UnsupportedOperationException("TODO: module04 - 신고 인정");
-    }
-
-    // REVIEWING → REJECTED 전이 (관리자 기각)
-    public void reject(Long adminId) {
-        throw new UnsupportedOperationException("TODO: module04 - 신고 기각");
+    public void markAsRead() {
+        this.isRead = true;
     }
 
     // === Getters (Setter 없음 = 도메인 행위로만 변경) ===
@@ -138,7 +120,7 @@ public class Report {
     public Long getTargetId() { return targetId; }
     public ReportReason getReason() { return reason; }
     public String getDetail() { return detail; }
-    public ReportStatus getStatus() { return status; }
+    public boolean isRead() { return isRead; }
     public LocalDateTime getReportedAt() { return reportedAt; }
     public LocalDateTime getHandledAt() { return handledAt; }
     public Long getHandlerAdminId() { return handlerAdminId; }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/repository/ReportRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/domain/repository/ReportRepository.java
@@ -1,8 +1,6 @@
 package com.wanted.momocity.report.domain.repository;
 
 import com.wanted.momocity.report.domain.model.Report;
-import com.wanted.momocity.report.domain.model.ReportStatus;
-
 import java.util.List;
 
 /* comment.
@@ -12,8 +10,8 @@ import java.util.List;
        → DIP. 도메인이 약속만 정의, 인프라가 구현.
     3. limit(N) 방식
        → 관리자 위젯이 작아 페이지네이션 불필요 (ErrorLogRepository 와 동일 정책).
-    4. findById / countByStatus 미선언
-       → YAGNI. module04 검토 기능 들어갈 때 추가.
+    4. findById 미선언
+       → module04 검토 기능 들어갈 때 추가.
  */
 public interface ReportRepository {
 
@@ -23,8 +21,8 @@ public interface ReportRepository {
     // 최근 신고 N개 (reportedAt DESC)
     List<Report> findRecent(int limit);
 
-    // 특정 상태의 최근 신고 N개
-    List<Report> findByStatus(ReportStatus status, int limit);
+    // 읽음 여부 기준 최근 신고 N개 (false=미읽음, true=읽음)
+    List<Report> findByIsRead(boolean isRead, int limit);
 
     // 전체 신고 수 (대시보드 통계용 - ReportStatsAdapter 가 호출)
     long countAll();

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportJpaEntity.java
@@ -21,9 +21,10 @@ import java.time.LocalDateTime;
        → created_at / updated_at 자동 채움 (@CreatedDate / @LastModifiedDate)
        → reportedAt 과는 의미 분리 (도메인 의도 vs DB row 메타)
     5. WHY enum → String 매핑
-       → targetType / reason / status 는 도메인에서 enum, 여기선 String
+       → targetType / reason 은 도메인에서 enum, 여기선 String
        → Adapter 가 enum.name() ↔ Enum.valueOf() 변환
        → member / lecture 와 동일 정책 (일관성)
+       → isRead 는 도메인과 동일하게 boolean 그대로 저장 (변환 불필요)
  */
 @Entity
 @Table(name = "report")
@@ -49,8 +50,8 @@ public class ReportJpaEntity extends BaseTimeEntity {
     @Column(name = "detail", length = 1000)
     private String detail;
 
-    @Column(name = "status", nullable = false, length = 20)
-    private String status;
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
 
     @Column(name = "reported_at", nullable = false)
     private LocalDateTime reportedAt;
@@ -67,7 +68,7 @@ public class ReportJpaEntity extends BaseTimeEntity {
 
     // Adapter 의 toEntity() 가 호출하는 전체 필드 생성자
     public ReportJpaEntity(Long id, Long reporterUserId, String targetType, Long targetId,
-                           String reason, String detail, String status,
+                           String reason, String detail, boolean isRead,
                            LocalDateTime reportedAt, LocalDateTime handledAt, Long handlerAdminId) {
         this.id = id;
         this.reporterUserId = reporterUserId;
@@ -75,16 +76,16 @@ public class ReportJpaEntity extends BaseTimeEntity {
         this.targetId = targetId;
         this.reason = reason;
         this.detail = detail;
-        this.status = status;
+        this.isRead = isRead;
         this.reportedAt = reportedAt;
         this.handledAt = handledAt;
         this.handlerAdminId = handlerAdminId;
     }
 
     // 영속화 모델 메서드 (도메인 행위 아님)
-    // 도메인 검증/규칙은 Report.review / confirm / reject 가 담당, 여기는 단순 필드 변경만
-    public void changeStatus(String status) {
-        this.status = status;
+    // 도메인 검증/규칙은 Report.markAsRead 가 담당, 여기는 단순 필드 변경만
+    public void markAsRead() {
+        this.isRead = true;
     }
 
     public void markHandled(LocalDateTime handledAt, Long handlerAdminId) {
@@ -98,7 +99,7 @@ public class ReportJpaEntity extends BaseTimeEntity {
     public Long getTargetId() { return targetId; }
     public String getReason() { return reason; }
     public String getDetail() { return detail; }
-    public String getStatus() { return status; }
+    public boolean isRead() { return isRead; }
     public LocalDateTime getReportedAt() { return reportedAt; }
     public LocalDateTime getHandledAt() { return handledAt; }
     public Long getHandlerAdminId() { return handlerAdminId; }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/ReportRepositoryAdapter.java
@@ -2,7 +2,6 @@ package com.wanted.momocity.report.infrastructure.persistence;
 
 import com.wanted.momocity.report.domain.model.Report;
 import com.wanted.momocity.report.domain.model.ReportReason;
-import com.wanted.momocity.report.domain.model.ReportStatus;
 import com.wanted.momocity.report.domain.model.ReportTargetType;
 import com.wanted.momocity.report.domain.repository.ReportRepository;
 import org.springframework.data.domain.PageRequest;
@@ -54,8 +53,8 @@ public class ReportRepositoryAdapter implements ReportRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Report> findByStatus(ReportStatus status, int limit) {
-        return repository.findAllByStatusOrderByReportedAtDesc(status.name(), PageRequest.of(0, limit))
+    public List<Report> findByIsRead(boolean isRead, int limit) {
+        return repository.findAllByIsReadOrderByReportedAtDesc(isRead, PageRequest.of(0, limit))
                 .stream()
                 .map(this::toDomain)
                 .toList();
@@ -78,7 +77,7 @@ public class ReportRepositoryAdapter implements ReportRepository {
                 report.getTargetId(),
                 report.getReason().name(),
                 report.getDetail(),
-                report.getStatus().name(),
+                report.isRead(),
                 report.getReportedAt(),
                 report.getHandledAt(),
                 report.getHandlerAdminId()
@@ -94,7 +93,7 @@ public class ReportRepositoryAdapter implements ReportRepository {
                 entity.getTargetId(),
                 ReportReason.valueOf(entity.getReason()),
                 entity.getDetail(),
-                ReportStatus.valueOf(entity.getStatus()),
+                entity.isRead(),
                 entity.getReportedAt(),
                 entity.getHandledAt(),
                 entity.getHandlerAdminId()

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/SpringDataReportRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/infrastructure/persistence/SpringDataReportRepository.java
@@ -22,6 +22,6 @@ public interface SpringDataReportRepository extends JpaRepository<ReportJpaEntit
     // 최근 N개 (reportedAt DESC) - Adapter 에서 PageRequest.of(0, limit) 으로 호출
     List<ReportJpaEntity> findAllByOrderByReportedAtDesc(Pageable pageable);
 
-    // 특정 상태의 최근 N개 (reportedAt DESC)
-    List<ReportJpaEntity> findAllByStatusOrderByReportedAtDesc(String status, Pageable pageable);
+    // 읽음 여부 기준 최근 N개 (reportedAt DESC)
+    List<ReportJpaEntity> findAllByIsReadOrderByReportedAtDesc(boolean isRead, Pageable pageable);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
@@ -3,7 +3,6 @@ package com.wanted.momocity.report.presentation.api;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.report.application.usecase.ReportQueryUseCase;
-import com.wanted.momocity.report.domain.model.ReportStatus;
 import com.wanted.momocity.report.presentation.api.response.ReportListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 /* comment.
     AdminReportController 정리
     1. 역할 : 관리자 신고 목록 조회 HTTP API 진입점 (ADMIN 권한 가진 사용자만 접근 가능)
-    2. 다루는 API : GET /api/v1/reports?limit=N&status=PENDING
+    2. 다루는 API : GET /api/v1/reports?limit=N&isRead=false
     3. 클래스 레벨 어노테이션
        - @RestController : REST API 컨트롤러. 반환값 자동 JSON 직렬화.
        - @RequiredArgsConstructor : final 필드 생성자 자동 생성 (Lombok).
@@ -30,14 +29,14 @@ import org.springframework.web.bind.annotation.RestController;
     4. 의존성
         - ReportQueryUseCase : UseCase 인터페이스 의존. 구현체는 ReportQueryService 모르고있는 상태
     5. getReports 처리 흐름 4단계
-        a) HTTP 요청 받기 (limit + status query param)
-        b) status null 여부에 따라 getRecent 또는 getByStatus 선택 호출
+        a) HTTP 요청 받기 (limit + isRead query param)
+        b) isRead null 여부에 따라 getRecent 또는 getByIsRead 선택 호출
         c) UseCase 출력(ReportList) → ReportListResponse.from() 으로 응답 DTO 변환
         d) ResponseEntity.ok() + 공통 응답 wrapper 로 반환
-    6. WHY status 파라미터가 optional (required = false)
+    6. WHY isRead 파라미터가 optional (required = false)
        → 호출자 의도 에 따라 두 가지 사용 패턴이 지원된다
-            1. status 없음 : 전체 최근 N개
-            2. status 있음 : 특정 상태의 최근 N개
+            1. isRead 없음 : 전체 최근 N개
+            2. isRead 있음 : 읽음 여부 기준 최근 N개 (false=미읽음, true=읽음)
        → 한 엔드포인트를 통해서 두 케이스를 처리한다.
     7. WHY ReportController 와 별도 컨트롤러 (같은 base path 공유)
        → 권한 정책이 다르기 때문에 클래스 레벨에서 분리하면 가독성 및 유지보수가 좋아진다.
@@ -57,7 +56,7 @@ public class AdminReportController {
     @GetMapping
     @Operation(
             summary = "관리자 신고 목록 조회",
-            description = "최근 N개의 신고를 조회한다. status 파라미터로 상태별 필터링 가능."
+            description = "최근 N개의 신고를 조회한다. isRead 파라미터로 읽음 여부 필터링 가능"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -70,13 +69,13 @@ public class AdminReportController {
     public ResponseEntity<ApiResponse<ReportListResponse>> getReports(
             @Parameter(description = "조회할 최대 개수", example = "10")
             @RequestParam(defaultValue = "10") int limit,
-            @Parameter(description = "신고 상태 필터 (선택)", example = "PENDING")
-            @RequestParam(required = false) ReportStatus status
+            @Parameter(description = "읽음 여부 필터 (선택, false=미읽음, true=읽음", example = "false")
+            @RequestParam(required = false) Boolean isRead
     ) {
-        // 1. status 유무에 따라 UseCase 메서드 선택
-        ReportQueryUseCase.ReportList list = (status == null)
+        // 1. isRead 유무에 따라 UseCase 메서드 선택
+        ReportQueryUseCase.ReportList list = (isRead == null)
                 ? reportQueryUseCase.getRecent(limit)
-                : reportQueryUseCase.getByStatus(status, limit);
+                : reportQueryUseCase.getByIsRead(isRead, limit);
 
         // 2. UseCase 출력 → 응답 DTO 변환
         ReportListResponse response = ReportListResponse.from(list);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/AdminReportController.java
@@ -69,7 +69,7 @@ public class AdminReportController {
     public ResponseEntity<ApiResponse<ReportListResponse>> getReports(
             @Parameter(description = "조회할 최대 개수", example = "10")
             @RequestParam(defaultValue = "10") int limit,
-            @Parameter(description = "읽음 여부 필터 (선택, false=미읽음, true=읽음", example = "false")
+            @Parameter(description = "읽음 여부 필터 (선택, false=미읽음, true=읽음)", example = "false")
             @RequestParam(required = false) Boolean isRead
     ) {
         // 1. isRead 유무에 따라 UseCase 메서드 선택

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/ReportListResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/ReportListResponse.java
@@ -36,9 +36,10 @@ public record ReportListResponse(
     /* comment.
         Item 정리
         1. 역할 : 신고 1건의 응답 형태이며 목록 안에 여러 개가 들어가게 된다.
-        2. WHY enum 을 String 으로 변환 (targetType, reason, status)
+        2. WHY enum 을 String 으로 변환 (targetType, reason)
            → 표현 계층은 enum 타입이 직접 노출되지 않는다.
            → JSON 직렬화 시 FE 호환성이 높아진다.
+           → isRead 는 boolean 그대로 노출 (변환 불필요)
         3. 필드 8개 의미
         reportId : 신고 식별자
         reporterUserId : 신고자 ID
@@ -46,7 +47,7 @@ public record ReportListResponse(
         targetId : 신고 대상 ID
         reason : 신고 사유
         detail : 자유 설명 (nullable)
-        status : 신고 처리 상태
+        isRead : 읽음 여부 (false=미읽음, true=읽음)
         reportedAt : 접수 시각
      */
     public record Item(
@@ -56,7 +57,7 @@ public record ReportListResponse(
             Long targetId,
             String reason,
             String detail,
-            String status,
+            boolean isRead,
             LocalDateTime reportedAt
     ) {
 
@@ -68,7 +69,7 @@ public record ReportListResponse(
                     report.getTargetId(),
                     report.getReason().name(),
                     report.getDetail(),
-                    report.getStatus().name(),
+                    report.isRead(),
                     report.getReportedAt()
             );
         }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/SubmitReportResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/report/presentation/api/response/SubmitReportResponse.java
@@ -11,9 +11,10 @@ import java.time.LocalDateTime;
     3. WHY record 사용
        → 불변 객체이기 때문이다
        → enrollment.CreateEnrollmentResponse 와 동일한 패턴
-    4. WHY enum 을 String 으로 변환 (targetType, reason, status)
+    4. WHY enum 을 String 으로 변환 (targetType, reason)
        → 표현 계층은 enum 값을 직접적으로 노출시키지 않는다.
        → JSON 직렬화 시 enum 그대로 노출하면 FE 에서 상수 매핑 부담
+       → isRead 는 boolean 그대로 노출 (변환 불필요)
     5. WHY from(Report) 정적 팩토리 메서드
        → 변환 로직을 한 곳에 모아 응집도
        → enum.name() 으로 변환해서 문자열로 명확하게 전달한다.
@@ -24,7 +25,7 @@ import java.time.LocalDateTime;
         targetId : 신고 대상 ID
         reason : 신고 사유 (enum → String)
         detail : 자유 설명 (nullable, JSON null 로 전달)
-        status : 신고 처리 상태 (접수 직후 = PENDING)
+        isRead : 읽음 여부 (접수 직후 = false)
         reportedAt : 신고 접수 시각
  */
 public record SubmitReportResponse(
@@ -34,7 +35,7 @@ public record SubmitReportResponse(
         Long targetId,
         String reason,
         String detail,
-        String status,
+        boolean isRead,
         LocalDateTime reportedAt
 ) {
 
@@ -46,7 +47,7 @@ public record SubmitReportResponse(
                 report.getTargetId(),
                 report.getReason().name(),
                 report.getDetail(),
-                report.getStatus().name(),
+                report.isRead(),
                 report.getReportedAt()
         );
     }


### PR DESCRIPTION
## API 변경 사항 (FE 공지 필요)

### `GET /api/v1/reports` — 신고 목록 조회

**Headers**
```
Authorization: Bearer {accessToken}
```

**Query Parameters 변경**
```
Before: ?status=PENDING
After:  ?isRead=false
```

**Response 변경**
```json
Before: { "status": "PENDING" }
After:  { "isRead": false }
```

### `POST /api/v1/reports` — 신고 접수

**Response 변경**
```json
Before: { "status": "PENDING" }
After:  { "isRead": false }
```

**예외 케이스**
| 상황 | 코드 |
|------|------|
| 토큰 없음 / 만료 | 401 UNAUTHORIZED |
| ADMIN 권한 없음 | 403 FORBIDDEN |

---

## 작업 내용

팀 협의로 `report` 테이블 ERD 변경 (`status_code` 제거 → `is_read` 추가) 에 따른 코드 일괄 반영.

- `ReportStatus` enum 삭제
- `Report` 도메인: `status` → `isRead`, `review/confirm/reject()` → `markAsRead()`
- `ReportJpaEntity`: `status` 컬럼 → `is_read` 컬럼
- Repository / UseCase / Service: `findByStatus` → `findByIsRead`, `getByStatus` → `getByIsRead`
- Controller / Response DTO: `status` 파라미터 및 필드 → `isRead` 일괄 교체

---

## 추후 작업

- [ ] DB 스키마 반영 — `status` 컬럼 제거, `is_read` 컬럼 추가
- [ ] FE 팀 API 스펙 변경 공지
- [ ] `ReportStatsPort.java` 신규 생성 (admin 대시보드 연동)
- [ ] module04 — 신고 검토 기능 구현 시 `markAsRead()` 활용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 신고 관리의 조회/표기 기준을 “상태(status)”에서 “읽음 여부(isRead)” 중심으로 전환했습니다.
  * 관리자 신고 목록 조회에서 필터 파라미터가 `status` → `isRead`로 변경되어, 읽음/미읽음 기준 조회가 가능해졌습니다.
  * 신고 목록 응답과 항목 표시가 업데이트되어 `status` 대신 `isRead`가 노출됩니다.
  * 신고 접수 응답 DTO도 `status` 대신 `isRead`를 포함하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->