### PR TITLE
[PR] k6 부하테스트 스크립트 추가 및 모니터링 스택 연동 검증

### DIFF
--- a/legend-momo-city/k6/lib/client.js
+++ b/legend-momo-city/k6/lib/client.js
@@ -1,0 +1,98 @@
+// k6/lib/client.js
+// ------------------------------------------------------------
+// MoMo City API 호출을 함수로 감싼 파일입니다.
+//
+// 의도:
+// - 시나리오 스크립트는 "사용자 행동"에만 집중합니다.
+// - HTTP 세부 구현(헤더, URL, check)은 이 파일에서 관리합니다.
+// - tags를 일관되게 붙여 k6 결과에서 API별 지표를 분리합니다.
+//   예: threshold에서 'http_req_duration{type:enrollment}'처럼 사용할 수 있습니다.
+// ------------------------------------------------------------
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { BASE_URL, randomLectureId, LECTURE_CHAPTER_MAP } from './config.js';
+
+function authHeaders(token) {
+    return {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+    };
+}
+
+// 강의 목록 조회 API입니다.
+// category, keyword, page는 선택값입니다.
+export function getLectures(params = {}, token = null) {
+    const { category, keyword, page = 1, size = 10 } = params;
+
+    let url = `${BASE_URL}/api/v1/lectures?page=${page}&size=${size}`;
+    if (category) url += `&category=${category}`;
+    if (keyword)  url += `&keyword=${encodeURIComponent(keyword)}`;
+
+    const headers = token
+        ? authHeaders(token)
+        : { 'Content-Type': 'application/json' };
+
+    const res = http.get(url, {
+        headers,
+        tags: { type: 'lecture-list', api: 'GET /api/v1/lectures' },
+    });
+
+    check(res, {
+        'lecture-list: status is 200': (r) => r.status === 200,
+        'lecture-list: no server error':  (r) => r.status !== 500,
+    });
+
+    return res;
+}
+
+// 수강신청 API입니다.
+// 첫 번째 성공은 201, 이미 신청한 경우 409 또는 400을 반환합니다.
+// responseCallback으로 400/409를 기대된 응답으로 등록해
+// k6의 http_req_failed 메트릭에서 실패로 집계되지 않도록 합니다.
+export function enrollLecture(token, lectureId = randomLectureId()) {
+    const res = http.post(
+        `${BASE_URL}/api/v1/lectures/${lectureId}/enrollments`,
+        null,
+        {
+            headers: authHeaders(token),
+            tags: { type: 'enrollment', api: 'POST /api/v1/lectures/{id}/enrollments' },
+            responseCallback: http.expectedStatuses(201, 400, 409),
+        }
+    );
+
+    check(res, {
+        'enrollment: success or duplicate': (r) => r.status === 201 || r.status === 409 || r.status === 400,
+        'enrollment: no server error':      (r) => r.status !== 500,
+    });
+
+    return res;
+}
+
+// 진척도 저장 API입니다.
+// 프론트에서 5~10초 주기로 현재 재생 위치를 전송하는 패턴을 재현합니다.
+// 90% 이상 시청 시 서버에서 챕터 완료 처리를 수행합니다.
+export function saveProgress(token, lectureId, chapterId, playbackSeconds) {
+    const res = http.patch(
+        `${BASE_URL}/api/v1/lectures/${lectureId}/chapters/${chapterId}/progress`,
+        JSON.stringify({ playbackSeconds }),
+        {
+            headers: authHeaders(token),
+            tags: { type: 'progress', api: 'PATCH /api/v1/lectures/{id}/chapters/{id}/progress' },
+        }
+    );
+
+    check(res, {
+        'progress: status is 200':  (r) => r.status === 200,
+        'progress: no server error': (r) => r.status !== 500,
+    });
+
+    return res;
+}
+
+// 강의 목록 조회 + 수강신청을 묶은 일반 학생 행동 시나리오입니다.
+// 혼합 트래픽 테스트에서 사용합니다.
+export function studentBrowseAndEnroll(token) {
+    getLectures({}, token);
+    enrollLecture(token, randomLectureId());
+}

--- a/legend-momo-city/k6/lib/config.js
+++ b/legend-momo-city/k6/lib/config.js
@@ -1,0 +1,67 @@
+// k6/lib/config.js
+// ------------------------------------------------------------
+// k6 스크립트에서 공통으로 사용하는 설정 모음입니다.
+//
+// 환경 변수로 테스트 조건을 바꿀 수 있습니다.
+// 예시:
+//   BASE_URL=http://localhost:8080 k6 run k6/scripts/01-enrollment.js
+//   RESULT_NAME=enrollment-before-index k6 run k6/scripts/01-enrollment.js
+// ------------------------------------------------------------
+
+// 테스트 대상 서버 주소입니다.
+// 환경 변수가 없으면 로컬 기본값을 사용합니다.
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+// 테스트 결과 파일 이름 prefix입니다.
+// 여러 번 실행할 때 RESULT_NAME을 바꾸면 덮어쓰기를 피할 수 있습니다.
+export const RESULT_NAME = __ENV.RESULT_NAME || 'k6-result';
+
+// 학생 계정 JWT 토큰 목록입니다. (student1~4)
+// 토큰 만료 시 재발급 후 이 배열을 교체합니다.
+export const STUDENT_TOKENS = [
+    __ENV.TOKEN_STUDENT1 || 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyIiwicm9sZXMiOiJST0xFX1NUVURFTlQiLCJpYXQiOjE3ODE4MzUwODUsImV4cCI6MTc4MTgzODY4NX0.zDMM516jbPYmrEPjaJug3Hv3NQp9eW17FsAGvlYnILU-4D6hFOfP4V_5-YPRuPXyhF9YE51ZYkTyApInr-JsZA',
+    __ENV.TOKEN_STUDENT2 || 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzIiwicm9sZXMiOiJST0xFX1NUVURFTlQiLCJpYXQiOjE3ODE4MzUwODUsImV4cCI6MTc4MTgzODY4NX0.sqMwuKwbeh9EvtxY_2B-sEkJyKEKAPSCscwcV-akUr4DWfMWrkM412c_vqPEIM4Gx7whPAEQFc58nPDrP-T8tw',
+    __ENV.TOKEN_STUDENT3 || 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI0Iiwicm9sZXMiOiJST0xFX1NUVURFTlQiLCJpYXQiOjE3ODE4MzUwODUsImV4cCI6MTc4MTgzODY4NX0.ikl6G2Aw9xp9n3fhecxFRenm10oqpwvzkTQuG2JWr7GD3DNd34QBSLAkWEi2w9C8axAptPuLbGUxBFlQZtvOKA',
+    __ENV.TOKEN_STUDENT4 || 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI1Iiwicm9sZXMiOiJST0xFX1NUVURFTlQiLCJpYXQiOjE3ODE4MzUwODUsImV4cCI6MTc4MTgzODY4NX0.hE5CiGhZYGO5oO6bPo9pPQZ2I3cH5CFS9yRGSp7UicJWSJSRRShT-5VIaRxxmYnGPoqeFNlJGXRv-VRIBpDL7A',
+];
+
+// 현재 DB에 있는 ACTIVE 상태 강의 ID 목록입니다.
+export const LECTURE_IDS = [1, 2, 3, 6, 8, 9];
+
+// 강의별 챕터 매핑입니다. (lectureId -> chapterId 배열)
+// 진척도 저장 테스트에서 유효한 챕터를 선택할 때 사용합니다.
+export const LECTURE_CHAPTER_MAP = {
+    1: [1, 2],
+    2: [3],
+    3: [4],
+    6: [6],
+    8: [8],
+    9: [9],
+};
+
+// 요청 사이 사용자 대기 시간 범위입니다.
+// 실제 사용자는 API를 쉬지 않고 반복 호출하지 않으므로 sleep이 필요합니다.
+export const MIN_SLEEP_SECONDS = Number(__ENV.MIN_SLEEP_SECONDS || 0.5);
+export const MAX_SLEEP_SECONDS = Number(__ENV.MAX_SLEEP_SECONDS || 1.5);
+
+export function randomInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export function randomLectureId() {
+    return LECTURE_IDS[Math.floor(Math.random() * LECTURE_IDS.length)];
+}
+
+export function randomStudentToken() {
+    return STUDENT_TOKENS[Math.floor(Math.random() * STUDENT_TOKENS.length)];
+}
+
+// VU 번호 기반으로 토큰을 순환 배정합니다.
+// 같은 VU는 항상 같은 학생 토큰을 사용해 중복 수강신청 패턴을 재현합니다.
+export function vuToken() {
+    return STUDENT_TOKENS[__VU % STUDENT_TOKENS.length];
+}
+
+export function randomSleepSeconds() {
+    return Math.random() * (MAX_SLEEP_SECONDS - MIN_SLEEP_SECONDS) + MIN_SLEEP_SECONDS;
+}

