### PR TITLE
[PR] 상점 도메인 생성 + 상품 전체 조회

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/application/service/StoreCommandService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/application/service/StoreCommandService.java
@@ -1,0 +1,14 @@
+package com.wanted.momocity.store.application.service;
+
+import com.wanted.momocity.store.application.usecase.StoreCommandUsecase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class StoreCommandService implements StoreCommandUsecase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/application/service/StoreQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/application/service/StoreQueryService.java
@@ -1,0 +1,31 @@
+package com.wanted.momocity.store.application.service;
+
+import com.wanted.momocity.store.application.usecase.StoreQueryUsecase;
+import com.wanted.momocity.store.domain.model.Store;
+import com.wanted.momocity.store.domain.model.StoreListResult;
+import com.wanted.momocity.store.domain.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreQueryService implements StoreQueryUsecase{
+
+    private final StoreRepository storeRepository;
+
+    // 전체 상품 목록 조회
+    @Override
+    public StoreListResult getProductList(int page, int size) {
+        List<Store> stores = storeRepository.getProductList(PageRequest.of(page - 1, size));
+        long totalElements = storeRepository.countProductList();
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+        return new StoreListResult(stores, page, size, totalElements, totalPages);
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/application/usecase/StoreCommandUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/application/usecase/StoreCommandUsecase.java
@@ -1,0 +1,4 @@
+package com.wanted.momocity.store.application.usecase;
+
+public interface StoreCommandUsecase {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/application/usecase/StoreQueryUsecase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/application/usecase/StoreQueryUsecase.java
@@ -1,0 +1,13 @@
+package com.wanted.momocity.store.application.usecase;
+
+import com.wanted.momocity.store.domain.model.Store;
+import com.wanted.momocity.store.domain.model.StoreListResult;
+
+import java.util.List;
+
+public interface StoreQueryUsecase {
+
+    // 상품 전체 목록 조회
+    StoreListResult getProductList(int page, int size);
+    
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/domain/model/Store.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/domain/model/Store.java
@@ -1,0 +1,25 @@
+package com.wanted.momocity.store.domain.model;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Store {
+
+    private final Long id;
+    private final Long price;
+    private final String url;
+    private final String name;
+    private final LocalDateTime createdAt;
+
+    public Store(Long id, Long price, String url, String name, LocalDateTime createdAt) {
+        this.id = id;
+        this.price = price;
+        this.url = url;
+        this.name = name;
+        this.createdAt = createdAt;
+    }
+
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/domain/model/StoreListResult.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/domain/model/StoreListResult.java
@@ -1,0 +1,13 @@
+package com.wanted.momocity.store.domain.model;
+
+import java.util.List;
+
+public record StoreListResult(
+
+        List<Store> stores,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/domain/repository/StoreRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/domain/repository/StoreRepository.java
@@ -1,0 +1,15 @@
+package com.wanted.momocity.store.domain.repository;
+
+import com.wanted.momocity.store.domain.model.Store;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface StoreRepository {
+
+    // 전체 상품 목록 조회
+    List<Store> getProductList(Pageable pageable);
+
+    // 페이지네이션 페이지 수
+    long countProductList();
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/infrastructure/persistence/SpringDataStoreRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/infrastructure/persistence/SpringDataStoreRepository.java
@@ -1,0 +1,6 @@
+package com.wanted.momocity.store.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataStoreRepository extends JpaRepository<StoreJpaEntity,Long> {
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/infrastructure/persistence/StoreJpaEntity.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/infrastructure/persistence/StoreJpaEntity.java
@@ -1,0 +1,42 @@
+package com.wanted.momocity.store.infrastructure.persistence;
+
+import com.wanted.momocity.store.domain.model.Store;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="store")
+public class StoreJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long price;
+
+    @Column
+    private String url;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column( nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public StoreJpaEntity() {}
+
+    public StoreJpaEntity(Long id, Long price, String url, String name, LocalDateTime createdAt) {
+        this.id = id;
+        this.price = price;
+        this.url = url;
+        this.name = name;
+        this.createdAt = createdAt;
+    }
+
+    public Store toDomain() {
+        return new Store(id, price, url, name, createdAt);
+    }
+
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/infrastructure/persistence/StoreRepositoryAdapter.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/infrastructure/persistence/StoreRepositoryAdapter.java
@@ -1,0 +1,31 @@
+package com.wanted.momocity.store.infrastructure.persistence;
+
+import com.wanted.momocity.store.domain.model.Store;
+import com.wanted.momocity.store.domain.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository("StoreRepositoryAdapter")
+@Transactional
+@RequiredArgsConstructor
+public class StoreRepositoryAdapter implements StoreRepository {
+
+    private final SpringDataStoreRepository springDataStoreRepository;
+
+    @Override
+    public List<Store> getProductList(Pageable pageable) {
+        return springDataStoreRepository.findAll(pageable)
+                .stream()
+                .map(StoreJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public long countProductList() {
+        return springDataStoreRepository.count();
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/StoreController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/StoreController.java
@@ -1,0 +1,52 @@
+package com.wanted.momocity.store.presentation.api;
+
+import com.wanted.momocity.global.presentation.api.common.ApiResponse;
+import com.wanted.momocity.store.application.usecase.StoreCommandUsecase;
+import com.wanted.momocity.store.application.usecase.StoreQueryUsecase;
+import com.wanted.momocity.store.domain.model.Store;
+import com.wanted.momocity.store.domain.model.StoreListResult;
+import com.wanted.momocity.store.presentation.api.common.StoreResponseCode;
+import com.wanted.momocity.store.presentation.api.common.StoreResponseMessage;
+import com.wanted.momocity.store.presentation.api.response.StoreListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/store")
+@Tag(name = "상점 관리", description = "포인트를 활용한 상점에서의 상품 구매 및 내역 관리")
+public class StoreController {
+
+    private final StoreQueryUsecase storeQueryUsecase;
+    private final StoreCommandUsecase storeCommandUsecase;
+
+    @GetMapping("/product/list")
+    @Operation(summary = "상점에 있는 모든 항목 조회")
+    public ResponseEntity<ApiResponse<StoreListResponse>> getStoreProductList(
+            @Parameter(description = "페이지 번호 (1-base)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "5") int size
+    ){
+
+        StoreListResult result = storeQueryUsecase.getProductList(page, size);
+        StoreListResponse response = StoreListResponse.from(result);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(
+                        StoreResponseCode.LIST_FOUND_SUCCESS,
+                        StoreResponseMessage.PRODUCT_LIST_FETCHED,
+                        response
+                ));
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/common/StoreResponseCode.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/common/StoreResponseCode.java
@@ -1,0 +1,12 @@
+package com.wanted.momocity.store.presentation.api.common;
+
+public final class StoreResponseCode {
+
+    private  StoreResponseCode(){}
+
+    public static final String PURCHASE_SUCCESS = "PURCHASE-SUCCESS";
+    public static final String LIST_FOUND_SUCCESS = "LIST-FETCHED";
+
+}
+
+

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/common/StoreResponseMessage.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/common/StoreResponseMessage.java
@@ -1,0 +1,9 @@
+package com.wanted.momocity.store.presentation.api.common;
+
+public final class StoreResponseMessage{
+
+    private StoreResponseMessage(){}
+
+    public static final String PRODUCT_LIST_FETCHED = "상품 목록이 조회되었습니다.";
+    public static final String PURCHASE_SUCCESS = "상품이 구매되었습니다.";
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/response/StoreListResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/store/presentation/api/response/StoreListResponse.java
@@ -1,0 +1,38 @@
+package com.wanted.momocity.store.presentation.api.response;
+
+import com.wanted.momocity.store.domain.model.Store;
+import com.wanted.momocity.store.domain.model.StoreListResult;
+
+import java.util.List;
+
+public record StoreListResponse(
+        List<Product> stores,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public record Product(
+            Long id,
+            String name,
+            Long price,
+            String url
+    ) {
+        public static Product toResponse(Store store) {
+            return new Product(
+                    store.getId(),
+                    store.getName(),
+                    store.getPrice(),
+                    store.getUrl()
+            );
+        }
+    }
+
+    public static StoreListResponse from(StoreListResult result) {
+        List<Product> items = result.stores()
+                .stream()
+                .map(Product::toResponse)
+                .toList();
+        return new StoreListResponse(items, result.page(), result.size(), result.totalElements(), result.totalPages());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- store 도메인 생성
- 상품 목록 전체 조회 기능 구현
--- 
## 상점 목록 전체 조회 api : /api/v1/store/product/list
- 페이지네이션 O
- 응답 칼럼 : id / 상품명 / 가격 / url
#### 📥 Request

**Headers** (필요 시)

```
Authorization: Bearer {accessToken}
```

---

#### 📤 Response

#### ✅ 200 OK  — 성공

```json
{
    "timestamp": "2026-06-24T13:00:50.1248296",
    "status": 200,
    "code": "LIST-FETCHED",
    "message": "상품 목록이 조회되었습니다.",
    "data": {
        "stores": [
            {
                "id": 1,
                "name": "모모 뱃지",
                "price": 500,
                "url": "https://momocity-bucket.s3.ap-northeast-2.amazonaws.com/store/item1.png"
            },
            {
                "id": 2,
                "name": "별빛 아이콘",
                "price": 300,
                "url": "https://momocity-bucket.s3.ap-northeast-2.amazonaws.com/store/item2.png"
            },
            {
                "id": 3,
                "name": "프리미엄 프레임",
                "price": 1000,
                "url": "https://momocity-bucket.s3.ap-northeast-2.amazonaws.com/store/item3.png"
            }
        ],
        "page": 1,
        "size": 3,
        "totalElements": 10,
        "totalPages": 4
    }
}
```


#### ❌ 실패 1 — (401) - 인증 안 됨

```json
{
    "timestamp": "2026-06-24T12:41:38.741783300",
    "status": 401,
    "code": "UNAUTHORIZED",
    "message": "다시 로그인 해주세요."
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스토어 상품 목록 조회 API 추가: `/api/v1/store/product/list` 엔드포인트 추가
  * 페이지네이션 지원: `page`(기본값 1)와 `size`(기본값 5) 파라미터로 상품 목록을 페이지 단위로 조회 가능
  * 상품 정보 조회: 상품의 id, name, price, url과 함께 전체 개수 및 페이지 메타데이터 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->