### PR TITLE
[PR/REFAC] 마이페이지 조회 시 건물 정보 전달 (building 도메인 변경) (임수영)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/service/EnrollmentQueryService.java
@@ -1,0 +1,32 @@
+package com.wanted.momocity.enrollment.application.service;
+
+import com.wanted.momocity.enrollment.application.usecase.EnrollmentQueryUsecase;
+import com.wanted.momocity.enrollment.domain.repository.BuildingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class EnrollmentQueryService implements EnrollmentQueryUsecase {
+
+    private final BuildingRepository buildingRepository;
+
+    @Override
+    public List<RenderingBuildingsView> userBuildingInfo(Long userId) {
+        return buildingRepository.findByUserId(userId)
+                .stream()
+                .map(building -> new RenderingBuildingsView(
+                        building.getCategory(),
+                        building.getPosition(),
+                        building.getLevel()
+                ))
+                .toList();
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/usecase/EnrollmentQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/usecase/EnrollmentQueryUsecase.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.enrollment.application.usecase;
 
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 
 import java.util.List;
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/usecase/EnrollmentQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/application/usecase/EnrollmentQueryUsecase.java
@@ -1,0 +1,19 @@
+package com.wanted.momocity.enrollment.application.usecase;
+
+import com.wanted.momocity.user.domain.model.Category;
+
+import java.util.List;
+
+public interface EnrollmentQueryUsecase {
+    // 해당 메서드가 사용되는 경우는 두 가지
+    // 1. 메인페이지 랜더링 시
+    // 2. 마이페이지에서 건물 정보 렌더링 시
+    List<RenderingBuildingsView> userBuildingInfo(Long userId);
+
+    record RenderingBuildingsView(
+            Category category,
+            Long position,
+            Integer level
+    ){}
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/model/Building.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/model/Building.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.enrollment.domain.model;
 
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 
 import java.time.LocalDateTime;
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/model/Building.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/model/Building.java
@@ -1,4 +1,6 @@
-package com.wanted.momocity.user.domain.model;
+package com.wanted.momocity.enrollment.domain.model;
+
+import com.wanted.momocity.user.domain.model.Category;
 
 import java.time.LocalDateTime;
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/repository/BuildingRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/domain/repository/BuildingRepository.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.enrollment.domain.repository;
+
+import com.wanted.momocity.enrollment.domain.model.Building;
+
+import java.util.List;
+
+public interface BuildingRepository {
+    List<Building> findByUserId(Long userId);
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/BuildingJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/BuildingJpaEntity.java
@@ -1,4 +1,4 @@
-package com.wanted.momocity.user.infrastructure.persistence;
+package com.wanted.momocity.enrollment.infrastructure.persistence;
 
 import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
 import com.wanted.momocity.user.domain.model.Category;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/BuildingJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/BuildingJpaEntity.java
@@ -1,7 +1,7 @@
 package com.wanted.momocity.enrollment.infrastructure.persistence;
 
 import com.wanted.momocity.global.infrastructure.persistence.BaseTimeEntity;
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 import jakarta.persistence.*;
 
 @Entity

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/BuildingRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/BuildingRepositoryAdapter.java
@@ -1,11 +1,11 @@
-package com.wanted.momocity.user.infrastructure.persistence;
+package com.wanted.momocity.enrollment.infrastructure.persistence;
 
-import com.wanted.momocity.user.domain.model.Building;
-import com.wanted.momocity.user.domain.repository.BuildingRepository;
+import com.wanted.momocity.enrollment.domain.model.Building;
+import com.wanted.momocity.enrollment.domain.repository.BuildingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,8 +14,9 @@ public class BuildingRepositoryAdapter implements BuildingRepository {
     private final SpringDataBuildingRepository springDataBuildingRepository;
 
     @Override
-    public Optional<Building> findByUserId(Long userId) {
+    public List<Building> findByUserId(Long userId) {
         return springDataBuildingRepository.findByUserId(userId)
+                .stream()
                 .map(entity -> new Building(
                         entity.getId(),
                         entity.getUserId(),
@@ -24,7 +25,8 @@ public class BuildingRepositoryAdapter implements BuildingRepository {
                         entity.getLevel(),
                         entity.getCreatedAt(),
                         entity.getUpdatedAt()
-                ));
+                ))
+                .toList();
     }
 
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/SpringDataBuildingRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/infrastructure/persistence/SpringDataBuildingRepository.java
@@ -1,9 +1,9 @@
-package com.wanted.momocity.user.infrastructure.persistence;
+package com.wanted.momocity.enrollment.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface SpringDataBuildingRepository extends JpaRepository<BuildingJpaEntity, Long> {
-    Optional<BuildingJpaEntity> findByUserId(Long userId);
+    List<BuildingJpaEntity> findByUserId(Long userId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/BuildingController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/BuildingController.java
@@ -1,13 +1,14 @@
-package com.wanted.momocity.user.presentation.api;
+package com.wanted.momocity.enrollment.presentation.api;
 
 import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
+import com.wanted.momocity.enrollment.application.usecase.EnrollmentQueryUsecase;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
-import com.wanted.momocity.user.application.usecase.UserQueryUsecase;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
+import com.wanted.momocity.global.presentation.api.common.ApiResponseMessage;
 import com.wanted.momocity.user.presentation.api.response.UserResponseCode;
 import com.wanted.momocity.user.presentation.api.response.UserResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +17,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-@Tag(name="User Building - 사용자 건물 정보 관리 ", description = "사용자 개인의 건물 정보를 다루기 위한 User api 관련 컨트롤러 - 추후 모듈에서는 마이페이지 속 빌딩 정보 조회 추가 예정")
-public class UserBuildingController {
+@Tag(name="Building - 사용자 건물 관리 ", description = "건물 정보를 다루기 위한 컨트롤러 ")
+public class BuildingController {
 
-    private final UserQueryUsecase userQueryUsecase;
+    private final EnrollmentQueryUsecase enrollmentQueryUsecase;
+
 
     @GetMapping("/user/buildings")
     @Operation(
@@ -33,13 +37,13 @@ public class UserBuildingController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    public ResponseEntity<ApiResponse<UserQueryUsecase.RenderingBuildingsView>> renderingBuildings(
+    public ResponseEntity<ApiResponse<List<EnrollmentQueryUsecase.RenderingBuildingsView>>> renderingBuildings(
             @AuthenticationPrincipal CustomUserDetails userDetails ){
 
         return ResponseEntity.ok(ApiResponse.success(
-                UserResponseCode.SUCCESS,
-                UserResponseMessage.VIEW_BUILDING_INFO,
-                userQueryUsecase.userBuildingInfo(userDetails.getUserId())
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                enrollmentQueryUsecase.userBuildingInfo(userDetails.getUserId())
         ));
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/BuildingController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/enrollment/presentation/api/BuildingController.java
@@ -35,7 +35,6 @@ public class BuildingController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "메인페이지 렌더링 정보 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     public ResponseEntity<ApiResponse<List<EnrollmentQueryUsecase.RenderingBuildingsView>>> renderingBuildings(
             @AuthenticationPrincipal CustomUserDetails userDetails ){

--- a/legend-momo-city/src/main/java/com/wanted/momocity/global/domain/model/Category.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/global/domain/model/Category.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.global.domain.model;
+
+public enum Category {
+
+    // 카테고리 종류
+    FITNESS, STUDY, COOK, BEAUTY, ART
+}
+
+

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/command/TeacherApplyCommand.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/command/TeacherApplyCommand.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.user.application.command;
 
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 
 public record TeacherApplyCommand(
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/service/UserQueryService.java
@@ -7,7 +7,6 @@ import com.wanted.momocity.user.domain.model.Role;
 import com.wanted.momocity.user.domain.model.Status;
 import com.wanted.momocity.user.domain.model.TeacherApplication;
 import com.wanted.momocity.user.domain.model.User;
-import com.wanted.momocity.user.domain.repository.BuildingRepository;
 import com.wanted.momocity.user.domain.repository.UserRepository;
 import com.wanted.momocity.user.presentation.api.response.AdminUserListResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +21,7 @@ import java.util.List;
 public class UserQueryService implements UserQueryUsecase {
 
     private final UserRepository userRepository;
-    private final BuildingRepository buildingRepository;
     private final UserPolicy userPolicy;
-
 
     // 마이페이지 내 정보 조회용
     @Override
@@ -48,16 +45,6 @@ public class UserQueryService implements UserQueryUsecase {
         userPolicy.nicknamePolicy(nickname);
     }
 
-    @Override
-    public RenderingBuildingsView userBuildingInfo(Long userId) {
-        return buildingRepository.findByUserId(userId)
-                .map(building -> new RenderingBuildingsView(
-                        building.getCategory(),
-                        building.getPosition(),
-                        building.getLevel()
-                ))
-                .orElse(new RenderingBuildingsView(null, null, null));
-    }
 
     // 대기 강사 전체 조회
     @Override

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
@@ -13,8 +13,6 @@ public interface UserQueryUsecase {
 
     void checkNickname(String nickname);
 
-    RenderingBuildingsView userBuildingInfo(Long userId);
-
     record UserDetailView(
             String profileImageUrl,
             String email,
@@ -25,13 +23,6 @@ public interface UserQueryUsecase {
             LocalDateTime createdAt
 
     ){}
-
-    record RenderingBuildingsView(
-            Category category,
-            Long position,
-            Integer level
-    ){}
-
 
     // 승인 대기 중인 강사 전체 목록 조회
     TeacherApplicationListResult getApplicationList(int page, int size);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/application/usecase/UserQueryUsecase.java
@@ -1,7 +1,6 @@
 package com.wanted.momocity.user.application.usecase;
 
 import com.wanted.momocity.user.domain.model.TeacherApplication;
-import com.wanted.momocity.user.domain.model.Category;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/Category.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/Category.java
@@ -1,9 +1,0 @@
-package com.wanted.momocity.user.domain.model;
-
-public enum Category {
-
-    // 강사가 선택한 본인이 가르칠 카테고리 종류
-    FITNESS, STUDY, COOK, BEAUTY, ART
-}
-
-

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/User.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/model/User.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.user.domain.model;
 
+import com.wanted.momocity.global.domain.model.Category;
 import lombok.Builder;
 
 import java.time.LocalDate;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/BuildingRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/BuildingRepository.java
@@ -1,9 +1,0 @@
-package com.wanted.momocity.user.domain.repository;
-
-import com.wanted.momocity.user.domain.model.Building;
-
-import java.util.Optional;
-
-public interface BuildingRepository {
-    Optional<Building> findByUserId(Long userId);
-}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.user.domain.repository;
 
+import com.wanted.momocity.global.domain.model.Category;
 import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
 import com.wanted.momocity.user.domain.model.*;
 
@@ -50,7 +51,7 @@ public interface UserRepository {
     boolean setAlarm(Long userId);
 
     // 강사 신청
-    void teacherApply(Long userId,String nickname, Category category, String proof);
+    void teacherApply(Long userId, String nickname, Category category, String proof);
 
     // 강사 중복 신청 확인용
     boolean existsByIdAndRoleAndStatus(Long userId, Role role, Status status);

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -1,7 +1,7 @@
 package com.wanted.momocity.user.infrastructure.persistence;
 
 
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 import com.wanted.momocity.user.domain.model.Role;
 import com.wanted.momocity.user.domain.model.Status;
 import org.springframework.data.domain.Pageable;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserJpaEntity.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.user.infrastructure.persistence;
 
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 import com.wanted.momocity.user.domain.model.Role;
 import com.wanted.momocity.user.domain.model.Status;
 import com.wanted.momocity.user.domain.model.User;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package com.wanted.momocity.user.infrastructure.persistence;
 
+import com.wanted.momocity.global.domain.model.Category;
 import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
 import com.wanted.momocity.user.domain.exception.UserNotFoundException;
 import com.wanted.momocity.user.domain.model.*;
@@ -116,7 +117,7 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
-    public void teacherApply(Long userId,String nickname , Category category, String proof) {
+    public void teacherApply(Long userId, String nickname , Category category, String proof) {
         springDataUserRepository.teacherApply(userId,nickname,category,proof);
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/UserController.java
@@ -4,6 +4,7 @@ import com.wanted.momocity.auth.application.port.BlacklistPort;
 import com.wanted.momocity.auth.application.port.RedisRefreshTokenPort;
 import com.wanted.momocity.auth.application.port.TokenProviderPort;
 import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
+import com.wanted.momocity.enrollment.application.usecase.EnrollmentQueryUsecase;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.user.application.command.NicknameRegisterCommand;
 import com.wanted.momocity.user.application.command.UpdateUserInfoCommand;
@@ -24,6 +25,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
@@ -32,6 +35,7 @@ public class UserController {
 
     private final UserCommandUsecase userCommandUsecase;
     private final UserQueryUsecase userQueryUsecase;
+    private final EnrollmentQueryUsecase enrollmentQueryUsecase;
 
     private final BlacklistPort blacklistPort;
     private final TokenProviderPort tokenProviderPort;
@@ -48,13 +52,17 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    public ResponseEntity<ApiResponse<UserQueryUsecase.UserDetailView>> getUserDetail(
+    public ResponseEntity<ApiResponse<UserInfoDetailResponse>> getUserDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        Long userId = userDetails.getUserId();
+        UserQueryUsecase.UserDetailView userDetail = userQueryUsecase.userDetail(userId);
+        List<EnrollmentQueryUsecase.RenderingBuildingsView>  userBuildingInfo = enrollmentQueryUsecase.userBuildingInfo(userId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 UserResponseCode.SUCCESS,
                 UserResponseMessage.VIEW_SUCCESS,
-                userQueryUsecase.userDetail(userDetails.getUserId())
+                new UserInfoDetailResponse(userDetail, userBuildingInfo)
         ));
     }
 

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/request/TeacherApplyRequest.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/request/TeacherApplyRequest.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.user.presentation.api.request;
 
-import com.wanted.momocity.user.domain.model.Category;
+import com.wanted.momocity.global.domain.model.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/UserInfoDetailResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/user/presentation/api/response/UserInfoDetailResponse.java
@@ -1,0 +1,11 @@
+package com.wanted.momocity.user.presentation.api.response;
+
+import com.wanted.momocity.enrollment.application.usecase.EnrollmentQueryUsecase;
+import com.wanted.momocity.user.application.usecase.UserQueryUsecase;
+
+import java.util.List;
+
+public record UserInfoDetailResponse(
+        UserQueryUsecase.UserDetailView userDetail,
+        List<EnrollmentQueryUsecase.RenderingBuildingsView> buildings) {
+}


### PR DESCRIPTION
## 작업 내용
1. 기존 마이페이지에는 건물 정보가 없었음
 그래서 마이페이지 랜더링 시 유저 정보와 함께 건물 정보를 응답에 보내도록 리펙토링 진행





2. 기존에는 building이 user 도메인에 있었음
- 그러나 팀적으로 이를 enrollment 에 두기로 합의함 
- 위 1번의 내용을 구현하기 위해선 building 도메인으로부터의 건물 정보가 필요했음
- 그래서 building으로 도메인을 옮기는 작업도 진행
---
## 마이페이지에서 내 정보 조회 정보 api : /api/v1/user/detail
- 유저 정보는 userDetail로 건물정보는 buildings에 리스트로 담아서 응답
#### 📥 Request

**Headers**

```
Authorization: Bearer {accessToken}
```


#### 📤 Response

#### ✅ 200 OK  — 성공 : 건물 하나도 없을 때 (건물 빈 배열)

```json
{
    "timestamp": "2026-06-21T00:54:41.1953584",
    "status": 200,
    "code": "SUCCESS",
    "message": "회원정보가 조회되었습니다.",
    "data": {
        "userDetail": {
            "profileImageUrl": "https://momocity-bucket.s3.ap-northeast-2.amazonaws.com/profile/momoProfile.png",
            "email": "sooyoung040927@gmail.com",
            "name": "123",
            "nickname": null,
            "birth": null,
            "isTempPwd": false,
            "createdAt": "2026-06-21T00:53:48"
        },
        "buildings": []
    }
}
```


#### ✅ 200 OK  — 성공 : 건물 있을 때 (건물 정보 배열)

```json
{
    "timestamp": "2026-06-21T01:24:47.2924637",
    "status": 200,
    "code": "SUCCESS",
    "message": "회원정보가 조회되었습니다.",
    "data": {
        "userDetail": {
            "profileImageUrl": "https://momocity-bucket.s3.ap-northeast-2.amazonaws.com/profile/momoProfile.png",
            "email": "sooyoung0927-@naver.com",
            "name": "김민수",
            "nickname": "minsu",
            "birth": "1998-03-12",
            "isTempPwd": false,
            "createdAt": "2026-03-04T16:21:34"
        },
        "buildings": [
            {
                "category": "FITNESS",
                "position": 1,
                "level": 3
            },
            {
                "category": "STUDY",
                "position": 2,
                "level": 1
            }
        ]
    }
}
```


#### ❌ 실패 — (401) - Unauthorized - 토큰 만료

```json
{
    "timestamp": "2026-06-07T18:43:02.706551700",
    "status": 401,
    "code": "UNAUTHORIZED",
    "message": "다시 로그인해 주세요."
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 상세 조회 응답에 건물 렌더링 정보(목록)가 함께 제공됩니다.

* **개선 사항**
  * 건물 정보 조회 흐름이 정리되어, 사용자별 건물 렌더링 데이터가 목록 형태로 일관되게 반환됩니다.
  * 사용자 프로필 조회 시 건물 정보가 통합되어 상세 화면에서 한 번에 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->