--- a/legend-momo-city/k6/lib/summary.js
+++ b/legend-momo-city/k6/lib/summary.js
@@ -1,0 +1,136 @@
+// k6/lib/summary.js
+// ------------------------------------------------------------
+// k6 실행 결과를 Markdown 표와 JSON으로 저장합니다.
+//
+// 사용 방법:
+//   import { createSummaryHandler } from '../lib/summary.js';
+//   export const handleSummary = createSummaryHandler('01-enrollment');
+//
+// 실행 후 생성되는 파일:
+//   k6/results/01-enrollment-summary.md
+//   k6/results/01-enrollment-summary.json
+// ------------------------------------------------------------
+
+import { RESULT_NAME } from './config.js';
+
+function safeName(name) {
+    return String(name || RESULT_NAME)
+        .replace(/[^a-zA-Z0-9._-]/g, '-')
+        .replace(/-+/g, '-');
+}
+
+function metricValue(data, metricName, key) {
+    const metric = data.metrics[metricName];
+    if (!metric || !metric.values || metric.values[key] === undefined) return '';
+    const value = metric.values[key];
+    if (typeof value !== 'number') return String(value);
+    return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+function rateValue(data, metricName) {
+    const metric = data.metrics[metricName];
+    if (!metric || !metric.values || metric.values.rate === undefined) return '';
+    return `${(metric.values.rate * 100).toFixed(2)}%`;
+}
+
+function countValue(data, metricName) {
+    return metricValue(data, metricName, 'count');
+}
+
+function durationRow(data, metricName, label) {
+    return `| ${label} | ${metricValue(data, metricName, 'avg')} | ${metricValue(data, metricName, 'min')} | ${metricValue(data, metricName, 'med')} | ${metricValue(data, metricName, 'p(90)')} | ${metricValue(data, metricName, 'p(95)')} | ${metricValue(data, metricName, 'p(99)')} | ${metricValue(data, metricName, 'max')} |`;
+}
+
+function buildMarkdown(data, name) {
+    const lines = [];
+
+    lines.push(`# k6 Result - ${name}`);
+    lines.push('');
+    lines.push('## Summary');
+    lines.push('');
+    lines.push('| Metric | Value |');
+    lines.push('| --- | ---: |');
+    lines.push(`| http_reqs | ${countValue(data, 'http_reqs')} |`);
+    lines.push(`| iterations | ${countValue(data, 'iterations')} |`);
+    lines.push(`| checks success rate | ${rateValue(data, 'checks')} |`);
+    lines.push(`| http_req_failed | ${rateValue(data, 'http_req_failed')} |`);
+    lines.push(`| data_received bytes | ${countValue(data, 'data_received')} |`);
+    lines.push(`| data_sent bytes | ${countValue(data, 'data_sent')} |`);
+    lines.push('');
+
+    lines.push('## Duration Metrics');
+    lines.push('');
+    lines.push('| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |');
+    lines.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+    lines.push(durationRow(data, 'http_req_duration', 'http_req_duration'));
+    lines.push(durationRow(data, 'http_req_waiting',  'http_req_waiting'));
+    lines.push(durationRow(data, 'http_req_blocked',  'http_req_blocked'));
+    lines.push('');
+
+    lines.push('## Metric Meaning');
+    lines.push('');
+    lines.push('| Value | Meaning |');
+    lines.push('| --- | --- |');
+    lines.push('| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |');
+    lines.push('| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |');
+    lines.push('| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |');
+    lines.push('| p90 | 90% 요청이 이 값 이하로 완료됩니다. |');
+    lines.push('| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |');
+    lines.push('| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |');
+    lines.push('| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |');
+    lines.push('');
+
+    lines.push('## How To Compare');
+    lines.push('');
+    lines.push('| Compare Point | What To Look For |');
+    lines.push('| --- | --- |');
+    lines.push('| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |');
+    lines.push('| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |');
+    lines.push('| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |');
+    lines.push('| Prometheus | 서버 내부 HTTP/custom metric 추세 |');
+    lines.push('| Loki | 느린 요청의 로그와 에러 이벤트 |');
+    lines.push('');
+
+    return `${lines.join('\n')}\n`;
+}
+
+function buildConsoleTable(data, name) {
+    return [
+        '',
+        `k6 summary: ${name}`,
+        '------------------------------------------------------------',
+        `http_reqs        : ${countValue(data, 'http_reqs')}`,
+        `iterations       : ${countValue(data, 'iterations')}`,
+        `checks           : ${rateValue(data, 'checks')}`,
+        `http_req_failed  : ${rateValue(data, 'http_req_failed')}`,
+        '',
+        'http_req_duration (ms)',
+        `  avg             : ${metricValue(data, 'http_req_duration', 'avg')}`,
+        `  min             : ${metricValue(data, 'http_req_duration', 'min')}`,
+        `  med             : ${metricValue(data, 'http_req_duration', 'med')}`,
+        `  p90             : ${metricValue(data, 'http_req_duration', 'p(90)')}`,
+        `  p95             : ${metricValue(data, 'http_req_duration', 'p(95)')}`,
+        `  p99             : ${metricValue(data, 'http_req_duration', 'p(99)')}`,
+        `  max             : ${metricValue(data, 'http_req_duration', 'max')}`,
+        '',
+        'http_req_waiting (ms)',
+        `  avg             : ${metricValue(data, 'http_req_waiting', 'avg')}`,
+        `  p95             : ${metricValue(data, 'http_req_waiting', 'p(95)')}`,
+        `  max             : ${metricValue(data, 'http_req_waiting', 'max')}`,
+        '------------------------------------------------------------',
+        `Markdown report  : k6/results/${name}-summary.md`,
+        `JSON report      : k6/results/${name}-summary.json`,
+        '',
+    ].join('\n');
+}
+
+export function createSummaryHandler(defaultName) {
+    return function handleSummary(data) {
+        const name = safeName(__ENV.RESULT_NAME || defaultName || RESULT_NAME);
+        return {
+            stdout: buildConsoleTable(data, name),
+            [`k6/results/${name}-summary.md`]:   buildMarkdown(data, name),
+            [`k6/results/${name}-summary.json`]: JSON.stringify(data, null, 2),
+        };
+    };
+}

--- a/legend-momo-city/k6/results/00-smoke-check-summary.json
+++ b/legend-momo-city/k6/results/00-smoke-check-summary.json
@@ -1,0 +1,267 @@
+{
+  "state": {
+    "testRunDurationMs": 3467.714,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 1,
+        "max": 1,
+        "value": 1
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 9.467333333333332,
+        "min": 5.139,
+        "med": 9.631,
+        "max": 14.773,
+        "p(90)": 12.228200000000001,
+        "p(95)": 13.500599999999999,
+        "p(99)": 14.518519999999999
+      },
+      "thresholds": {
+        "p(95)<2000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 11832,
+        "rate": 3412.0460914596765
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.085,
+        "med": 0.101,
+        "max": 0.512,
+        "p(90)": 0.2568000000000001,
+        "p(95)": 0.3843999999999999,
+        "p(99)": 0.48647999999999997,
+        "avg": 0.1621111111111111
+      }
+    },
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 9
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "med": 9.631,
+        "max": 14.773,
+        "p(90)": 12.228200000000001,
+        "p(95)": 13.500599999999999,
+        "p(99)": 14.518519999999999,
+        "avg": 9.467333333333332,
+        "min": 5.139
+      },
+      "type": "trend"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 3,
+        "rate": 0.865123248341703
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.21988888888888886,
+        "min": 0.001,
+        "med": 0.003,
+        "max": 1.953,
+        "p(90)": 0.39860000000000034,
+        "p(95)": 1.1757999999999993,
+        "p(99)": 1.7975599999999998
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 3408,
+        "rate": 982.7800101161745
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 13.312999999999999,
+        "p(99)": 14.3322,
+        "avg": 9.286000000000001,
+        "min": 5.035,
+        "med": 9.444,
+        "max": 14.587,
+        "p(90)": 12.039
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 18,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.03839999999999999,
+        "p(99)": 0.042879999999999995,
+        "avg": 0.01922222222222222,
+        "min": 0.009,
+        "med": 0.014,
+        "max": 0.044,
+        "p(90)": 0.0328
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 2.595369745025109,
+        "count": 9
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.019777777777777776,
+        "min": 0,
+        "med": 0,
+        "max": 0.178,
+        "p(90)": 0.03560000000000003,
+        "p(95)": 0.10679999999999994,
+        "p(99)": 0.16376
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 1479.9705456,
+        "p(99)": 1505.07137552,
+        "avg": 1155.021389,
+        "min": 756.131375,
+        "med": 1197.586209,
+        "max": 1511.346583,
+        "p(90)": 1448.5945082
+      }
+    }
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "lecture-list: status is 200",
+          "path": "::lecture-list: status is 200",
+          "id": "b10b145867557e85689dd4a99d8b42ec",
+          "passes": 3,
+          "fails": 0
+        },
+        {
+          "name": "lecture-list: no server error",
+          "path": "::lecture-list: no server error",
+          "id": "10ab21a2d4ec71d61f54b95bf7aaefa1",
+          "passes": 3,
+          "fails": 0
+        },
+        {
+          "passes": 3,
+          "fails": 0,
+          "name": "enrollment: success or duplicate",
+          "path": "::enrollment: success or duplicate",
+          "id": "83a21dc82286244ec083c742662980b3"
+        },
+        {
+          "name": "enrollment: no server error",
+          "path": "::enrollment: no server error",
+          "id": "479afda0cfd38b521d99af510f588c34",
+          "passes": 3,
+          "fails": 0
+        },
+        {
+          "passes": 3,
+          "fails": 0,
+          "name": "progress: status is 200",
+          "path": "::progress: status is 200",
+          "id": "caab62b75fcff12ace7654d84f720a32"
+        },
+        {
+          "name": "progress: no server error",
+          "path": "::progress: no server error",
+          "id": "fe43e8fbfd8d0171a91f3b3f0372d2b5",
+          "passes": 3,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": ""
+  }
+}

