### PR TITLE
[PR] 관리자 수강평 삭제 API 추가 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/LectureReviewQueryPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/LectureReviewQueryPort.java
@@ -15,7 +15,7 @@ public interface LectureReviewQueryPort {
     // 리뷰 통계 DTO
     record ReviewStats(
             // 평균 평점
-            double avarageRating,
+            double averageRating,
             // 리뷰 개수
             int reviewCount
     ) {}
@@ -25,7 +25,7 @@ public interface LectureReviewQueryPort {
             Long reviewId,
             Long userId,
             String userName,
-            String profileImaginUrl,
+            String profileImageUrl,
             String content,
             int rating,
             LocalDateTime createdAt

--- a/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/LectureReviewQueryPort.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/lecture/application/port/LectureReviewQueryPort.java
@@ -1,0 +1,34 @@
+package com.wanted.momocity.lecture.application.port;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+// Lecture 서비스가 review 정보를 조회하기 위한 인터페이스
+public interface LectureReviewQueryPort {
+
+    // 특정 강의의 평균 평점과 리뷰 개수 조회 메서드
+    ReviewStats getReviewStats(Long lectureId);
+
+    // 특정 강의의 리뷰 목록을 페이지 네이션으로 조회하는 메서드
+    ReviewPage getReviews(Long lectureId, int page, int size);
+
+    // 리뷰 통계 DTO
+    record ReviewStats(
+            // 평균 평점
+            double avarageRating,
+            // 리뷰 개수
+            int reviewCount
+    ) {}
+
+    // 리뷰 1개의 응답 정보 DTO
+    record ReviewPage(
+            Long reviewId,
+            Long userId,
+            String userName,
+            String profileImaginUrl,
+            String content,
+            int rating,
+            LocalDateTime createdAt
+    ){}
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/application/service/ReviewCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/application/service/ReviewCommandService.java
@@ -7,6 +7,7 @@ import com.wanted.momocity.review.application.command.ReviewCommand;
 import com.wanted.momocity.review.application.usecase.ReviewCommandUseCase;
 import com.wanted.momocity.review.domain.exception.DuplicateReviewException;
 import com.wanted.momocity.review.domain.exception.ReviewAccessDeniedException;
+import com.wanted.momocity.review.domain.exception.ReviewNotFoundException;
 import com.wanted.momocity.review.domain.model.Review;
 import com.wanted.momocity.review.domain.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -87,5 +88,17 @@ public class ReviewCommandService implements ReviewCommandUseCase {
                 savedReview.getUserId(),
                 savedReview.getLectureId()
         );
+    }
+
+    // ReviewCommandUseCase 인터페이스의 메서드를 구현한다는 표시
+    @Override
+    public void deleteReview(Long reviewId) {
+        // 삭제할 리뷰가 DB에 존재하지 않는지 확인
+        if (!reviewRepository.existsById(reviewId)) {
+            throw new ReviewNotFoundException("수강평을 찾을 수 없습니다.");
+        }
+
+        // 리뷰 ID 기준으로 수강평 삭제 실행
+        reviewRepository.deleteById(reviewId);
     }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/application/usecase/ReviewCommandUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/application/usecase/ReviewCommandUseCase.java
@@ -7,4 +7,7 @@ public interface ReviewCommandUseCase {
     void createReview(
             ReviewCommand.CreateReviewCommand command
     );
+
+    // 관리자 수강평 삭제 기능
+    void deleteReview(Long reviewId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/domain/exception/ReviewNotFoundException.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/domain/exception/ReviewNotFoundException.java
@@ -1,0 +1,8 @@
+package com.wanted.momocity.review.domain.exception;
+
+// 수강평을 찾지 못했을 때 예외
+public class ReviewNotFoundException extends RuntimeException {
+    public ReviewNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/domain/repository/ReviewRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/domain/repository/ReviewRepository.java
@@ -13,4 +13,10 @@ public interface ReviewRepository {
             Long userId,
             Long lectureId
     );
+
+    // 삭제 전 리뷰 존재 여부 확인
+    boolean existsById(Long reviewId);
+
+    // 리뷰 Id 기준 삭제
+    void deleteById(Long reviewId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/infrastructure/adapter/ReviewRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/infrastructure/adapter/ReviewRepositoryAdapter.java
@@ -36,4 +36,16 @@ public class ReviewRepositoryAdapter implements ReviewRepository {
                 lectureId
         );
     }
+
+    // 리뷰 존재 여부 확인
+    @Override
+    public boolean existsById(Long reviewId) {
+        return reviewJpaRepository.existsById(reviewId);
+    }
+
+    // 리뷰 삭제 (관리자)
+    @Override
+    public void deleteById(Long reviewId) {
+        reviewJpaRepository.deleteById(reviewId);
+    }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
@@ -51,7 +51,7 @@ public class ReviewController {
     }
 
     // 강의 삭제
-    @DeleteMapping("/{reviewId}")
+    @DeleteMapping("/reviews/{reviewId}")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')") // 관리자만 삭제 가능
     public ResponseEntity<?> deleteReview(@PathVariable Long reviewId // URL에서 reviewId 추출
     ) { // 메서드 시작

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,4 +49,14 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CreateReviewSuccessResponse.created());
     }
+
+    // 강의 삭제
+    @DeleteMapping("/{reviewId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')") // 관리자만 삭제 가능
+    public ResponseEntity<?> deleteReview(@PathVariable Long reviewId // URL에서 reviewId 추출
+    ) { // 메서드 시작
+        reviewCommandUseCase.deleteReview(reviewId); // 서비스에 삭제 요청 위임
+
+        return ResponseEntity.ok(CreateReviewSuccessResponse.deleted()); // 삭제 성공 응답 반환
+    } // 메서드 종료
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/response/CreateReviewSuccessResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/response/CreateReviewSuccessResponse.java
@@ -19,4 +19,13 @@ public record CreateReviewSuccessResponse(
                 "수강평이 등록되었습니다."
         );
     }
+
+    public static CreateReviewSuccessResponse deleted() {
+        return new CreateReviewSuccessResponse(
+                LocalDateTime.now(),
+                200,
+                ApiResponseCode.SUCCESS,
+                "수강평이 삭제되었습니다."
+        );
+    }
 }


### PR DESCRIPTION
close #385 

- 삭제 성공 시

<img width="713" height="738" alt="스크린샷 2026-06-24 오전 10 03 48" src="https://github.com/user-attachments/assets/86aa9610-2a08-4372-ac89-8357df80b6a1" />

## 📌 작업 내용

- 관리자 수강평 삭제 API를 추가했습니다.
- 수강평 삭제 유스케이스를 추가했습니다.
- 수강평 삭제를 위한 Repository 메서드를 추가했습니다.
- 존재하지 않는 수강평 삭제 요청 시 `ReviewNotFoundException`을 발생하도록 처리했습니다.
- 수강평 삭제 성공 응답을 추가했습니다.

## 🔐 권한 정책

- 학생은 수강평 작성만 가능합니다.
- 학생과 강사는 수강평 삭제가 불가능합니다.
- 관리자만 수강평 삭제가 가능합니다.

LectureReviewQueryPort 같은 경우는 조회 진행하다가 삭제가 우선이라 진행하느라 아직 개발은 다 완성되지 않았으나 코드 오류는 없기 때문에 머지해도 괜찮습니다.

---

## 📥 API

```http
DELETE /api/v1/lectures/reviews/{reviewId}
```


## ❌ 에러 응답
403 Forbidden
관리자 권한이 없는 사용자가 요청한 경우
```
{
  "timestamp": "2026-06-24T10:00:48.987117",
  "status": 403,
  "code": "COMMON-FORBIDDEN",
  "message": "접근 권한이 없습니다."
}
```

404 Not Found
삭제할 수강평이 존재하지 않는 경우
```
{
  "timestamp": "2026-06-24T10:30:00",
  "status": 404,
  "code": "COMMON-NOT-FOUND",
  "message": "수강평을 찾을 수 없습니다."
}
```

💬 참고
- 수강평 삭제 요청에는 reviewId만 사용합니다.
- reviewId는 수강평을 유일하게 식별하므로 lectureId는 요청에 포함하지 않습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 강의별 리뷰 통계 조회(평균 평점, 리뷰 개수) 추가
  * 강의 리뷰 목록 조회(페이지 단위) 추가
  * 관리자 전용 리뷰 삭제 기능 추가(삭제 성공 응답 제공)

* **버그 수정**
  * 존재하지 않는 리뷰를 삭제 요청할 경우 예외로 처리하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->