### PR TITLE
[REFACT] Calendar 도메인 일별 Response 값 수정 및 StreakLevel ENUM 타입 정의

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/port/TodayChapterInfo.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/application/port/TodayChapterInfo.java
@@ -9,6 +9,8 @@ package com.wanted.momocity.calendar.application.port;
 
 public record TodayChapterInfo(
         String lectureTitle,
+        Long lectureId,
+        String category,
         String chapterTitle
 ) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/CalendarController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/CalendarController.java
@@ -75,6 +75,7 @@ public class CalendarController {
             description = "해당 날짜의 Todo 와 오늘 수강한 챕터 목록을 반환합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "날짜 파라미터 누락 또는 형식 오류"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 토큰 만료")
     })
     @GetMapping("/daily")

--- a/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/common/CalendarResponseCode.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/calendar/presentation/api/common/CalendarResponseCode.java
@@ -12,7 +12,7 @@ public class CalendarResponseCode {
 
     // 캘린더 조회
     public static final String MONTHLY_CALENDAR_FOUND = "CALENDAR-MONTHLY-FOUND";
-    public final String DAILY_CALENDAR_FOUND   = "CALENDAR-DAILY-FOUND";
+    public static final String DAILY_CALENDAR_FOUND   = "CALENDAR-DAILY-FOUND";
 
     // Todo
     public static final String TODO_CREATED          = "CALENDAR-TODO-CREATED";

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/application/service/StreakQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/application/service/StreakQueryService.java
@@ -30,6 +30,14 @@ public class StreakQueryService implements StreakQueryUseCase {
 
     @Override
     public StreakMonthlyResponse getMonthlyStreak(Long userId, LocalDate startDate, LocalDate endDate) {
+
+        // 단일 월 범위 검증
+        // startDate 와 endDate 가 동일한 년-월에 속하는지 확인 -> 여러 달에 걸친 범위 방지
+        if (startDate.getYear() != endDate.getYear() ||
+                startDate.getMonthValue() != endDate.getMonthValue()) {
+            throw new IllegalArgumentException("조회 범위는 동일한 년-월이어야 합니다.");
+        }
+
         List<Streak> streaks = streakRepository
                 .findUserIdAndStreakDateBetween(userId, startDate,endDate);
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/domain/model/Streak.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/domain/model/Streak.java
@@ -8,7 +8,7 @@ public class Streak {
     private Long userId;
     private LocalDate streakDate;
     private int dailyWatchedSeconds;
-    private int level;
+    private StreakLevel level;
 
     // 신규 생성용
     public static Streak create(Long userId, LocalDate streakDate, int watchedSeconds) {
@@ -16,14 +16,14 @@ public class Streak {
         streak.userId = userId;
         streak.streakDate = streakDate;
         streak.dailyWatchedSeconds = watchedSeconds;
-        streak.level = calculateLevel(watchedSeconds);
+        streak.level = StreakLevel.from(watchedSeconds);
         return streak;
     }
 
     // DB 복원용
     public static Streak reconstitute(
             Long id, Long userId, LocalDate streakDate,
-            int dailyWatchedSeconds, int level
+            int dailyWatchedSeconds, StreakLevel level
     ) {
         Streak streak = new Streak();
         streak.id = id;
@@ -39,22 +39,13 @@ public class Streak {
         // 음수 방어
         if (watchedSeconds <= 0) return;
         this.dailyWatchedSeconds += watchedSeconds;
-        this.level = calculateLevel(this.dailyWatchedSeconds);
-    }
-
-    // dailyWatchedSeconds 기준으로 레벨 계산
-    private static int calculateLevel(int seconds) {
-        if (seconds <= 0) return 0;
-        if (seconds <= 600) return 1;
-        if (seconds <= 1800) return 2;
-        if (seconds <= 3600) return 3;
-        return 4;
+        this.level = StreakLevel.from(this.dailyWatchedSeconds);
     }
 
     public Long getId() {return id;}
     public Long getUserId() {return userId;}
     public LocalDate getStreakDate() {return streakDate;}
     public int getDailyWatchedSeconds() {return dailyWatchedSeconds;}
-    public int getLevel() {return level;}
+    public StreakLevel getLevel() {return level;}
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/domain/model/StreakLevel.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/domain/model/StreakLevel.java
@@ -1,0 +1,21 @@
+package com.wanted.momocity.streak.domain.model;
+
+/*
+* comment.
+*  잔디 레벨 정책 ENUM
+*  -> daily_watched_seconds 기준으로 레벨 결정
+* */
+
+public enum StreakLevel {
+
+    LEVEL0, LEVEL1, LEVEL2, LEVEL3, LEVEL4;
+
+    public static StreakLevel from(int seconds) {
+        if (seconds <= 0)    return LEVEL0;
+        if (seconds <= 600)  return LEVEL1;
+        if (seconds <= 1800) return LEVEL2;
+        if (seconds <= 3600) return LEVEL3;
+        return LEVEL4;
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/infrastructure/persistence/StreakJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/infrastructure/persistence/StreakJpaEntity.java
@@ -2,11 +2,13 @@ package com.wanted.momocity.streak.infrastructure.persistence;
 
 import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
 import com.wanted.momocity.streak.domain.model.Streak;
+import com.wanted.momocity.streak.domain.model.StreakLevel;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /*
 * comment.
@@ -27,7 +29,7 @@ import java.time.LocalDate;
 )
 
 @NoArgsConstructor
-public class StreakJpaEntity extends BaseTimeEntity {
+public class StreakJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,7 +45,18 @@ public class StreakJpaEntity extends BaseTimeEntity {
     private int dailyWatchedSeconds;
 
     @Column(name = "level", nullable = false)
-    private int level;
+    @Enumerated(EnumType.STRING)
+    private StreakLevel level;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 
     // from() : Domain Model -> JpaEntity 변환 (저장용)
     public static StreakJpaEntity from(Streak domain) {

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/presentation/api/common/StreakExceptionHandler.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/presentation/api/common/StreakExceptionHandler.java
@@ -45,5 +45,18 @@ public class StreakExceptionHandler {
                         "year 는 2000~2100, month 는 1~12 사이 값이어야 합니다."
                 ));
     }
+    
+    // startDate. endDate 가 다른 년 - 월인 경우 발생 -> 400 으로 처리
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException exception
+    ) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of(
+                        HttpStatus.BAD_REQUEST.value(),
+                        ApiResponseCode.VALIDATION_ERROR,
+                        exception.getMessage()
+                ));
+    }
 
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/presentation/api/response/StreakMonthlyResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/presentation/api/response/StreakMonthlyResponse.java
@@ -6,8 +6,8 @@ import java.util.List;
 /*
 * comment.
 *  월간 잔디 조회 응답 DTO
-*  - startDate : 조회 시작 날짜
-*  - endDate : 조회 종료 날짜
+*  - year : 조회 연도
+*  - month : 조회 월
 *  - streaks : 날짜별 잔디 목록
 *  - 시청 기록 없는 날짜는 포함 안 함
 * */

--- a/legend-momo-city/src/main/java/com/wanted/momocity/streak/presentation/api/response/StreakResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/streak/presentation/api/response/StreakResponse.java
@@ -1,5 +1,7 @@
 package com.wanted.momocity.streak.presentation.api.response;
 
+import com.wanted.momocity.streak.domain.model.StreakLevel;
+
 import java.time.LocalDate;
 
 /*
@@ -11,6 +13,6 @@ import java.time.LocalDate;
 
 public record StreakResponse(
         LocalDate streakDate,
-        int level
+        StreakLevel level
 ) {
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/TodayChapterAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/viewing/infrastructure/catalog/TodayChapterAdapter.java
@@ -5,6 +5,7 @@ import com.wanted.momocity.calendar.application.port.TodayChapterPort;
 import com.wanted.momocity.viewing.application.port.ChapterPort;
 import com.wanted.momocity.viewing.application.port.LecturePort;
 import com.wanted.momocity.viewing.domain.model.LearningHistory;
+import com.wanted.momocity.viewing.domain.model.Lecture;
 import com.wanted.momocity.viewing.domain.repository.LearningHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,13 +48,14 @@ public class TodayChapterAdapter implements TodayChapterPort {
                     String chapterTitle = chapterPort.findById(history.getChapterId())
                             .getTitle();
 
-                    // 강의 제목 조회
+                    // 강의 정보 조회 (제목 + 카테고리)
                     // LecturePort.findById() 로 조회 -> 없으면 DomainRuleViolationException 발생
-                    String lectureTitle = lecturePort.findById(history.getLectureId())
-                            .getTitle();
+                    Lecture lecture = lecturePort.findById(history.getLectureId());
 
                     return new TodayChapterInfo(
-                            lectureTitle,
+                            lecture.getTitle(),
+                            history.getLectureId(),
+                            lecture.getCategory(),
                             chapterTitle
                     );
                 })


### PR DESCRIPTION
<img width="756" height="826" alt="스크린샷 2026-06-19 16 41 04" src="https://github.com/user-attachments/assets/87922a31-5d3d-41a6-bd87-5abedc823c9d" />
<img width="533" height="796" alt="스크린샷 2026-06-19 16 46 21" src="https://github.com/user-attachments/assets/32e15c86-34b2-4a65-b62b-769ecf073105" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스트릭 시청 시간에 따라 단계별 레벨(레벨 등급)로 표시하도록 개선
  * 오늘의 챕터 정보 응답에 강의 ID와 카테고리 정보를 추가
* **Bug Fixes**
  * 월간 스트릭 조회 시 날짜 범위가 동일 연/월인지 검증 강화
* **Documentation**
  * 캘린더 API에 잘못된 날짜 요청(400) 응답 문구 추가
  * 스트릭 관련 잘못된 요청 시 400 응답 형태를 명확히 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->