--- a/legend-momo-city/k6/results/00-smoke-check-summary.md
+++ b/legend-momo-city/k6/results/00-smoke-check-summary.md
@@ -1,0 +1,43 @@
+# k6 Result - 00-smoke-check
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 9 |
+| iterations | 3 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 11832 |
+| data_sent bytes | 3408 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 9.47 | 5.14 | 9.63 | 12.23 | 13.50 | 14.52 | 14.77 |
+| http_req_waiting | 9.29 | 5.04 | 9.44 | 12.04 | 13.31 | 14.33 | 14.59 |
+| http_req_blocked | 0.22 | 0.00 | 0.00 | 0.40 | 1.18 | 1.80 | 1.95 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 로그와 에러 이벤트 |
+

--- a/legend-momo-city/k6/results/01-enrollment-summary.json
+++ b/legend-momo-city/k6/results/01-enrollment-summary.json
@@ -1,0 +1,252 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "id": "83a21dc82286244ec083c742662980b3",
+          "passes": 1404,
+          "fails": 0,
+          "name": "enrollment: success or duplicate",
+          "path": "::enrollment: success or duplicate"
+        },
+        {
+          "name": "enrollment: no server error",
+          "path": "::enrollment: no server error",
+          "id": "479afda0cfd38b521d99af510f588c34",
+          "passes": 1404,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": ""
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 50605.121
+  },
+  "metrics": {
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 2.84,
+        "med": 6.052,
+        "max": 13.161,
+        "p(90)": 8.1564,
+        "p(95)": 8.781949999999998,
+        "p(99)": 10.599549999999999,
+        "avg": 6.271094729344731
+      }
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "avg": 0.11174501424501396,
+        "min": 0.029,
+        "med": 0.1,
+        "max": 1.349,
+        "p(90)": 0.17,
+        "p(95)": 0.19784999999999994,
+        "p(99)": 0.268
+      },
+      "type": "trend"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 762231,
+        "rate": 15062.329363860232
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 2,
+        "max": 49
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.021,
+        "p(95)": 0.025,
+        "p(99)": 0.05296999999999999,
+        "avg": 0.015758547008547057,
+        "min": 0.003,
+        "med": 0.012,
+        "max": 2.533
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1404,
+        "rate": 27.74422770375354
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0.23690999999999995,
+        "avg": 0.007885327635327635,
+        "min": 0,
+        "med": 0,
+        "max": 0.365
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      },
+      "type": "gauge"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1404,
+        "rate": 27.74422770375354
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 2.903,
+        "med": 6.172,
+        "max": 13.45,
+        "p(90)": 8.344,
+        "p(95)": 8.98535,
+        "p(99)": 10.86404,
+        "avg": 6.398598290598299
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 507.0675,
+        "med": 1008.7503750000001,
+        "max": 1508.098708,
+        "p(90)": 1403.7676082,
+        "p(95)": 1452.01586865,
+        "p(99)": 1499.948495,
+        "avg": 1012.8085968938757
+      }
+    },
+    "http_req_duration{type:enrollment}": {
+      "contains": "time",
+      "values": {
+        "p(90)": 8.344,
+        "p(95)": 8.98535,
+        "p(99)": 10.86404,
+        "avg": 6.398598290598299,
+        "min": 2.903,
+        "med": 6.172,
+        "max": 13.45
+      },
+      "thresholds": {
+        "p(95)<2000": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "http_req_tls_handshaking": {
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0
+      },
+      "type": "trend"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 1404,
+        "rate": 0,
+        "passes": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 6.398598290598299,
+        "min": 2.903,
+        "med": 6.172,
+        "max": 13.45,
+        "p(90)": 8.344,
+        "p(95)": 8.98535,
+        "p(99)": 10.86404
+      }
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 525096,
+        "rate": 10376.341161203824
+      },
+      "type": "counter"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 2808,
+        "fails": 0
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.003,
+        "max": 2.846,
+        "p(90)": 0.006,
+        "p(95)": 0.007849999999999939,
+        "p(99)": 0.29,
+        "avg": 0.01500641025641026,
+        "min": 0.001
+      }
+    }
+  }
+}

