### PR TITLE
[PR] 강의평 목록 조회 API 구현 (모성진)

### DIFF
--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/application/query/ReviewQuery.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/application/query/ReviewQuery.java
@@ -1,0 +1,20 @@
+package com.wanted.momocity.review.application.query;
+
+// 강의평 목록 조회 클래스
+public class ReviewQuery {
+
+    private ReviewQuery() {
+    }
+
+    // 수강평 목록 조회 요청 레코드
+    public record GetReviewListQuery(
+            // 수강평 조회 할 강의 id
+            Long lectureId,
+            // 조회할 페이지 변호
+            int page,
+            // 한 페이지에 조회할 수강평 개수
+            int  size
+    ) {
+
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/application/service/ReviewQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/application/service/ReviewQueryService.java
@@ -1,0 +1,81 @@
+package com.wanted.momocity.review.application.service;
+
+import com.wanted.momocity.auth.application.port.LoadUserPort;
+import com.wanted.momocity.auth.domain.exception.UserNotFoundException;
+import com.wanted.momocity.lecture.domain.exception.LectureNotFoundException;
+import com.wanted.momocity.lecture.domain.repository.LectureRepository;
+import com.wanted.momocity.review.application.query.ReviewQuery;
+import com.wanted.momocity.review.application.usecase.ReviewQueryUseCase;
+import com.wanted.momocity.review.infrastructure.persistence.ReviewJpaEntity;
+import com.wanted.momocity.review.infrastructure.persistence.ReviewJpaRepository;
+import com.wanted.momocity.review.presentation.api.response.ReviewListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.lang.model.element.NestingKind;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewQueryService implements ReviewQueryUseCase {
+
+    // 수강평 DB 조회 담당
+    private final ReviewJpaRepository reviewJpaRepository;
+    // 강의 존재 여부 확인
+    private final LectureRepository lectureRepository;
+    // 리뷰 작성자 조회
+    private final LoadUserPort loadUserPort;
+
+    @Override
+    public ReviewListResponse getReviews(ReviewQuery.GetReviewListQuery query) {
+        // 요청한 lectureId에 해당하는 강의가 있는지 확인
+        lectureRepository.findById(query.lectureId())
+                .orElseThrow(() -> new LectureNotFoundException("강의를 찾을 수 없습니다."));
+
+
+        Pageable pageable = PageRequest.of(query.page(), query.size());
+
+        // 최신순으로 강의평 조회
+        Page<ReviewJpaEntity> reviewPage = reviewJpaRepository.findAllByLectureIdOrderByCreatedAtDesc(
+                query.lectureId(),
+                pageable
+        );
+
+        // 해당 강의의 평균 평점 조회
+        double averageRating = reviewJpaRepository.findAverageRatingByLectureId(query.lectureId());
+
+        // 해당 강의의 전체 수강평 개수 조회
+        long reviewCount = reviewJpaRepository.countByLectureId(query.lectureId());
+
+        // 수강평 목록 조회 응답
+        return new ReviewListResponse(reviewPage.getContent().stream() // 현재 페이지의 수강평 목록을 스트림으로 변환
+                .map(this::toReviewItemResponse) // ReviewJpaEntity를 ReviewItemResponse로 변환
+                .toList(), // 변환된 수강평 응답 목록을 List로 수집
+                query.page(), // 현재 페이지 번호
+                query.size(), // 한 페이지 크기
+                reviewPage.getTotalElements(), // 전체 수강평 개수
+                reviewPage.getTotalPages() // 전체 페이지 수
+        );
+    }
+
+    // 수강 Entity
+    private ReviewListResponse.ReviewItemResponse toReviewItemResponse(ReviewJpaEntity review) {
+        // 리뷰 작성자 Id로 사용자 정보 조회
+        var user = loadUserPort.findById(review.getUserId()) // 리뷰 작성자 ID로 사용자 정보 조회
+                .orElseThrow(() -> new UserNotFoundException("수강평 작성자를 찾을 수 없습니다.")); // 작성자 정보가 없으면 예외 발생
+
+        // 수강평 1개 응답
+        return  new ReviewListResponse.ReviewItemResponse(review.getUserId(), // 수강평 작성자 ID
+                user.getNickname(), // 수강평 작성자 닉네임
+                review.getId(), // 수강평 ID
+                review.getCreatedAt(), // 수강평 작성 시간
+                review.getContent(), // 수강평 작성 내용
+                review.getRating(), // 수강평 별점
+                user.getProfileImageUrl() // 수강평 작성자 프로필 이미
+        );
+    }
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/application/service/ReviewQueryService.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/application/service/ReviewQueryService.java
@@ -45,12 +45,6 @@ public class ReviewQueryService implements ReviewQueryUseCase {
                 pageable
         );
 
-        // 해당 강의의 평균 평점 조회
-        double averageRating = reviewJpaRepository.findAverageRatingByLectureId(query.lectureId());
-
-        // 해당 강의의 전체 수강평 개수 조회
-        long reviewCount = reviewJpaRepository.countByLectureId(query.lectureId());
-
         // 수강평 목록 조회 응답
         return new ReviewListResponse(reviewPage.getContent().stream() // 현재 페이지의 수강평 목록을 스트림으로 변환
                 .map(this::toReviewItemResponse) // ReviewJpaEntity를 ReviewItemResponse로 변환

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/application/usecase/ReviewQueryUseCase.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/application/usecase/ReviewQueryUseCase.java
@@ -1,0 +1,12 @@
+package com.wanted.momocity.review.application.usecase;
+
+import com.wanted.momocity.review.application.query.ReviewQuery;
+import com.wanted.momocity.review.presentation.api.response.ReviewListResponse;
+
+// 수강평 조회 기능
+public interface ReviewQueryUseCase {
+    // 수강평 목록 조회 기능 메서드
+    ReviewListResponse getReviews(
+            ReviewQuery.GetReviewListQuery query
+    );
+}

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/infrastructure/persistence/ReviewJpaRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/infrastructure/persistence/ReviewJpaRepository.java
@@ -1,6 +1,10 @@
 package com.wanted.momocity.review.infrastructure.persistence;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewJpaRepository extends JpaRepository<ReviewJpaEntity, Long> {
 
@@ -9,4 +13,15 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewJpaEntity, Long
             Long userId,
             Long lectureId
     );
+
+    // 해당 강의의 rating 평균을 구하고 없으면 0 반환
+    @Query("select coalesce(avg(r.rating), 0) " +
+            "from ReviewJpaEntity r where r.lectureId = :lectureId")
+    // 특정 강의의 평균 평점 조회
+    double findAverageRatingByLectureId(@Param("lectureId") Long lectureId);
+
+    // 특정 강의 수강평을 최신순
+    Page<ReviewJpaEntity> findAllByLectureIdOrderByCreatedAtDesc(Long lectureId, Pageable pageable);
+
+    long countByLectureId(Long lectureId);
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/infrastructure/persistence/ReviewJpaRepository.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/infrastructure/persistence/ReviewJpaRepository.java
@@ -1,6 +1,6 @@
 package com.wanted.momocity.review.infrastructure.persistence;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
@@ -4,10 +4,13 @@ import com.wanted.momocity.auth.infrastructure.security.CustomUserDetails;
 import com.wanted.momocity.global.presentation.api.common.ApiResponse;
 import com.wanted.momocity.global.presentation.api.common.ApiResponseCode;
 import com.wanted.momocity.review.application.command.ReviewCommand;
+import com.wanted.momocity.review.application.query.ReviewQuery;
 import com.wanted.momocity.review.application.usecase.ReviewCommandUseCase;
+import com.wanted.momocity.review.application.usecase.ReviewQueryUseCase;
 import com.wanted.momocity.review.presentation.api.request.CreateReviewRequest;
 import com.wanted.momocity.review.presentation.api.response.CreateReviewResponse;
 import com.wanted.momocity.review.presentation.api.response.CreateReviewSuccessResponse;
+import com.wanted.momocity.review.presentation.api.response.ReviewListResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     private final ReviewCommandUseCase reviewCommandUseCase;
+    private final ReviewQueryUseCase reviewQueryUseCase;
 
     @PostMapping("/{lectureId}/reviews")
     public ResponseEntity<CreateReviewSuccessResponse> createReview(
@@ -54,9 +58,35 @@ public class ReviewController {
     @DeleteMapping("/reviews/{reviewId}")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')") // 관리자만 삭제 가능
     public ResponseEntity<?> deleteReview(@PathVariable Long reviewId // URL에서 reviewId 추출
-    ) { // 메서드 시작
+    ) {
         reviewCommandUseCase.deleteReview(reviewId); // 서비스에 삭제 요청 위임
 
         return ResponseEntity.ok(CreateReviewSuccessResponse.deleted()); // 삭제 성공 응답 반환
-    } // 메서드 종료
+    }
+
+    // 강의 수강평 목록 조회
+    @GetMapping("/{lectureId}/reviews")
+    public ResponseEntity<ApiResponse<ReviewListResponse>> getReviews(
+            @PathVariable Long lectureId,
+            @RequestParam(defaultValue = "0") int page, // 요청한 페이지 번호, 기본값 = 0
+            @RequestParam(defaultValue = "10") int size // 한 페이지 요청 수강평 개수, 기본값 = 10
+    ) {
+        // 서비스로 넘길 수강평 목록 조회 query 생성
+        ReviewQuery.GetReviewListQuery query = new ReviewQuery.GetReviewListQuery(
+                lectureId,
+                page,
+                size
+        );
+
+        // 수강평 목록 조회 UseCase 호출
+        ReviewListResponse response = reviewQueryUseCase.getReviews(query);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ApiResponseCode.SUCCESS,
+                        "수강평 목록 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
 }

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/ReviewController.java
@@ -12,6 +12,8 @@ import com.wanted.momocity.review.presentation.api.response.CreateReviewResponse
 import com.wanted.momocity.review.presentation.api.response.CreateReviewSuccessResponse;
 import com.wanted.momocity.review.presentation.api.response.ReviewListResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -68,8 +70,9 @@ public class ReviewController {
     @GetMapping("/{lectureId}/reviews")
     public ResponseEntity<ApiResponse<ReviewListResponse>> getReviews(
             @PathVariable Long lectureId,
-            @RequestParam(defaultValue = "0") int page, // 요청한 페이지 번호, 기본값 = 0
-            @RequestParam(defaultValue = "10") int size // 한 페이지 요청 수강평 개수, 기본값 = 10
+            @RequestParam(defaultValue = "0") @Min(0) int page, // 요청한 페이지 번호, 기본값 = 0
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size // 한 페이지 요청 수강평 개수, 기본값 = 10
+
     ) {
         // 서비스로 넘길 수강평 목록 조회 query 생성
         ReviewQuery.GetReviewListQuery query = new ReviewQuery.GetReviewListQuery(

--- a/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/response/ReviewListResponse.java
+++ b/legend-momo-city/src/main/java/com/wanted/momocity/review/presentation/api/response/ReviewListResponse.java
@@ -1,0 +1,27 @@
+package com.wanted.momocity.review.presentation.api.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 수강평 목록 조회 응답
+public record ReviewListResponse(
+        // 현재 페이지에 해당하는 수강평 목록
+        List<ReviewItemResponse> content,
+        int page,
+        int size,
+        // 전체 강의평 개수
+        long totalElements,
+        // 전체 페이지 수
+        int totalPages
+) {
+    // 수강평 1개에 들어가는 응답
+    public record ReviewItemResponse(
+            Long userId, // 수강평 작성자 ID
+            String nickname, // 수강평 작성자 닉네임
+            Long reviewId, // 수강평 ID
+            LocalDateTime createdAt, // 수강평 작성 시간
+            String content, // 수강평 작성 내용
+            int rating, // 수강평 별점
+            String profileImageUrl // 수강평 작성자 프로필 이미지 URL
+    ) {}
+}


### PR DESCRIPTION
close #389 

<img width="706" height="708" alt="스크린샷 2026-06-24 오후 4 12 09" src="https://github.com/user-attachments/assets/025d97fd-97f5-4326-9a2e-9a6622fc8ffb" />

## 최종 API 명세 내용 작성

### 1. Header / Body / Request 값

```http
GET /api/v1/lectures/{lectureId}/reviews?page=0&size=10
```
<img width="644" height="424" alt="스크린샷 2026-06-24 오후 4 57 32" src="https://github.com/user-attachments/assets/6f675c29-8dc9-440b-a359-62d78e7eee6e" />

2. Response 값
✅ 200 OK
```
{
  "timestamp": "2026-06-24T15:50:59.342799",
  "status": 200,
  "code": "COMMON-SUCCESS",
  "message": "수강평 목록 조회에 성공했습니다.",
  "data": {
    "content": [
      {
        "userId": 5,
        "nickname": "성진",
        "reviewId": 1,
        "createdAt": "2026-05-19T10:20:00",
        "content": "설명이 자세해서 이해하기 좋았습니다.",
        "rating": 5,
        "profileImageUrl": "https://example.com/images/profile.png"
      }
    ],
    "page": 0,
    "size": 10,
    "totalElements": 1,
    "totalPages": 1
  }
}
```

❌ 404 Not Found
```
{
  "timestamp": "2026-06-24T15:50:59.342799",
  "status": 404,
  "code": "COMMON-NOT-FOUND",
  "message": "강의를 찾을 수 없습니다."
}
```

### 3. 참고사항
- 강의 상세 화면의 수강평 탭 클릭 시 호출하는 API입니다.
- 강의 상세 조회 API와 별도로 수강평 목록만 조회합니다.
- 수강평 목록은 최신순으로 정렬됩니다.
- 페이지 번호는 0부터 시작합니다.
- 기본 페이지 크기는 10입니다.
- lectureId, averageRating, reviewCount는 강의 상세 조회 API에서 제공합니다.
- 수강평 목록 조회 API는 content, page, size, totalElements, totalPages만 제공합니다.
- content에는 userId, nickname, reviewId, createdAt, content, rating, profileImageUrl을 포함합니다.
- 수강평 수정 기능은 제공하지 않습니다.
- 수강평 삭제는 관리자만 가능합니다.
- 작업 내용 명세

### 4. 어떤 기능을 구현했는지
- 강의별 수강평 목록 조회 API를 구현했습니다.
- 강의 상세 조회 API가 수강평 목록까지 포함하지 않도록 역할을 분리하고, 프론트에서 수강평 탭을 클릭했을 때 별도의 API로 수강평 목록을 조회할 수 있도록 구현했습니다.

### 5. 변경 사항이 무엇인지
- 수강평 목록 조회 Query 추가
- 수강평 목록 조회 UseCase 추가
- 수강평 목록 조회 Service 추가
- 수강평 목록 조회 Response DTO 추가
- 수강평 목록 조회 Controller API 추가
- ReviewJpaRepository에 강의별 수강평 최신순 페이지 조회 메서드 추가
- 존재하지 않는 강의 ID 요청 시 예외 처리 추가
- 수강평 응답에 작성자 닉네임 및 프로필 이미지 포함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 강의별 수강평 목록을 조회할 수 있는 기능이 추가되었습니다.
  * 페이지 번호와 개수를 지정해 원하는 범위의 수강평을 불러올 수 있습니다.
  * 목록 응답에 작성자 정보, 평점, 작성일, 전체 개수, 평균 평점이 포함됩니다.

* **Bug Fixes**
  * 조회 대상 강의나 작성자가 없을 경우 적절한 오류가 반환되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->