--- a/legend-momo-city/k6/results/01-enrollment-summary.md
+++ b/legend-momo-city/k6/results/01-enrollment-summary.md
@@ -1,0 +1,43 @@
+# k6 Result - 01-enrollment
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 1404 |
+| iterations | 1404 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 762231 |
+| data_sent bytes | 525096 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 6.40 | 2.90 | 6.17 | 8.34 | 8.99 | 10.86 | 13.45 |
+| http_req_waiting | 6.27 | 2.84 | 6.05 | 8.16 | 8.78 | 10.60 | 13.16 |
+| http_req_blocked | 0.02 | 0.00 | 0.00 | 0.01 | 0.01 | 0.29 | 2.85 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 로그와 에러 이벤트 |
+

--- a/legend-momo-city/k6/results/02-lecture-list-summary.json
+++ b/legend-momo-city/k6/results/02-lecture-list-summary.json
@@ -1,0 +1,252 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "path": "::lecture-list: status is 200",
+          "id": "b10b145867557e85689dd4a99d8b42ec",
+          "passes": 6519,
+          "fails": 0,
+          "name": "lecture-list: status is 200"
+        },
+        {
+          "name": "lecture-list: no server error",
+          "path": "::lecture-list: no server error",
+          "id": "10ab21a2d4ec71d61f54b95bf7aaefa1",
+          "passes": 6519,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71333.565
+  },
+  "metrics": {
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 48.714,
+        "p(90)": 6.3784,
+        "p(95)": 7.294099999999999,
+        "p(99)": 10.172299999999993,
+        "avg": 4.166676177327802,
+        "min": 1.328,
+        "med": 3.675
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 13038,
+        "fails": 0
+      }
+    },
+    "http_req_duration{type:lecture-list}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 7.395499999999998,
+        "p(99)": 10.242499999999996,
+        "avg": 4.236863322595492,
+        "min": 1.373,
+        "med": 3.743,
+        "max": 48.936,
+        "p(90)": 6.4546
+      },
+      "thresholds": {
+        "p(95)<1000": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 3,
+        "min": 3,
+        "max": 199
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.201,
+        "avg": 0.006076852277956743,
+        "min": 0,
+        "med": 0,
+        "max": 1.669,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1011.2085423035741,
+        "min": 502.488375,
+        "med": 1020.326458,
+        "max": 1506.154542,
+        "p(90)": 1407.256858,
+        "p(95)": 1459.5299423,
+        "p(99)": 1495.9447725
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 10.242499999999996,
+        "avg": 4.236863322595492,
+        "min": 1.373,
+        "med": 3.743,
+        "max": 48.936,
+        "p(90)": 6.4546,
+        "p(95)": 7.395499999999998
+      }
+    },
+    "http_req_sending": {
+      "values": {
+        "max": 0.136,
+        "p(90)": 0.013,
+        "p(95)": 0.018,
+        "p(99)": 0.035,
+        "avg": 0.008097560975609954,
+        "min": 0.002,
+        "med": 0.007
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "avg": 0.062089584292069094,
+        "min": 0.006,
+        "med": 0.056,
+        "max": 0.364,
+        "p(90)": 0.09,
+        "p(95)": 0.112,
+        "p(99)": 0.174
+      },
+      "type": "trend"
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 200,
+        "min": 200,
+        "max": 200
+      },
+      "type": "gauge"
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "rate": 60116.2860709401,
+        "count": 4288309
+      },
+      "type": "counter"
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1534834,
+        "rate": 21516.29460829555
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 1.886,
+        "p(90)": 0.004,
+        "p(95)": 0.006,
+        "p(99)": 0.24181999999999992,
+        "avg": 0.009561129007516432,
+        "min": 0,
+        "med": 0.002
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 6519,
+        "rate": 91.38755367126262
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 6519
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 6519,
+        "rate": 91.38755367126262
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 1.373,
+        "med": 3.743,
+        "max": 48.936,
+        "p(90)": 6.4546,
+        "p(95)": 7.395499999999998,
+        "p(99)": 10.242499999999996,
+        "avg": 4.236863322595492
+      }
+    }
+  }
+}

--- a/legend-momo-city/k6/results/02-lecture-list-summary.md
+++ b/legend-momo-city/k6/results/02-lecture-list-summary.md
@@ -1,0 +1,43 @@
+# k6 Result - 02-lecture-list
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 6519 |
+| iterations | 6519 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 4288309 |
+| data_sent bytes | 1534834 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 4.24 | 1.37 | 3.74 | 6.45 | 7.40 | 10.24 | 48.94 |
+| http_req_waiting | 4.17 | 1.33 | 3.67 | 6.38 | 7.29 | 10.17 | 48.71 |
+| http_req_blocked | 0.01 | 0 | 0.00 | 0.00 | 0.01 | 0.24 | 1.89 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 로그와 에러 이벤트 |
+

--- a/legend-momo-city/k6/results/03-mixed-summary.json
+++ b/legend-momo-city/k6/results/03-mixed-summary.json
@@ -1,0 +1,284 @@
+{
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "lecture-list: status is 200",
+          "path": "::lecture-list: status is 200",
+          "id": "b10b145867557e85689dd4a99d8b42ec",
+          "passes": 6022,
+          "fails": 0
+        },
+        {
+          "name": "lecture-list: no server error",
+          "path": "::lecture-list: no server error",
+          "id": "10ab21a2d4ec71d61f54b95bf7aaefa1",
+          "passes": 6022,
+          "fails": 0
+        },
+        {
+          "passes": 1826,
+          "fails": 0,
+          "name": "enrollment: success or duplicate",
+          "path": "::enrollment: success or duplicate",
+          "id": "83a21dc82286244ec083c742662980b3"
+        },
+        {
+          "id": "479afda0cfd38b521d99af510f588c34",
+          "passes": 1826,
+          "fails": 0,
+          "name": "enrollment: no server error",
+          "path": "::enrollment: no server error"
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 61369.189
+  },
+  "metrics": {
+    "http_reqs": {
+      "contains": "default",
+      "values": {
+        "count": 7848,
+        "rate": 127.88176164426746
+      },
+      "type": "counter"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 17521043,
+        "rate": 285502.2737875842
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 4.831300000000001,
+        "p(95)": 5.448299999999999,
+        "p(99)": 19.412679999999988,
+        "avg": 3.6178636595310882,
+        "min": 1.436,
+        "med": 3.106,
+        "max": 41.562
+      }
+    },
+    "http_req_waiting": {
+      "contains": "time",
+      "values": {
+        "p(95)": 5.362249999999998,
+        "p(99)": 19.34048999999999,
+        "avg": 3.5541558358817533,
+        "min": 1.4,
+        "med": 3.045,
+        "max": 41.482,
+        "p(90)": 4.76
+      },
+      "type": "trend"
+    },
+    "vus": {
+      "values": {
+        "value": 10,
+        "min": 10,
+        "max": 130
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_duration{type:lecture-list}": {
+      "thresholds": {
+        "p(95)<1000": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 2.865,
+        "max": 38.686,
+        "p(90)": 3.7489000000000003,
+        "p(95)": 4.08495,
+        "p(99)": 16.866709999999987,
+        "avg": 3.211475257389571,
+        "min": 1.436
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1477828,
+        "rate": 24080.94394077784
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "p(95)": 1453.6126206000001,
+        "p(99)": 1494.402153,
+        "avg": 1002.7124047740795,
+        "min": 503.260084,
+        "med": 1002.0737915,
+        "max": 1534.92075,
+        "p(90)": 1403.5134081
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 130,
+        "min": 130,
+        "max": 130
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0.148,
+        "p(90)": 0.01,
+        "p(95)": 0.012,
+        "p(99)": 0.023,
+        "avg": 0.006225025484199957,
+        "min": 0.001,
+        "med": 0.005
+      }
+    },
+    "http_req_tls_handshaking": {
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      },
+      "type": "trend"
+    },
+    "http_req_duration{type:enrollment}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 24.013249999999996,
+        "avg": 4.958099671412924,
+        "min": 2.442,
+        "med": 4.522,
+        "max": 41.562,
+        "p(90)": 5.707,
+        "p(95)": 6.10475
+      },
+      "thresholds": {
+        "p(95)<2000": {
+          "ok": true
+        }
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 7848,
+        "rate": 127.88176164426746
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 31.072,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 1.3261299999999985,
+        "avg": 0.052400993883792046,
+        "min": 0
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.001,
+        "max": 33.561,
+        "p(90)": 0.003,
+        "p(95)": 0.003,
+        "p(99)": 3.189839999999998,
+        "avg": 0.0863737257899838,
+        "min": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 15696,
+        "fails": 0
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 3.6178636595310882,
+        "min": 1.436,
+        "med": 3.106,
+        "max": 41.562,
+        "p(90)": 4.831300000000001,
+        "p(95)": 5.448299999999999,
+        "p(99)": 19.412679999999988
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 7848
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.115,
+        "avg": 0.05748279816513713,
+        "min": 0.006,
+        "med": 0.055,
+        "max": 0.29,
+        "p(90)": 0.077,
+        "p(95)": 0.087
+      }
+    }
+  }
+}

--- a/legend-momo-city/k6/results/03-mixed-summary.md
+++ b/legend-momo-city/k6/results/03-mixed-summary.md
@@ -1,0 +1,43 @@
+# k6 Result - 03-mixed
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 7848 |
+| iterations | 7848 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 17521043 |
+| data_sent bytes | 1477828 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 3.62 | 1.44 | 3.11 | 4.83 | 5.45 | 19.41 | 41.56 |
+| http_req_waiting | 3.55 | 1.40 | 3.04 | 4.76 | 5.36 | 19.34 | 41.48 |
+| http_req_blocked | 0.09 | 0 | 0.00 | 0.00 | 0.00 | 3.19 | 33.56 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 로그와 에러 이벤트 |
+

--- a/legend-momo-city/k6/results/04-progress-summary.json
+++ b/legend-momo-city/k6/results/04-progress-summary.json
@@ -1,0 +1,252 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 404,
+          "fails": 1,
+          "name": "progress: status is 200",
+          "path": "::progress: status is 200",
+          "id": "caab62b75fcff12ace7654d84f720a32"
+        },
+        {
+          "fails": 0,
+          "name": "progress: no server error",
+          "path": "::progress: no server error",
+          "id": "fe43e8fbfd8d0171a91f3b3f0372d2b5",
+          "passes": 405
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 77787.847
+  },
+  "metrics": {
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "min": 100,
+        "max": 100,
+        "value": 100
+      },
+      "type": "gauge"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 7730.190625,
+        "max": 10000.253334,
+        "p(90)": 9600.587533,
+        "p(95)": 9763.3823918,
+        "p(99)": 9978.22687,
+        "avg": 7652.939612120992,
+        "min": 5035.644875
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 405,
+        "rate": 5.206468820251575
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 164765,
+        "rate": 2118.1329263425946
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 1,
+        "fails": 404,
+        "rate": 0.0024691358024691358
+      },
+      "thresholds": {
+        "rate<0.05": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.08257283950617296,
+        "min": 0.002,
+        "med": 0.006,
+        "max": 1.893,
+        "p(90)": 0.32760000000000006,
+        "p(95)": 0.35579999999999995,
+        "p(99)": 0.374
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 0.318,
+        "p(90)": 0.256,
+        "p(95)": 0.2861999999999999,
+        "p(99)": 0.301,
+        "avg": 0.05998518518518518,
+        "min": 0
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.1515728395061728,
+        "min": 0.06,
+        "med": 0.155,
+        "max": 0.429,
+        "p(90)": 0.19860000000000003,
+        "p(95)": 0.21759999999999996,
+        "p(99)": 0.24671999999999997
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 21.6878,
+        "p(99)": 25.32432,
+        "avg": 17.023716049382738,
+        "min": 8.59,
+        "med": 16.882,
+        "max": 135.251,
+        "p(90)": 20.6088
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 4,
+        "min": 2,
+        "max": 100
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 265583,
+        "rate": 3414.1965646638864
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 1,
+        "rate": 0.9987654320987654,
+        "passes": 809
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 16.731074257425764,
+        "min": 8.59,
+        "med": 16.877000000000002,
+        "max": 54.621,
+        "p(90)": 20.5257,
+        "p(95)": 21.656399999999998,
+        "p(99)": 25.01577
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 16.83854567901233,
+        "min": 8.481,
+        "med": 16.702,
+        "max": 135.016,
+        "p(90)": 20.371000000000002,
+        "p(95)": 21.4662,
+        "p(99)": 25.125199999999996
+      }
+    },
+    "http_req_duration{type:progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 20.6088,
+        "p(95)": 21.6878,
+        "p(99)": 25.32432,
+        "avg": 17.023716049382738,
+        "min": 8.59,
+        "med": 16.882,
+        "max": 135.251
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.097,
+        "avg": 0.03359753086419754,
+        "min": 0.008,
+        "med": 0.027,
+        "max": 0.114,
+        "p(90)": 0.066,
+        "p(95)": 0.076
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 405,
+        "rate": 5.206468820251575
+      },
+      "type": "counter",
+      "contains": "default"
+    }
+  }
+}

--- a/legend-momo-city/k6/results/04-progress-summary.md
+++ b/legend-momo-city/k6/results/04-progress-summary.md
@@ -1,0 +1,43 @@
+# k6 Result - 04-progress
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 405 |
+| iterations | 405 |
+| checks success rate | 99.88% |
+| http_req_failed | 0.25% |
+| data_received bytes | 265583 |
+| data_sent bytes | 164765 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 17.02 | 8.59 | 16.88 | 20.61 | 21.69 | 25.32 | 135.25 |
+| http_req_waiting | 16.84 | 8.48 | 16.70 | 20.37 | 21.47 | 25.13 | 135.02 |
+| http_req_blocked | 0.08 | 0.00 | 0.01 | 0.33 | 0.36 | 0.37 | 1.89 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 로그와 에러 이벤트 |
+

--- a/legend-momo-city/k6/scripts/00-smoke-check.js
+++ b/legend-momo-city/k6/scripts/00-smoke-check.js
@@ -1,0 +1,43 @@
+// k6/scripts/00-smoke-check.js
+// ------------------------------------------------------------
+// 목적:
+// - 본격 부하테스트 전에 서버가 정상 응답하는지 확인합니다.
+// - 성능 한계를 찾는 테스트가 아니라 "테스트 가능한 상태인지" 확인하는 테스트입니다.
+//
+// 실행:
+//   k6 run k6/scripts/00-smoke-check.js
+// ------------------------------------------------------------
+
+import { sleep } from 'k6';
+import { getLectures, enrollLecture, saveProgress } from '../lib/client.js';
+import { vuToken, randomLectureId, randomSleepSeconds } from '../lib/config.js';
+import { createSummaryHandler } from '../lib/summary.js';
+
+export const options = {
+    vus: 1,
+    iterations: 3,
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+    thresholds: {
+        http_req_failed:   ['rate<0.01'],
+        http_req_duration: ['p(95)<2000'],
+    },
+};
+
+export default function () {
+    const token = vuToken();
+
+    // 1. 강의 목록 조회로 DB 연결과 기본 API를 확인합니다.
+    getLectures({ page: 1 }, token);
+
+    // 2. 수강신청으로 쓰기 API를 확인합니다.
+    //    이미 신청된 경우 400/409 응답도 정상으로 처리합니다.
+    enrollLecture(token, 1);
+
+    // 3. 진척도 저장으로 PATCH API를 확인합니다.
+    //    student1~4는 lecture 1에 미리 수강신청된 상태입니다.
+    saveProgress(token, 1, 1, 100);
+
+    sleep(randomSleepSeconds());
+}
+
+export const handleSummary = createSummaryHandler('00-smoke-check');

--- a/legend-momo-city/k6/scripts/01-enrollment.js
+++ b/legend-momo-city/k6/scripts/01-enrollment.js
@@ -1,0 +1,53 @@
+// k6/scripts/01-enrollment.js
+// ------------------------------------------------------------
+// 목적:
+// - 수강신청 러시 트래픽에서 DB 쓰기 성능과 중복 방지 로직을 확인합니다.
+//
+// 관찰할 것:
+// - k6: enrollment 타입 p95, http_req_failed
+// - Prometheus: http_server_requests_seconds (enrollment 엔드포인트)
+// - Loki: 수강신청 성공/중복 로그 비율
+//
+// 실행:
+//   k6 run k6/scripts/01-enrollment.js
+//   RESULT_NAME=enrollment-rush k6 run k6/scripts/01-enrollment.js
+// ------------------------------------------------------------
+
+import { sleep } from 'k6';
+import { enrollLecture } from '../lib/client.js';
+import { vuToken, randomLectureId, randomSleepSeconds } from '../lib/config.js';
+import { createSummaryHandler } from '../lib/summary.js';
+
+export const options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+    scenarios: {
+        enrollment_rush: {
+            executor: 'ramping-vus',
+            stages: [
+                { duration: '10s', target: 20 },  // 워밍업: 20명까지 증가
+                { duration: '30s', target: 50 },  // 피크: 50명 유지 (수강신청 러시)
+                { duration: '10s', target: 0  },  // 종료
+            ],
+            gracefulRampDown: '10s',
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        // enrollment 타입 요청만 별도로 기준을 둡니다.
+        // 중복 수강신청(400/409)은 실패로 집계되지 않으므로 순수 서버 처리 속도를 봅니다.
+        'http_req_duration{type:enrollment}': ['p(95)<2000'],
+    },
+};
+
+export default function () {
+    // VU 번호 기반 토큰 배정: 같은 VU는 항상 같은 학생으로 동작합니다.
+    // 이를 통해 중복 수강신청 거절 패턴을 자연스럽게 재현합니다.
+    const token = vuToken();
+    const lectureId = randomLectureId();
+
+    enrollLecture(token, lectureId);
+
+    sleep(randomSleepSeconds());
+}
+
+export const handleSummary = createSummaryHandler('01-enrollment');

--- a/legend-momo-city/k6/scripts/02-lecture-list.js
+++ b/legend-momo-city/k6/scripts/02-lecture-list.js
@@ -1,0 +1,59 @@
+// k6/scripts/02-lecture-list.js
+// ------------------------------------------------------------
+// 목적:
+// - 강의 목록 조회 API의 읽기 집중 부하에서 응답 성능을 측정합니다.
+// - 카테고리 필터, 키워드 검색, 비로그인/로그인 혼합 패턴을 포함합니다.
+//
+// 관찰할 것:
+// - k6: lecture-list 타입 p95
+// - Prometheus: http_server_requests_seconds (GET /api/v1/lectures)
+// - Loki: 느린 조회 쿼리 로그
+//
+// 실행:
+//   k6 run k6/scripts/02-lecture-list.js
+//   RESULT_NAME=lecture-list-peak k6 run k6/scripts/02-lecture-list.js
+// ------------------------------------------------------------
+
+import { sleep } from 'k6';
+import { getLectures } from '../lib/client.js';
+import { randomStudentToken, randomSleepSeconds } from '../lib/config.js';
+import { createSummaryHandler } from '../lib/summary.js';
+
+export const options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+    scenarios: {
+        lecture_list_load: {
+            executor: 'ramping-vus',
+            stages: [
+                { duration: '10s', target: 50  },  // 워밍업
+                { duration: '30s', target: 100 },  // 100명 유지
+                { duration: '20s', target: 200 },  // 200명 피크
+                { duration: '10s', target: 0   },  // 종료
+            ],
+            gracefulRampDown: '10s',
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        // 읽기 API는 쓰기보다 빨라야 합니다. p95 1초 기준을 둡니다.
+        'http_req_duration{type:lecture-list}': ['p(95)<1000'],
+    },
+};
+
+const CATEGORIES = ['FITNESS', 'STUDY', 'COOK', 'BEAUTY', 'ART', null];
+const KEYWORDS    = ['홈트', '필라테스', '자바', '영어', null];
+
+export default function () {
+    const category = CATEGORIES[Math.floor(Math.random() * CATEGORIES.length)];
+    const keyword  = KEYWORDS[Math.floor(Math.random() * KEYWORDS.length)];
+    const page     = Math.floor(Math.random() * 3) + 1;
+
+    // 비로그인 70% / 학생 로그인 30% 혼합으로 실제 서비스 패턴을 흉내냅니다.
+    const token = Math.random() < 0.3 ? randomStudentToken() : null;
+
+    getLectures({ category, keyword, page }, token);
+
+    sleep(randomSleepSeconds());
+}
+
+export const handleSummary = createSummaryHandler('02-lecture-list');

--- a/legend-momo-city/k6/scripts/03-mixed.js
+++ b/legend-momo-city/k6/scripts/03-mixed.js
@@ -1,0 +1,61 @@
+// k6/scripts/03-mixed.js
+// ------------------------------------------------------------
+// 목적:
+// - 강의 목록 조회(읽기)와 수강신청(쓰기)이 동시에 발생하는 혼합 트래픽을 시뮬레이션합니다.
+// - 읽기가 쓰기의 영향을 받아 느려지는지 확인합니다.
+//
+// 관찰할 것:
+// - k6: 읽기/쓰기 타입별 p95 비교
+// - Prometheus: JVM 스레드, 커넥션 풀 사용량 변화
+// - Loki: 동시 요청에서 에러 발생 여부
+//
+// 실행:
+//   k6 run k6/scripts/03-mixed.js
+// ------------------------------------------------------------
+
+import { sleep } from 'k6';
+import { getLectures, enrollLecture } from '../lib/client.js';
+import { vuToken, randomLectureId, randomSleepSeconds } from '../lib/config.js';
+import { createSummaryHandler } from '../lib/summary.js';
+
+export const options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+    scenarios: {
+        // 읽기 VU: 100명이 강의 목록 조회를 계속 실행합니다.
+        read_users: {
+            executor: 'constant-vus',
+            vus: 100,
+            duration: '60s',
+            exec: 'readLectures',
+        },
+        // 쓰기 VU: 30명이 수강신청을 계속 실행합니다.
+        // 읽기보다 VU가 적은 이유는 실제 서비스에서 조회가 수강신청보다 훨씬 많기 때문입니다.
+        write_users: {
+            executor: 'constant-vus',
+            vus: 30,
+            duration: '60s',
+            exec: 'enrollLectures',
+        },
+    },
+    thresholds: {
+        'http_req_duration{type:lecture-list}': ['p(95)<1000'],
+        'http_req_duration{type:enrollment}':   ['p(95)<2000'],
+        http_req_failed: ['rate<0.01'],
+    },
+};
+
+export function readLectures() {
+    getLectures({ page: 1 });
+    sleep(randomSleepSeconds());
+}
+
+export function enrollLectures() {
+    const token = vuToken();
+    enrollLecture(token, randomLectureId());
+    sleep(randomSleepSeconds());
+}
+
+// 03-mixed.js는 exec으로 함수를 직접 지정하므로 default는 사용하지 않습니다.
+export default function () {}
+
+export const handleSummary = createSummaryHandler('03-mixed');

--- a/legend-momo-city/k6/scripts/04-progress.js
+++ b/legend-momo-city/k6/scripts/04-progress.js
@@ -1,0 +1,65 @@
+// k6/scripts/04-progress.js
+// ------------------------------------------------------------
+// 목적:
+// - 학생들이 강의를 동시에 시청하며 5~10초 주기로 진척도를 저장할 때의 쓰기 성능을 측정합니다.
+//
+// 전제:
+// - student1~4가 lecture 1에 수강신청된 상태여야 합니다.
+//   (00-smoke-check 또는 01-enrollment 실행 이후 또는 DB에 직접 삽입)
+//
+// 관찰할 것:
+// - k6: progress 타입 p95
+// - Prometheus: DB 커넥션 사용량 (진척도 저장은 매번 upsert를 수행합니다)
+// - Loki: 챕터 완료 이벤트 로그 발생 여부
+//
+// 실행:
+//   k6 run k6/scripts/04-progress.js
+// ------------------------------------------------------------
+
+import { sleep } from 'k6';
+import { saveProgress } from '../lib/client.js';
+import { vuToken, randomSleepSeconds } from '../lib/config.js';
+import { createSummaryHandler } from '../lib/summary.js';
+
+export const options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+    scenarios: {
+        progress_save: {
+            executor: 'ramping-vus',
+            stages: [
+                { duration: '10s', target: 20  },  // 워밍업
+                { duration: '40s', target: 50  },  // 50명 유지
+                { duration: '10s', target: 100 },  // 100명 피크 (동시 시청자 시뮬레이션)
+                { duration: '10s', target: 0   },  // 종료
+            ],
+            gracefulRampDown: '10s',
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.05'],
+        'http_req_duration{type:progress}': ['p(95)<1500'],
+    },
+};
+
+// 진척도 저장 대상 챕터 목록입니다.
+// lecture 1의 챕터 1(600초), 챕터 2(900초)를 사용합니다.
+const CHAPTERS = [
+    { lectureId: 1, chapterId: 1, durationSec: 600 },
+    { lectureId: 1, chapterId: 2, durationSec: 900 },
+];
+
+export default function () {
+    const token   = vuToken();
+    const chapter = CHAPTERS[Math.floor(Math.random() * CHAPTERS.length)];
+
+    // 재생 위치를 랜덤으로 설정합니다.
+    // 0~95% 구간에서 선택해 챕터 완료 이벤트가 적당히 발생하도록 합니다.
+    const playbackSeconds = Math.floor(Math.random() * chapter.durationSec * 0.95);
+
+    saveProgress(token, chapter.lectureId, chapter.chapterId, playbackSeconds);
+
+    // 실제 플레이어는 5~10초마다 저장 요청을 보내므로 sleep 범위를 맞춥니다.
+    sleep(5 + Math.random() * 5);
+}
+
+export const handleSummary = createSummaryHandler('04-progress');


### PR DESCRIPTION
## 최종 API 명세

> 이번 PR은 기능 API가 아닌 테스트 인프라 추가입니다.
> 아래는 부하테스트 대상 API 목록입니다.

| 시나리오 | Method | Endpoint |
|---|---|---|
| 강의 목록 조회 | GET | `/api/v1/lectures` |
| 수강신청 | POST | `/api/v1/lectures/{lectureId}/enrollments` |
| 진척도 저장 | PATCH | `/api/v1/lectures/{lectureId}/chapters/{chapterId}/progress` |

**공통 Request Header**
```
Authorization: Bearer {JWT Token}
Content-Type: application/json
```

**진척도 저장 Request Body**
```json
{
  "playbackSeconds": 100
}
```

**참고사항**
- 수강신청 API는 중복 신청 시 400/409 반환 → 부하테스트에서 정상 응답으로 처리 (`responseCallback` 적용)
- 강의 목록 조회는 비로그인(70%) / 학생 로그인(30%) 혼합 패턴으로 구성

---

## 작업 내용 명세

### 구현 내용

k6 부하테스트 스크립트를 강사님 수업 구조와 동일하게 `lib / scripts / results` 3단 구조로 구성했습니다.

```
k6/
├── lib/
│   ├── config.js    # 공통 설정 (__ENV 환경변수, 토큰, 강의 ID, 유틸 함수)
│   ├── client.js    # API 호출 함수 분리 (시나리오 파일은 행동에만 집중)
│   └── summary.js   # 테스트 결과 MD + JSON 자동 저장
└── scripts/
    ├── 00-smoke-check.js   # 서버 정상 동작 확인 (1 VU, 3 iterations)
    ├── 01-enrollment.js    # 수강신청 러시 (최대 50 VU, ramping)
    ├── 02-lecture-list.js  # 강의 목록 조회 읽기 부하 (최대 200 VU)
    ├── 03-mixed.js         # 읽기 100 VU + 쓰기 30 VU 동시 혼합
    └── 04-progress.js      # 진척도 저장 주기 쓰기 부하 (최대 100 VU)
```

### 변경 사항

- `k6/lib/client.js`
  - `enrollLecture`: 중복 수강신청(400/409)을 `http_req_failed` 실패에서 제외하기 위해 `responseCallback: http.expectedStatuses(201, 400, 409)` 적용
- `k6/lib/config.js`
  - `__ENV` 기반 환경변수 지원으로 `BASE_URL`, `RESULT_NAME`, 토큰을 외부 주입 가능하도록 구성

---

## 검증 이미지

### 00-smoke-check 실행 결과

- `checks: 100%`
- `http_req_failed: 0.00%`
- 스모크 테스트 threshold 전부 통과

> 각 시나리오 실행 후 `k6/results/` 에 MD + JSON 결과 파일 자동 생성됨

---

## 추후 작업

- [ ] 01 ~ 04 시나리오 전체 실행 및 Grafana 대시보드에서 결과 확인
- [ ] Prometheus 메트릭 기반 병목 지점 분석
- [ ] Loki 로그에서 느린 요청 및 에러 이벤트 추적
- [ ] 필요 시 인덱스 또는 캐싱 적용 후 before/after 비교 테스트